### PR TITLE
Remove html `Audio` usage

### DIFF
--- a/src/device/plugin.js
+++ b/src/device/plugin.js
@@ -10,7 +10,7 @@ export class DevicePlugin {
   register(app) {
     const device = new Device()
     const ua = navigator.userAgent
-    const ae = new Audio()
+    const ae = document.createElement('audio')
 
     app.setResource(device)
 

--- a/src/device/resources/device.js
+++ b/src/device/resources/device.js
@@ -61,7 +61,7 @@ export class DeviceCapabilities {
    *
    * @type {boolean}
    */
-  audio = !!new Audio().canPlayType
+  audio = !!document.createElement('audio').canPlayType
 
   /**
    * A list of audio extensions this device supports.


### PR DESCRIPTION
## Objective
The javascript `Audio` conflicts with the one defined in the audio package, which corrupts the build files.

## Solution
Replace all `Audio` (which refer to the html audio) with the explicit `document.createElement('audio')`

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.