### PR TITLE
Refactor build system

### DIFF
--- a/.config/rollup.config.js
+++ b/.config/rollup.config.js
@@ -1,6 +1,7 @@
 import { readFileSync } from "fs"
 import { resolve } from "path"
 import { cwd } from "process"
+import { addJsdocExports } from "../scripts/rollupplugin.js"
 
 const pkg = JSON.parse(readFileSync(resolve(cwd(), "./package.json")).toString())
 
@@ -22,7 +23,9 @@ export default [{
 
   // UMD
   input,
-  plugins: [],
+  plugins: [
+    addJsdocExports()
+  ],
   output: {
     file: "dist/index.umd.js",
     format: "umd",
@@ -37,7 +40,9 @@ export default [{
 
   // ESM
   input,
-  plugins: [],
+  plugins: [
+    addJsdocExports()
+  ],
   output: {
     file: "dist/index.module.js",
     format: "esm",
@@ -45,5 +50,4 @@ export default [{
     sourcemap: false,
     banner
   }
-}
-]
+}]

--- a/scripts/rollupplugin.js
+++ b/scripts/rollupplugin.js
@@ -1,0 +1,12 @@
+export function addJsdocExports(){
+    return {
+      name:'remove-jsdoc-import',
+      transform(_code,path){
+        if (path.includes('typedef')) {
+          return {
+            moduleSideEffects:'no-treeshake'
+          }
+        }
+      }
+    }
+  }

--- a/scripts/typedef.js
+++ b/scripts/typedef.js
@@ -1,56 +1,39 @@
 import { readFileSync,writeFileSync,readdirSync } from "fs"
 import { join,resolve } from "path"
 
-concatTypedefs(resolve(process.cwd(),"src"),resolve(process.cwd(),"dist"))
+removeImports(resolve(process.cwd(),"dist"))
 
-/**
- * @param {string} input
- * @param {string} output
- */
-function concatTypedefs(input,output) {
-    const files = readdirSync(input,{ recursive: true })
-        .filter(str => str.includes("typedef"))
-        .filter(path => path.includes(".js"))
-        .filter(path => !path.includes("index.js"))
+function removeImports(output) {
     const outputfiles = readdirSync(output)
-    let blob = ""
-
-    for (const file of files) {
-        const fragment = readFileSync(join(input,file.toString()),{ encoding: "utf-8" })
-        const processedFragment = removeExport(removeNoCheck(fragment))
-
-        blob += "\n" + processedFragment
-    }
 
     for (const filename of outputfiles) {
         if (filename.includes(".d.ts") || filename.includes(".min.")) continue
 
-        const acc = readFileSync(join(output,filename),{ encoding: "utf-8" }) + blob
+        const acc = readFileSync(join(output,filename),{ encoding: "utf-8" })
 
-        writeFileSync(join(output,filename),acc)
+        writeFileSync(join(output,filename),removeterms(acc))
     }
 }
 
 /**
- * Ensure the exports is in the bottom.
- * @param {string} input 
- * @returns {string}
+ * 
+ * @param {string} word 
  */
-function removeExport(input) {
-    const index = input.lastIndexOf("export")
-
-    if (!input.includes('export')) return input
-
-    return input.slice(0,index)
-}
-
-/**
- * Ensure the no-check tag is there.
- * @param {string} input 
- * @returns {string}
- */
-function removeNoCheck(input) {
-    if(!input.includes('@ts-nocheck')) return input
-
-    return input.slice(input.indexOf("\n") + 1,input.length)
+function removeterms(word) {
+    const start = /(?=\/\*\*)/
+    const end = '*/'
+    const fragments = word
+    .split(start)
+    .flatMap(
+      term=>{
+        const terms = term.split(end)
+        terms[0] += end
+        return terms
+      }
+    )
+    .filter(
+      term=> !term.includes('@import')
+    )
+    const pr = fragments.join("")
+    return pr
 }


### PR DESCRIPTION
## Objective
 - Adds a rollup plugin which prevents tree shaking of single typedefs.
 - Modifies typedef script to remove jsdoc import comments

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.