### PR TITLE
Export typedefs from `touch` package

### DIFF
--- a/src/touch/index.js
+++ b/src/touch/index.js
@@ -1,3 +1,4 @@
 export * from './core/index.js'
 export * from './resources/index.js'
 export * from './plugin.js'
+export * from './typedef/index.js'


### PR DESCRIPTION
## Objective
Add the type definitions of `touch` package to its exports.

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.