### PR TITLE
Import package `wima` in demos

### DIFF
--- a/demos/demos/despawn.js
+++ b/demos/demos/despawn.js
@@ -1,4 +1,4 @@
-/** @import {Entity} from 'chaosstudio' */
+/** @import {Entity} from 'wima' */
 import {
   Mesh,
   CanvasMeshedMaterial,
@@ -10,7 +10,7 @@ import {
   EntityCommands,
   Cleanup,
   warn
-} from 'chaosstudio'
+} from 'wima'
 
 export default new Demo('despawn', [init], [update])
 

--- a/demos/demos/easing.js
+++ b/demos/demos/easing.js
@@ -14,7 +14,7 @@ import {
   Demo,
   Cleanup,
   warn
-} from 'chaosstudio'
+} from 'wima'
 
 export default new Demo('easing', [init])
 

--- a/demos/demos/keyboard.js
+++ b/demos/demos/keyboard.js
@@ -1,4 +1,4 @@
-/** @import {Entity} from 'chaosstudio' */
+/** @import {Entity} from 'wima' */
 import {
   Assets,
   Material,
@@ -14,7 +14,7 @@ import {
   Cleanup,
   Keyboard,
   KeyCode
-} from 'chaosstudio'
+} from 'wima'
 
 const offsetX = 100
 const offsetY = 100

--- a/demos/demos/material.js
+++ b/demos/demos/material.js
@@ -8,7 +8,7 @@ import {
   Color,
   Demo,
   Cleanup
-} from 'chaosstudio'
+} from 'wima'
 
 export default new Demo('materials', [init])
 

--- a/demos/demos/mouse.js
+++ b/demos/demos/mouse.js
@@ -1,4 +1,4 @@
-/** @import {Entity} from 'chaosstudio' */
+/** @import {Entity} from 'wima' */
 import {
   Mesh,
   CanvasMeshedMaterial,
@@ -12,7 +12,7 @@ import {
   Keyboard,
   KeyCode,
   MouseButton
-} from 'chaosstudio'
+} from 'wima'
 
 const offsetX = 100
 const offsetY = 100

