### PR TITLE
Deprecate `App.registerEvent()` and replace with `EventPlugin`.

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -2,8 +2,8 @@
 /** @import { SystemFunc } from '../ecs/index.js' */
 /** @import { HandleProvider, Parser } from '../asset/index.js' */
 import { World, Scheduler, Executor, ComponentHooks, RAFExecutor, ImmediateExecutor } from '../ecs/index.js'
-import { EventDispatch } from '../event/index.js'
-import { assert } from '../logger/index.js'
+import { EventPlugin } from '../event/index.js'
+import { assert,deprecate } from '../logger/index.js'
 import { AppSchedule } from './schedules.js'
 import { Assets, generateParserSystem } from '../asset/index.js'
 import { SchedulerBuilder, SystemConfig } from './core/index.js'
@@ -88,7 +88,7 @@ export class App {
     }
 
     this.systemsevents = []
-    
+
     this.systemBuilder.pushToScheduler(this.scheduler)
     this.scheduler.run(this.world)
 
@@ -131,16 +131,15 @@ export class App {
   }
 
   /**
+   * @deprecated
    * @template {Function} T
    * @param {T} event
    */
   registerEvent(event) {
-    const name = `events<${event.name.toLowerCase()}>`
-
-    this
-      .registerType(event)
-      .world.setResourceByName(name, new EventDispatch())
-    this.systemsevents.push(new SystemConfig(makeEventClear(name), AppSchedule.Update))
+    deprecate('App.registerEvent()', 'EventPlugin')
+    this.registerPlugin(
+      new EventPlugin({ event })
+    )
 
     return this
   }

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -200,15 +200,3 @@ export class App {
     return this
   }
 }
-
-/**
- * @param {string} name 
- * @returns {SystemFunc}
- */
-function makeEventClear(name) {
-  return function clearEvents(world) {
-    const dispatch = world.getResource(name)
-
-    dispatch.clear()
-  }
-}

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -31,7 +31,10 @@ export class App {
   initialized = false
 
   /**
-   * @private
+   * This will be removed in future revisions
+   * with no prior notice after system ordering is
+   * added
+   * 
    * @type {SystemConfig[]}
    */
   systemsevents = []

--- a/src/event/index.js
+++ b/src/event/index.js
@@ -1,3 +1,4 @@
 export * from './core/index.js'
 export * from './typedef/index.js'
 export * from './systems/index.js'
+export * from './plugin.js'

--- a/src/event/index.js
+++ b/src/event/index.js
@@ -1,2 +1,3 @@
 export * from './core/index.js'
 export * from './typedef/index.js'
+export * from './systems/index.js'

--- a/src/event/plugin.js
+++ b/src/event/plugin.js
@@ -1,0 +1,37 @@
+import { App, AppSchedule, SystemConfig } from '../app/index.js'
+import { makeEventClear } from './systems/index.js'
+import { EventDispatch } from './core/index.js'
+
+export class EventPlugin {
+
+  /**
+   * @readonly
+   * @type {Function}
+   */
+  event
+
+  /**
+   * @param {{ event: Function; }} options
+   */
+  constructor(options) {
+    const { event } = options
+
+    this.event = event
+  }
+
+  /**
+   * @param {App} app
+   */
+  register(app) {
+    const { event } = this
+    const name = `events<${event.name.toLowerCase()}>`
+    
+    app
+      .registerType(event)
+      .getWorld().setResourceByName(name, new EventDispatch())
+    
+    // TODO - Once system ordering is implemented,remove this
+    // and `App.systemsevents`.
+    app.systemsevents.push(new SystemConfig(makeEventClear(name), AppSchedule.Update))
+  }
+}

--- a/src/event/systems/index.js
+++ b/src/event/systems/index.js
@@ -1,0 +1,12 @@
+/** @import {SystemFunc} from '../../ecs/index.js'*/
+/**
+ * @param {string} name 
+ * @returns {SystemFunc}
+ */
+export function makeEventClear(name) {
+  return function clearEvents(world) {
+    const dispatch = world.getResource(name)
+
+    dispatch.clear()
+  }
+}


### PR DESCRIPTION
## Objective
This is to ensure modularity of packages and that the event package should contain all the event functionality.

## Solution
N/A

## Showcase
```javascript
class MyEvent {}
const app = new App()

// This registers a new event `MyEvent` into the app.
app.registerPlugin(new EventPlugin({
  event:MyEvent
}))
```

## Migration guide
Before:
```javascript
class MyEvent {}
const app = new App()

app.registerEvent(MyEvent)
```
After:
```javascript
class MyEvent {}
const app = new App()

app.registerPlugin(new EventPlugin({
  event:MyEvent
}))
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.