### PR TITLE
Scale `Color` values on canvas2d backend.

### DIFF
--- a/src/render-canvas2d/plugin.js
+++ b/src/render-canvas2d/plugin.js
@@ -150,8 +150,8 @@ function renderBasic(ctx, material, mesh) {
   if (!positions) return
 
   ctx.lineWidth = strokeWidth
-  ctx.fillStyle = `rgba(${fill.r},${fill.g},${fill.b},${fill.a})`
-  ctx.strokeStyle = `rgba(${stroke.r},${stroke.g},${stroke.b},${stroke.a})`
+  ctx.fillStyle = `rgba(${fill.r * 255},${fill.g * 255},${fill.b * 255},${fill.a * 255})`
+  ctx.strokeStyle = `rgba(${stroke.r * 255},${stroke.g * 255},${stroke.b * 255},${stroke.a * 255})`
 
   vertices(ctx, positions, true)
   ctx.stroke()
@@ -167,8 +167,8 @@ function renderText(ctx, material) {
 
   ctx.textAlign = align
   ctx.lineWidth = strokeWidth
-  ctx.fillStyle = `rgba(${fill.r},${fill.g},${fill.b},${fill.a})`
-  ctx.strokeStyle = `rgba(${stroke.r},${stroke.g},${stroke.b},${stroke.a})`
+  ctx.fillStyle = `rgba(${fill.r * 255},${fill.g * 255},${fill.b * 255},${fill.a * 255})`
+  ctx.strokeStyle = `rgba(${stroke.r * 255},${stroke.g * 255},${stroke.b * 255},${stroke.a * 255})`
   ctx.font = `${fontSize}px ${font}`
   ctx.textRendering = 'geometricPrecision'
   ctx.fillText(text, 0, 0)


### PR DESCRIPTION
## Objective
Scales the value from 0-255 to 0-1 to better fit
with render standards.
This will allow interop of `Color` between different render backends e.g webgl,webgpu and canvas2d as
`Color` is normalized.

## Solution
N/A

## Showcase
N/A

## Migration guide
`Color` values used in materials using canvas2d rendering backend should be normalized i.e mapped from 0-255 to 0-1

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.