### PR TITLE
Rename `Attribute` to `MeshAttributeData`

### DIFF
--- a/src/render-core/core/attributedata.js
+++ b/src/render-core/core/attributedata.js
@@ -1,9 +1,10 @@
-export class Attribute{
+export class MeshAttributeData {
 
   /**
-   * @private
    * @type {Float32Array}
    */
+  data
+  
   /**
    * @param {Float32Array} data
    */

--- a/src/render-core/core/index.js
+++ b/src/render-core/core/index.js
@@ -1,4 +1,4 @@
-export * from './attribute.js'
+export * from './attributedata.js'
 export * from './atributelocation.js'
 export * from './shaderstage.js'
 export * from './projection.js'


### PR DESCRIPTION
## Objective
Stated in the title

## Solution
N/A

## Showcase
N/A

## Migration guide
Before:
```typescript diff
 const data = new Attribute(new Float32Array([0,1,2])
```
After:
```typescript
const data = new MeshAttributeData(new Float32Array([0,1,2])
```
## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.