### PR TITLE
Make `Entity` a real type

### DIFF
--- a/src/ecs/entities/entity.js
+++ b/src/ecs/entities/entity.js
@@ -16,6 +16,6 @@ export class Entity {
    * @param {Entity} other
    */
   equals(other){
-    return this.index == other.index
+    return this.index === other.index
   }
 }

--- a/src/ecs/entities/entity.js
+++ b/src/ecs/entities/entity.js
@@ -1,18 +1,21 @@
 export class Entity {
-    /**
-     * @type {number}
-     */
-    index
-    /**
-     * @param {number} index
-     */
-    constructor(index){
-        this.index = index
-    }
-    /**
-     * @param {Entity} other
-     */
-    equals(other){
-        return this.index == other.index
-    }
+
+  /**
+   * @type {number}
+   */
+  index
+
+  /**
+   * @param {number} index
+   */
+  constructor(index){
+    this.index = index
+  }
+
+  /**
+   * @param {Entity} other
+   */
+  equals(other){
+    return this.index == other.index
+  }
 }

--- a/src/ecs/entities/entity.js
+++ b/src/ecs/entities/entity.js
@@ -1,0 +1,18 @@
+export class Entity {
+    /**
+     * @type {number}
+     */
+    index
+    /**
+     * @param {number} index
+     */
+    constructor(index){
+        this.index = index
+    }
+    /**
+     * @param {Entity} other
+     */
+    equals(other){
+        return this.index == other.index
+    }
+}

--- a/src/ecs/entities/index.js
+++ b/src/ecs/entities/index.js
@@ -1,2 +1,3 @@
 export * from './entities.js'
 export * from './location.js'
+export * from './entity.js'

--- a/src/ecs/typedef/entity.js
+++ b/src/ecs/typedef/entity.js
@@ -1,4 +1,0 @@
-/**
- * @typedef {number} Entity
- */
-export default {}

--- a/src/ecs/typedef/index.js
+++ b/src/ecs/typedef/index.js
@@ -1,5 +1,4 @@
 export * from './componenthook.js'
-export * from './entity.js'
 export * from './filter.js'
 export * from './system.js'
 export * from './identifiers.js'


### PR DESCRIPTION
## Objective
Makes `Entity` a class instead of a number typedef.

## Solution
N/A

## Showcase
N/A

## Migration guide
If your project is dependent on `Entity` being a number, you will need to update your code:

```diff
- const entity = 0
+ const entity = new Entity()

function doSomething(entity:number){
  // do something here
}

- doSomething(entity)
+ doSomething(entity.index)
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.