### PR TITLE
Update webgl demos

### DIFF
--- a/demos/webgl.js
+++ b/demos/webgl.js
@@ -4,7 +4,6 @@ import {
   AppSchedule,
   World,
   FPSDebugger,
-  AssetPlugin,
   AudioPlugin,
   CommandsPlugin,
   DefaultTweenPlugin,
@@ -40,7 +39,6 @@ const app = new App()
 
 app
   .registerPlugin(new CommandsPlugin())
-  .registerPlugin(new AssetPlugin())
   .registerPlugin(new AudioPlugin())
   .registerPlugin(new TimePlugin())
   .registerPlugin(new WindowPlugin())


### PR DESCRIPTION
## Objective
Remove `AssetPlugin` from registered plugins in webgl demos

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.