### PR TITLE
Make `Query` accept component types instead of component names

### DIFF
--- a/src/command/commands/despawn.js
+++ b/src/command/commands/despawn.js
@@ -7,7 +7,7 @@ export class DespawnCommand extends Command {
   /**
    * @type {Entity}
    */
-  entity = 0
+  entity
 
   /**
    * @param {Entity} entity

--- a/src/command/commands/spawn.js
+++ b/src/command/commands/spawn.js
@@ -8,7 +8,7 @@ export class SpawnCommand extends Command {
    * @readonly
    * @type {Entity}
    */
-  entity = 0
+  entity
 
   /**
    * @type {any[]}

--- a/src/ecs/query.js
+++ b/src/ecs/query.js
@@ -1,4 +1,5 @@
-/** @import { ComponentId, ArchetypeId, Entity, Tuple, ComponentName } from './typedef/index.js'*/
+/** @import { ComponentId, ArchetypeId, Tuple, ComponentName } from './typedef/index.js'*/
+import { Entity } from './entities/index.js'
 import { World } from './registry.js'
 import { ArchetypeTable } from './tables/archetypetable.js'
 
@@ -100,7 +101,7 @@ export class Query {
    */
   get(entity) {
     const entities = this.registry.getEntities()
-    const location = entities.get(entity)
+    const location = entities.get(entity.index)
 
     if(!location) return null
 

--- a/src/ecs/query.js
+++ b/src/ecs/query.js
@@ -227,3 +227,8 @@ export class Query {
 /**
  * @typedef {new (...args:any[])=>unknown} Constructor
  */
+
+/**
+ * @template {Constructor[]} T
+ * @typedef {{[K in keyof T]:InstanceType<T[K]>}} InstanceTypeTuple
+ */

--- a/src/ecs/query.js
+++ b/src/ecs/query.js
@@ -25,7 +25,8 @@ import { ArchetypeTable } from './tables/archetypetable.js'
  * // are available
  * ```
  * 
- * @template {Tuple} T
+ * @template {InstanceTypeTuple<U>} T
+ * @template {Constructor[]} U 
  */
 export class Query {
 
@@ -55,10 +56,11 @@ export class Query {
 
   /**
    * @param {World} registry
-   * @param {ComponentName[]} descriptors
+   * @param {[...U]} componentTypes
    */
-  constructor(registry, descriptors) {
+  constructor(registry, componentTypes) {
     this.registry = registry
+    const descriptors = componentTypes.map((type) => type.name.toLowerCase())
 
     for (let i = 0; i < descriptors.length; i++) {
       this.components[i] = []
@@ -74,7 +76,7 @@ export class Query {
   update(table) {
     const { descriptors, components } = this
     const archids = table.getArchetypeIds(descriptors, [])
-
+    
     for (let i = 0; i < archids.length; i++) {
       this.archmapper.set(archids[i], i)
     }

--- a/src/ecs/query.js
+++ b/src/ecs/query.js
@@ -223,3 +223,7 @@ export class Query {
  * @param {T} components2
  * @returns {void}
  */
+
+/**
+ * @typedef {new (...args:any[])=>unknown} Constructor
+ */

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -1,10 +1,10 @@
-/** @import { ComponentId, Tuple, Entity } from './typedef/index.js'*/
+/** @import { ComponentId, Tuple } from './typedef/index.js'*/
 
 import { ArchetypeTable } from './tables/index.js'
 import { TypeStore } from './typestore.js'
 import { assert } from '../logger/index.js'
 import { ComponentHooks } from './component/index.js'
-import { Entities } from './entities/entities.js'
+import { Entities,Entity } from './entities/index.js'
 import { EntityLocation } from './entities/location.js'
 
 export class World {
@@ -32,12 +32,7 @@ export class World {
    */
   entities = new Entities()
   constructor() {
-
-    // Because the type `Entity` is a typedef, not an actual class.
-    // @ts-ignore
-    this.typestore.set({
-      name: 'entity'
-    })
+    this.typestore.set(Entity)
   }
 
   /**
@@ -140,23 +135,25 @@ export class World {
    * @returns {Entity}
    */
   create(components) {
-    const entity = this.entities.reserve()
+    const entityIndex = this.entities.reserve()
+
+    // SAFETY: the entity was reserved in this function so we know its there.
+    const location = /** @type {EntityLocation}*/(this.entities.get(entityIndex))
     const ids = this.getComponentIds(components)
+    const entity = new Entity(entityIndex)
     
     assert(ids, `Cannot insert "${components.map((e) => `\`${e.constructor.name}\``).join(', ')}" into \`ArchetypeTable\`.Ensure that all of them are registered properly using \`World.registerType()\``)
     
     ids.push(0)
     components.push(entity)
     
-    const [id, index] = this.table.insert(components, ids)
+    const [id, tableIndex] = this.table.insert(components, ids)
     
-    // SAFETY: the entity was reserved in this function so we know its there.
-    const location = /** @type {EntityLocation}*/(this.entities.get(entity))
 
     location.archid = id
-    location.index = index
+    location.index = tableIndex
     this.callAddComponentHook(entity, ids)
-
+    
     return entity
   }
 
@@ -168,7 +165,7 @@ export class World {
    * @param {T} components - The entity to add.
    */
   insert(entity, components) {
-    const location = this.entities.get(entity)
+    const location = this.entities.get(entity.index)
     
     assert(location, 'Cannot insert to an entity not created on the world.Use `World.create()` then try to insert the given entity into the world.')
 
@@ -191,7 +188,7 @@ export class World {
     location.index = newIndex
 
     if (swapped){
-      const swappedlocation = /** @type {EntityLocation} */(this.entities.get(swapped))
+      const swappedlocation = /** @type {EntityLocation} */(this.entities.get(swapped.index))
 
       swappedlocation.index = index
     }
@@ -218,7 +215,7 @@ export class World {
    * @param {Entity} entity - The entity to remove.
    */
   remove(entity) {
-    const location = this.entities.get(entity)
+    const location = this.entities.get(entity.index)
 
     if(!location) return
 
@@ -235,10 +232,10 @@ export class World {
 
     location.archid = -1
     location.index = -1
-    this.entities.recycle(entity)
+    this.entities.recycle(entity.index)
 
     if (swapped){
-      const swappedlocation = /** @type {EntityLocation} */(this.entities.get(swapped))
+      const swappedlocation = /** @type {EntityLocation} */(this.entities.get(swapped.index))
 
       swappedlocation.index = index
     }
@@ -251,7 +248,7 @@ export class World {
    * @returns {T | null}
    */
   get(entity, compName) {
-    const location = this.entities.get(entity)
+    const location = this.entities.get(entity.index)
 
     if(!location) return null
 

--- a/src/window/resources/windows.js
+++ b/src/window/resources/windows.js
@@ -6,7 +6,7 @@ export class Windows {
 
   /**
    * @private
-   * @type {Map<Entity,HTMLCanvasElement>}
+   * @type {Map<number,HTMLCanvasElement>}
    */
   entities = new Map()
 
@@ -15,8 +15,8 @@ export class Windows {
    * @returns {HTMLCanvasElement}
    */
   getWindow(entity){
-    const window = this.entities.get(entity)
-
+    const window = this.entities.get(entity.index)
+    
     assert(window, 'the provided window entity does not have a corresponding canvas element.')
 
     return window
@@ -27,13 +27,13 @@ export class Windows {
    * @param {HTMLCanvasElement} window
    */
   setWindow(entity, window){
-    this.entities.set(entity, window)
+    this.entities.set(entity.index, window)
   }
   
   /**
    * @param {Entity} entity
    */
   delete(entity){
-    this.entities.delete(entity)
+    this.entities.delete(entity.index)
   }
 }


### PR DESCRIPTION
## Objective
 - Implements #76 

## Solution
Discussed in the issue

## Showcase
N/A

## Migration guide
Before:
```typescript
const AComponent {}
const query = new Query<[AComponent]>(world,["acomponent"])
```
After:
```typescript
const AComponent {}
const query = new Query(world,[AComponent])
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.