### PR TITLE
Rename `AttributeLocation` to `MeshAttribute`

### DIFF
--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -1,6 +1,6 @@
 import { GlDataType } from '../../render-webgl/index.js'
 
-export class AttributeLocation {
+export class MeshAttribute {
 
   /**
    * @readonly

--- a/src/render-core/core/index.js
+++ b/src/render-core/core/index.js
@@ -1,4 +1,4 @@
 export * from './attributedata.js'
-export * from './atributelocation.js'
+export * from './attribute.js'
 export * from './shaderstage.js'
 export * from './projection.js'


### PR DESCRIPTION
## Objective
Stated in title.

## Solution
N/A

## Showcase
N/A

## Migration guide
Before:
```typescript
const attribute = new AttributeLocation(/** insert arguments */)
```
After:
```typescript
const attribute = new MeshAttribute(/** insert arguments */)
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.