--- a/demos/demos/render/basictriangle.js
+++ b/demos/demos/render/basictriangle.js
@@ -10,7 +10,7 @@ import {
   GlobalTransform3D,
   World,
   Cleanup
-} from 'chaosstudio'
+} from 'wima'
 import { addCamera3D } from './utils.js'
 
 /**

--- a/demos/demos/render/cameraorthographic.js
+++ b/demos/demos/render/cameraorthographic.js
@@ -14,7 +14,7 @@ import {
   World,
   Cleanup,
   createCamera3D
-} from 'chaosstudio'
+} from 'wima'
 
 /**
  * @param {World} world

--- a/demos/demos/render/cameraperspective.js
+++ b/demos/demos/render/cameraperspective.js
@@ -14,7 +14,7 @@ import {
   World,
   Cleanup,
   createCamera3D
-} from 'chaosstudio'
+} from 'wima'
 
 /**
  * @param {World} world

--- a/demos/demos/render/camerarotate.js
+++ b/demos/demos/render/camerarotate.js
@@ -12,7 +12,7 @@ import {
   World,
   Cleanup,
   createCamera3D
-} from 'chaosstudio'
+} from 'wima'
 
 /**
  * @param {World} world

--- a/demos/demos/render/colorchangetriangle.js
+++ b/demos/demos/render/colorchangetriangle.js
@@ -11,7 +11,7 @@ import {
   GlobalTransform3D,
   World,
   Cleanup
-} from 'chaosstudio'
+} from 'wima'
 import { addCamera3D } from './utils.js'
 
 /**

--- a/demos/demos/render/colortriangle.js
+++ b/demos/demos/render/colortriangle.js
@@ -11,7 +11,7 @@ import {
   GlobalTransform3D,
   World,
   Cleanup
-} from 'chaosstudio'
+} from 'wima'
 import { addCamera3D } from './utils.js'
 
 /**

--- a/demos/demos/render/geometries.js
+++ b/demos/demos/render/geometries.js
@@ -11,7 +11,7 @@ import {
   Rotation3D,
   World,
   Cleanup
-} from 'chaosstudio'
+} from 'wima'
 import { addCamera3D } from './utils.js'
 
 /**

--- a/demos/demos/render/movingtriangle.js
+++ b/demos/demos/render/movingtriangle.js
@@ -11,7 +11,7 @@ import {
   World,
   Cleanup,
   Query
-} from 'chaosstudio'
+} from 'wima'
 import { addCamera3D } from './utils.js'
 
 /**

--- a/demos/demos/render/rotationtriangle.js
+++ b/demos/demos/render/rotationtriangle.js
@@ -11,7 +11,7 @@ import {
   Cleanup,
   GlobalTransform3D,
   Rotation3D
-} from 'chaosstudio'
+} from 'wima'
 import { addCamera3D } from './utils.js'
 
 /**

--- a/demos/demos/render/utils.js
+++ b/demos/demos/render/utils.js
@@ -2,7 +2,7 @@ import {
   World,
   Cleanup,
   createCamera3D
-} from 'chaosstudio'
+} from 'wima'
 
 /**
  * @param {World} world

--- a/demos/demos/spawn.js
+++ b/demos/demos/spawn.js
@@ -10,7 +10,7 @@ import {
   Handle,
   warn,
   Cleanup
-} from 'chaosstudio'
+} from 'wima'
 
 export default new Demo('spawn', [init], [update])
 

--- a/demos/demos/touch.js
+++ b/demos/demos/touch.js
@@ -1,4 +1,4 @@
-/** @import {Entity} from 'chaosstudio' */
+/** @import {Entity} from 'wima' */
 import {
   Mesh,
   CanvasMeshedMaterial,
@@ -11,7 +11,7 @@ import {
   warn,
   Cleanup,
   Touches
-} from 'chaosstudio'
+} from 'wima'
 
 /** @type {Map<number,Entity>} */
 class TouchtoEntityMap extends Map { }

--- a/demos/index.html
+++ b/demos/index.html
@@ -25,7 +25,7 @@
   <script type="importmap">
     {
       "imports": {
-        "chaosstudio": "/src/index.js"
+        "wima": "/src/index.js"
       }
     }
   </script>

--- a/demos/main.js
+++ b/demos/main.js
@@ -1,4 +1,4 @@
-/** @import {Entity} from 'chaos-studio' */
+/** @import {Entity} from 'wima' */
 import {
   App,
   AppSchedule,
@@ -21,7 +21,7 @@ import {
   Query,
   warn,
   createCamera2D
-} from 'chaosstudio'
+} from 'wima'
 import spawn from './demos/spawn.js'
 import despawn from './demos/despawn.js'
 import easing from './demos/easing.js'

--- a/demos/webgl.html
+++ b/demos/webgl.html
@@ -13,7 +13,7 @@
   <script type="importmap">
     {
       "imports": {
-        "chaosstudio": "/src/index.js"
+        "wima": "/src/index.js"
       }
     }
   </script>

--- a/demos/webgl.js
+++ b/demos/webgl.js
@@ -1,4 +1,4 @@
-/** @import {Entity} from 'chaos-studio' */
+/** @import {Entity} from 'wima' */
 import {
   App,
   AppSchedule,
@@ -23,7 +23,7 @@ import {
   Query,
   warn,
   createCamera2D
-} from 'chaosstudio'
+} from 'wima'
 import {
   basictriangle,
   colortriangle,


### PR DESCRIPTION
## Objective
The engine main package was adapted from another
engine called chaos-studio thus demos import from
that package.
This updates the import statements to import from
this engine(wima) instead of the previous engine


## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.