### PR TITLE
Remove `BasicMaterialFlags`

### DIFF
--- a/src/render-webgl/assets/materials/basic.js
+++ b/src/render-webgl/assets/materials/basic.js
@@ -70,23 +70,3 @@ export class WebglBasicMaterial extends Material {
     ])
   }
 }
-
-
-// Removed this option as `WebglBasicMaterial.flags` as somehow webgl doesnt work well with bitflags.
-// May readd in the future if i find how to make it work.
-/**
- * @readonly
- * @enum {number}
- *
- * export const BasicMaterialFlags = {
- * /**
- * Default flag which doesnt enable any feature.
- * /
- * None: 0,
- * /**
- * Enables vertex colors
- * /
- * VertexColor: 1 << 0,
- * Transparent: 1 << 1
- * }
- */

--- a/src/render-webgl/assets/materials/basic.js
+++ b/src/render-webgl/assets/materials/basic.js
@@ -9,11 +9,6 @@ import {
 export class WebglBasicMaterial extends Material {
 
   /**
-   * @type {BasicMaterialFlags}
-   *
-   * flags = BasicMaterialFlags.None
-   */
-  /**
    * @type {boolean}
    */
   enableVertexColors


### PR DESCRIPTION
## Objective
What exactly does this pr do e.g fix a bug, upgrade packages, make a new feature.

## Solution
This removes `BasicMaterialFlags` and its associated usages as they is commented out.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.