### PR TITLE
Map space keyboard button into `KeyCode.Space`

### DIFF
--- a/src/keyboard/plugin.js
+++ b/src/keyboard/plugin.js
@@ -273,6 +273,9 @@ function mapKeyBoardButtons(keycode) {
     case 'Backspace':
       return KeyCode.BackSpace
 
+    case 'Space':
+      return KeyCode.Space
+
     case 'CapsLock':
       return KeyCode.Capslock
 


### PR DESCRIPTION
## Objective
Map space keyboard button to  `KeyCode.Space`

## Solution
Add a mapping of the space keyboard button.

## Showcase
If applicable,show how to use the feature being added.Recordings and screenshots can be added.

## Migration guide
Incase of breaking changes,what do users need to do to migrate to next version?

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.