### PR TITLE
Type `Camera` constructor

### DIFF
--- a/src/render-core/components/camera.js
+++ b/src/render-core/components/camera.js
@@ -6,6 +6,12 @@ export class Camera {
    * @type {Projection}
    */
   projection
+
+  /**
+   * @param {Projection} projection 
+   * @param {number} near 
+   * @param {number} far 
+   */
   constructor(projection = new PerspectiveProjection(), near = 0.1, far = 1000) {
     this.projection = projection
     this.near = near


### PR DESCRIPTION
## Objective
Explicitly type `Camera` constructor to remove confusion of parameter type inference

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.