### PR TITLE
Deprecate `App.registerAsset<T>()`

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -5,8 +5,9 @@ import { World, Scheduler, Executor, ComponentHooks, RAFExecutor, ImmediateExecu
 import { EventDispatch } from '../event/index.js'
 import { assert } from '../logger/index.js'
 import { AppSchedule } from './schedules.js'
-import { Assets, generateParserSystem } from '../asset/index.js'
+import { generateParserSystem } from '../asset/index.js'
 import { SchedulerBuilder, SystemConfig } from './core/index.js'
+import { AssetPlugin } from '../asset/plugins/asset.js'
 
 const registererror = 'Systems, plugins or resources should be registered or set before `App().run()`'
 
@@ -146,16 +147,20 @@ export class App {
   }
 
   /**
+   * @deprecated
    * @template T
    * @param {Function} asset
    * @param {HandleProvider<T>} [handleprovider]
    */
   registerAsset(asset, handleprovider) {
-    const name = asset.name.toLowerCase()
+    this.registerPlugin(new AssetPlugin({
 
-    // @ts-ignore
-    // ill deal with this later
-    this.world.setResourceByName(`assets<${name}>`, new Assets(asset.default, handleprovider))
+      // this function will be removed so the cast does not 
+      // matter much
+      // eslint-disable-next-line object-shorthand
+      asset:/** @type {any}*/(asset),
+      handleprovider
+    }))
 
     return this
   }


### PR DESCRIPTION
## Objective
Deprecates App.registerAssetParser<T>()`

## Solution
N/A

## Showcase
N/A

## Migration guide
You should no longer use `App.registerAssetParser<T>()`

 - Before:
 ```javascript
class MyAsset {}

let app = new App()

app.registerAsset(MyAsset)
```


 - After:
 ```javascript
class MyAsset {}

let app = new App()

app.registerPlugin(new AssetPlugin({
  asset:MyAsset
})
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.