### PR TITLE
Modify `World.getResource` to use component types not component names.

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,6 +3,10 @@
         "strict": true,
         "checkJs":true,
         "target": "ES2020",
+        "module": "NodeNext",
+        "paths": {
+            "wima":["/src/index.js"]
+        }
     },
     "include":[
         "src",

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -273,10 +273,11 @@ export class World {
    * @returns {T}
    */
   getResource(resourceType) {
-    const name = resourceType.name
+    const { name } = resourceType
     const resource = this.resources[name.toLowerCase()]
 
-    assert(resource,`The resource \`${name}\` does not exist in the world.`)
+    assert(resource, `The resource \`${name}\` does not exist in the world.`)
+
     return resource
   }
 

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -269,11 +269,15 @@ export class World {
 
   /**
    * @template T
-   * @param {string} name
+   * @param {new (...args:any[])=>T} resourceType
    * @returns {T}
    */
-  getResource(name) {
-    return this.resources[name]
+  getResource(resourceType) {
+    const name = resourceType.name
+    const resource = this.resources[name.toLowerCase()]
+
+    assert(resource,`The resource \`${name}\` does not exist in the world.`)
+    return resource
   }
 
   /**


### PR DESCRIPTION
## Objective
 - Implements #77 

## Solution
Discussed in the issue

## Showcase
N/A

## Migration guide
Before:
```typescript
class A {}

const world = new World()
const resource = world.getResource<A>("a")
```
After:
```typescript
class A {}

const world = new World()

// This is the type safe method
const query = world.getResource(A)

// Sometimes you need to get a resource by name
// This might be removed in the future
const query = world.getResource<A>("a")

```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.