### PR TITLE
Add `Matrix3x4.toMatrix4()`

### DIFF
--- a/src/math/matrix3x4.js
+++ b/src/math/matrix3x4.js
@@ -113,6 +113,12 @@ export class Matrix3x4 {
   }
 
   /**
+   * @returns {Matrix4}
+   */
+  toMatrix4(){
+    return Matrix3x4.toMatrix4(this)
+  }
+  /**
    * @param {Matrix3x4} out
    * @param {number} e11
    * @param {number} e12


### PR DESCRIPTION
## Objective
Offers a way to convert a `Matrix3x4` to a `Matrix4`.

## Solution
N/A

## Showcase
```javascript
const convertibleMatrix = new Matrix3x4();

// instance method
const matrix1 = convertibleMatrix.toMatrix4();

// static method
const matrix2 = Matrix3x4.toMatrix4(convertibleMatrix);
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.