### PR TITLE
Center cameras to middle of window on canvas2d.

### DIFF
--- a/src/render-canvas2d/plugin.js
+++ b/src/render-canvas2d/plugin.js
@@ -60,6 +60,9 @@ function renderToCanvas(world) {
   const canvas = canvases.getWindow(window[0])
   const ctx = canvas.getContext('2d')
 
+  const offsetX = window[1].getWidth() / 2
+  const offsetY = window[1].getHeight() / 2
+  
   if (!ctx) return warn('2d context could not be created on the canvas.')
     
   const [cameraTransform] = camera
@@ -67,6 +70,7 @@ function renderToCanvas(world) {
 
   ctx.clearRect(0, 0, canvas.width, canvas.height)
   ctx.save()
+  ctx.translate(offsetX, offsetY)
   ctx.transform(
     view.a,
     view.b,


### PR DESCRIPTION
## Objective
Changes camera origin from the top left of a window to the center a the window.
This ensures that cameras transform(translate,rotate and scale) about the center of a window instead of the top left of the screen.

## Solution
N/A

## Showcase
N/A

## Migration guide
If you depend on cameras being centered on the top left of a window, you will need to modify your app/plugin/system to use the new configuration.

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.