### PR TITLE
Add `World.getResourceByName`

### DIFF
--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -279,6 +279,15 @@ export class World {
   /**
    * @template T
    * @param {string} name
+   * @returns {T}
+   */
+  getResourceByName(name) {
+    return this.resources[name]
+  }
+
+  /**
+   * @template T
+   * @param {string} name
    * @param {T} resource
    * @returns {void}
    */

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -5,7 +5,7 @@ import { EventDispatch } from '../event/index.js'
 import { assert, warn } from '../logger/index.js'
 import { Camera, Material, MaterialHandle, Mesh, MeshHandle, ProgramCache } from '../render-core/index.js'
 import { GlobalTransform3D } from '../transform/index.js'
-import { MainWindow, WindowResize, Windows } from '../window/index.js'
+import { MainWindow, Window, WindowResize, Windows } from '../window/index.js'
 import { materialAddHook, meshAddHook } from './hooks/index.js'
 import { AttributeMap, ClearColor, MeshCache, UBOCache } from './resources/index.js'
 


### PR DESCRIPTION
## Objective
Adds a method to get a resource by name.

## Solution
N/A

## Showcase
```typescript
class AResource {}

const resource = world.getResourceByName("aresource")
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.