### PR TITLE
Fix meshes not drawn on canvas2d rendering context backend.

### DIFF
--- a/src/render-canvas2d/plugin.js
+++ b/src/render-canvas2d/plugin.js
@@ -145,7 +145,7 @@ function renderMaterial(ctx, material, mesh, textures) {
  */
 function renderBasic(ctx, material, mesh) {
   const { fill, stroke, strokeWidth } = material
-  const positions = mesh.getAttribute('position')?.data
+  const positions = mesh.getAttribute('position2d')?.data
 
   if (!positions) return
 


### PR DESCRIPTION
## Objective
 - Fix issue #23

## Solution
Used 'position2d' mesh vertex attribute instead of 'position'.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.