### PR TITLE
Rename `Matrix2x3.setFromTransform()` to `Matrix2x3.compose()`.

### DIFF
--- a/src/math/matrix2x3.js
+++ b/src/math/matrix2x3.js
@@ -42,7 +42,7 @@ export class Matrix2x3 {
    *
    * @returns {this}
    */
-  setFromTransform(translation, orientation, scale) {
+  compose(translation, orientation, scale) {
     Matrix2x3.compose(this, translation, orientation, scale)
 
     return this

--- a/src/math/matrix2x3.js
+++ b/src/math/matrix2x3.js
@@ -43,7 +43,7 @@ export class Matrix2x3 {
    * @returns {this}
    */
   setFromTransform(translation, orientation, scale) {
-    Matrix2x3.setFromTransform(this, translation, orientation, scale)
+    Matrix2x3.compose(this, translation, orientation, scale)
 
     return this
   }
@@ -168,7 +168,7 @@ export class Matrix2x3 {
    * @param {Vector2} scale
    * @returns {Matrix2x3}
    */
-  static setFromTransform(matrix, translation, orientation, scale) {
+  static compose(matrix, translation, orientation, scale) {
     const cos = Math.cos(orientation.value)
     const sin = Math.sin(orientation.value)
 


### PR DESCRIPTION
## Objective
A quality of life improvement due to the shorter name.

## Solution
N/A

## Showcase
N/A

## Migration guide
Before:
```javascript
matrix.setFromTransform(position,orientation,scale)
```
After:
```javascript
matrix.compose(position,orientation,scale)
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.