### PR TITLE
Add `AssetParserPlugin<T>`

### DIFF
--- a/src/asset/plugins/index.js
+++ b/src/asset/plugins/index.js
@@ -1,1 +1,2 @@
 export * from './asset.js'
+export * from './parser.js'

--- a/src/asset/plugins/parser.js
+++ b/src/asset/plugins/parser.js
@@ -1,5 +1,49 @@
+import { App, AppSchedule } from '../../app/index.js'
 import { Parser } from '../core/index.js'
+import { generateParserSystem } from '../systems/index.js'
 
+
+/**
+ * @template T
+ */
+
+export class AssetParserPlugin {
+
+  /**
+   * @readonly
+   * @type {new (...args:any)=>T}
+   */
+  asset
+
+  /**
+   * @readonly
+   * @type {Parser<T>}
+   */
+  parser
+
+  /**
+   * @param {AssetParserPluginOptions<T>} options 
+   */
+  constructor(options) {
+    const { asset, parser } = options
+
+    this.asset = asset
+    this.parser = parser
+  }
+
+  /**
+   * @param {App} app
+   */
+  register(app) {
+    const { asset, parser } = this
+    const name = asset.name.toLowerCase()
+
+    app
+      .registerSystem(AppSchedule.Update, generateParserSystem(name))
+      .getWorld()
+      .setResourceByName(`parser<${name}>`, parser)
+  }
+}
 
 /**
  * @template T

--- a/src/asset/plugins/parser.js
+++ b/src/asset/plugins/parser.js
@@ -1,0 +1,9 @@
+import { Parser } from '../core/index.js'
+
+
+/**
+ * @template T
+ * @typedef AssetParserPluginOptions
+ * @property {new ()=>T} asset
+ * @property {Parser<T>} parser
+ */

--- a/src/asset/systems/loader.js
+++ b/src/asset/systems/loader.js
@@ -32,8 +32,8 @@ export function generateParserSystem(name) {
     /** @type {EventDispatch<AssetLoadFail>} */
     const fail = world.getResource('events<assetloadfail>')
 
-    /** @type {AssetBasePath} */
-    const baseUrl = world.getResource('assetbasepath')
+    /** @type {AssetBasePath<T>} */
+    const baseUrl = world.getResource(`assetbasepath<${name}>`)
 
     const paths = assets.flushToLoad()
 

--- a/src/asset/systems/loader.js
+++ b/src/asset/systems/loader.js
@@ -16,7 +16,7 @@ export function generateParserSystem(name) {
    * @param {World} world
    */
   return async function loadToAssets(world) {
-        
+
     /** @type {Assets<T>} */
     const assets = world.getResource(`assets<${name}>`)
 
@@ -37,7 +37,7 @@ export function generateParserSystem(name) {
 
     const paths = assets.flushToLoad()
 
-    if(!parser) return
+    if (!parser) return
 
     for (let i = 0; i < paths.length; i++) {
       const rawpath = paths[i]
@@ -45,14 +45,14 @@ export function generateParserSystem(name) {
       const extension = getFileExtension(path)
 
       if (!parser.verify(extension, device)) {
-        fail.write(new AssetLoadFail(rawpath, `The extension "${extension}" is not supported by ${parser.constructor.name}` ))
+        fail.write(new AssetLoadFail(rawpath, `The extension "${extension}" is not supported by ${parser.constructor.name}`))
         continue
       }
 
       const result = await load(path, parser)
 
-      if(result){
-        
+      if (result) {
+
         assets.setByPath(rawpath, result)
         success.write(new AssetLoadSuccess(rawpath))
       } else {


### PR DESCRIPTION
## Objective
Adds `AssetParserPlugin<T>` which registers an asset of type `T`
This will be used instead of using `App.registerAssetParser()` to register all the asset types.
This also centralises the asset functionality into the `asset` package.

## Solution
N/A

## Showcase
 - Javascript:
  ```javascript
  class Mesh {}
  class MeshParser extends Parser {}
  
  let app = new App()
  app
    .registerPlugin(new AssetPlugin({
      asset:Mesh
    })
    .registerPlugin(new AssetParserPlugin({
      asset:Mesh,
      parser:new MeshParser()
    })
  ```
 - Typescript:
  ```typescript
  class Mesh {}
  class MeshParser extends Parser<Mesh> {}
  
  let app = new App()
  app
    .registerPlugin(new AssetPlugin({
      asset:Mesh
    })
    .registerPlugin(new AssetParserPlugin({
      asset:Mesh,
      parser:new MeshParser()
    })
  ```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.