### PR TITLE
Remove `ts-nocheck` on some typedefs

### DIFF
--- a/src/app/typedef/types.js
+++ b/src/app/typedef/types.js
@@ -1,4 +1,4 @@
-// @ts-nocheck
+/** @import {App} from '../app.js' */
 /**
  * @callback RegisterFunc
  * @param {App} app

--- a/src/command/typedef/commandfn.js
+++ b/src/command/typedef/commandfn.js
@@ -1,4 +1,5 @@
-// @ts-nocheck
+/** @import { Command } from "../core/index.js" */
+
 /**
  * @template {Command} T
  * @callback CommandFn

--- a/src/ecs/typedef/componenthook.js
+++ b/src/ecs/typedef/componenthook.js
@@ -1,4 +1,5 @@
-// @ts-nocheck
+/** @import { World } from "../registry.js" */
+/** @import { Entity } from "../entities/index.js" */
 /**
  * @callback ComponentHook
  * @param {Entity} entity

--- a/src/ecs/typedef/filter.js
+++ b/src/ecs/typedef/filter.js
@@ -1,4 +1,6 @@
-// @ts-nocheck
+/** @import {Archetype} from '../tables/index.js' */
+/** @import {ArchetypeId} from './identifiers.js' */
+
 /**
  * @callback ArchetypeFilter
  * @param {Archetype} archetype

--- a/src/ecs/typedef/system.js
+++ b/src/ecs/typedef/system.js
@@ -1,4 +1,4 @@
-// @ts-nocheck
+/** @import {World} from '../registry.js'*/
 /**
  * @callback SystemFunc
  * @param {World} registry

--- a/src/event/typedef/reader.js
+++ b/src/event/typedef/reader.js
@@ -1,4 +1,4 @@
-// @ts-nocheck
+/** @import {CEvent} from '../core/index.js' */
 /**
  * @template T
  * @callback EventReader


### PR DESCRIPTION
## Objective
Remove `// ts-nocheck` on the typedefs to better the type inference of the typedefs.

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.