### PR TITLE
Change `Vector2.multiply()` and `Vector2.divide()` to use `Vector2`, Add method to divide/multiply `Vector2` by numbers

### DIFF
--- a/src/math/vector2.js
+++ b/src/math/vector2.js
@@ -126,8 +126,8 @@ export class Vector2 {
 
   /**
    * Rotates this vector by a given angle in radians.
-   *
-   * @param {number} cos
+  *
+  * @param {number} cos
    * @param {number} sin
    * @returns {this}
    */
@@ -755,7 +755,7 @@ export class Vector2 {
    * A vector whose x and y values will remain 0.
    *
    * @readonly
-   * @type { Vector2}
+   * @type { Vector2 }
    */
   static ZERO = new Vector2()
 
@@ -763,7 +763,7 @@ export class Vector2 {
    * Default up direction.
    *
    * @readonly
-   * @type { Vector2}
+   * @type { Vector2 }
    */
   static UP = new Vector2(0, 1)
 }

--- a/src/math/vector2.js
+++ b/src/math/vector2.js
@@ -118,8 +118,13 @@ export class Vector2 {
    * @param {number} n
    * @returns {this}
    */
-  multiply(n) {
-    Vector2.multiplyScalar(this, n, this)
+  
+  /**
+   * @param {Vector2} v
+   * @returns {this}
+   */
+  multiply(v) {
+    Vector2.multiply(this, v, this)
 
     return this
   }

--- a/src/math/vector2.js
+++ b/src/math/vector2.js
@@ -294,11 +294,11 @@ export class Vector2 {
   /**
    * Divides this vector with a scalar.
    *
-   * @param {number} n
+   * @param {Vector2} v
    * @returns {this}
    */
-  divide(n) {
-    this.multiply(1 / n)
+  divide(v) {
+    Vector2.divide(this, v, this)
 
     return this
   }

--- a/src/math/vector2.js
+++ b/src/math/vector2.js
@@ -304,6 +304,15 @@ export class Vector2 {
   }
 
   /**
+   * @param {number} s
+   * @returns {this}
+   */
+  divideScalar(s){
+    Vector2.divideScalar(this,s,this)
+    return this
+  }
+
+  /**
    * Checks to see if this vector is equal to
    * another vector.
    *

--- a/src/math/vector2.js
+++ b/src/math/vector2.js
@@ -130,6 +130,15 @@ export class Vector2 {
   }
 
   /**
+   * @param {number} s
+   * @returns {this}
+   */
+  multiplyScalar(s){
+    Vector2.multiplyScalar(this,s,this)
+    return this
+  }
+
+  /**
    * Rotates this vector by a given angle in radians.
   *
   * @param {number} cos


### PR DESCRIPTION
## Objective
Adds `Vector2.divideScalar()` and `Vector2.multiplyScalar()` instance methods which multiply a vector by a number component-wise
Change `Vector2.multiply()` and `Vector2.divide()` to multiply and divide by a `Vector2` instead of a number.

## Solution
N/A

## Showcase
```javascript
const vector1 = new Vector2()
const vector2 = new Vector2()

// operate using a `Vector2`
vector1.multiply(vector2)
vector1.divide(vector2)

// operate using a number
vector1.multiplyScalar(2)
vector1.divideScalar(2)
```

## Migration guide
The method to multiply and divide vectors using numbers has changed. 
Before:
```javascript
const vector = new Vector2()

vector.multiply(2)
vector.divide(2)
```
After:
```javascript
const vector = new Vector2()

// operates with numbers
vector.multiplyScalar(2)
vector.divideScalar(2)
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.