### PR TITLE
Modify all damping resources to contain coefficient instead of inheriting `Number`

### DIFF
--- a/src/damping/resources/angulardampen.js
+++ b/src/damping/resources/angulardampen.js
@@ -1,2 +1,16 @@
-export class Angular2DDamping extends Number {}
+export class Angular2DDamping {
+
+  /**
+   * @type {number}
+   */
+  value
+
+  /**
+   * @param {number} value 
+   */
+  constructor(value = 0){
+    this.value = value
+  }
+}
+
 export class Angular3DDamping extends Number {}

--- a/src/damping/resources/angulardampen.js
+++ b/src/damping/resources/angulardampen.js
@@ -12,5 +12,17 @@ export class Angular2DDamping {
     this.value = value
   }
 }
+export class Angular3DDamping {
 
-export class Angular3DDamping extends Number {}
+  /**
+   * @type {number}
+   */
+  value
+
+  /**
+   * @param {number} value 
+   */
+  constructor(value = 0){
+    this.value = value
+  }
+}

--- a/src/damping/resources/lineardampen.js
+++ b/src/damping/resources/lineardampen.js
@@ -1,2 +1,16 @@
-export class Linear2DDamping extends Number {}
+export class Linear2DDamping{
+
+  /**
+   * @type {number}
+   */
+  value
+
+  /**
+   * @param {number} value 
+   */
+  constructor(value = 0){
+    this.value = value
+  }
+}
+
 export class Linear3DDamping extends Number {}

--- a/src/damping/resources/lineardampen.js
+++ b/src/damping/resources/lineardampen.js
@@ -13,4 +13,17 @@ export class Linear2DDamping{
   }
 }
 
-export class Linear3DDamping extends Number {}
+export class Linear3DDamping {
+
+  /**
+   * @type {number}
+   */
+  value
+
+  /**
+   * @param {number} value 
+   */
+  constructor(value = 0){
+    this.value = value
+  }
+}


### PR DESCRIPTION
## Objective
The resources `Linear2DDamping`, `Angular3DDamping`,  `Angular2DDamping` and `Angular3DDamping` no longer inherit from number but contains the coefficient in a property `value`.

This is because math operators in typescript cannot be overloaded even if it inherits Number due to type conflicts.


## Solution
N/A

## Showcase
N/A

## Migration guide
```typescript
// This can be done for the listed resources
const damping = new Linear2DDamping()
const speed = 10

// before
const finalSpeed = damping * speed

// after
const finalSpeed = damping.value * speed

```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.