### PR TITLE
Type `assert` correctly

### DIFF
--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -53,12 +53,12 @@ export function throws(message) {
 
 
 /**
- * Logs out a message,warning or error to the console according to the supplied log function.
+ * Throws an error if the supplied test is null or undefined.
  *
  * @template T
  * @param {T} test
  * @param {string} message
- * @returns {asserts test is true }
+ * @returns {asserts test is NonNullable<T>}
  */
 export function assert(test, message) {
   if (test === undefined || test === null) throws(message)


### PR DESCRIPTION
## Objective
Types `assert` to remove typescript compile time error.

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.