### PR TITLE
Import `Window` to prevent type confusion.

### DIFF
--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -5,7 +5,7 @@ import { EventDispatch } from '../event/index.js'
 import { assert, warn } from '../logger/index.js'
 import { Camera, Material, MaterialHandle, Mesh, MeshHandle, ProgramCache } from '../render-core/index.js'
 import { GlobalTransform3D } from '../transform/index.js'
-import { MainWindow, WindowResize, Windows } from '../window/index.js'
+import { MainWindow, Window, WindowResize, Windows } from '../window/index.js'
 import { materialAddHook, meshAddHook } from './hooks/index.js'
 import { AttributeMap, ClearColor, MeshCache, UBOCache } from './resources/index.js'
 


### PR DESCRIPTION
## Objective
The library `Window` is being confused with the
DOM `Window` type which can cause build to confuse the two

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.