### PR TITLE
Move static mesh attributes from `Mesh` to `MeshAttribute`

### DIFF
--- a/src/render-core/assets/mesh.js
+++ b/src/render-core/assets/mesh.js
@@ -827,12 +827,6 @@ export class Mesh {
     return new Mesh()
   }
 
-  static UVLocation = new AttributeLocation(
-    'uv',
-    2,
-    GlDataType.Float,
-    2
-  )
   static UVBLocation = new AttributeLocation(
     'uvb',
     3,

--- a/src/render-core/assets/mesh.js
+++ b/src/render-core/assets/mesh.js
@@ -827,12 +827,6 @@ export class Mesh {
     return new Mesh()
   }
 
-  static Tangent3DLocation = new AttributeLocation(
-    'tangent3d',
-    7,
-    GlDataType.Float,
-    3
-  )
   static ColorLocation = new AttributeLocation(
     'color',
     8,

--- a/src/render-core/assets/mesh.js
+++ b/src/render-core/assets/mesh.js
@@ -826,11 +826,4 @@ export class Mesh {
   static default() {
     return new Mesh()
   }
-
-  static ColorLocation = new AttributeLocation(
-    'color',
-    8,
-    GlDataType.Float,
-    4
-  )
 }

--- a/src/render-core/assets/mesh.js
+++ b/src/render-core/assets/mesh.js
@@ -827,12 +827,6 @@ export class Mesh {
     return new Mesh()
   }
 
-  static UVBLocation = new AttributeLocation(
-    'uvb',
-    3,
-    GlDataType.Float,
-    2
-  )
   static Normal2DLocation = new AttributeLocation(
     'normal2d',
     4,

--- a/src/render-core/assets/mesh.js
+++ b/src/render-core/assets/mesh.js
@@ -827,12 +827,6 @@ export class Mesh {
     return new Mesh()
   }
 
-  static Normal2DLocation = new AttributeLocation(
-    'normal2d',
-    4,
-    GlDataType.Float,
-    2
-  )
   static Normal3DLocation = new AttributeLocation(
     'normal3d',
     5,

--- a/src/render-core/assets/mesh.js
+++ b/src/render-core/assets/mesh.js
@@ -827,12 +827,6 @@ export class Mesh {
     return new Mesh()
   }
 
-  static Position3DLocation = new AttributeLocation(
-    'position3d',
-    1,
-    GlDataType.Float,
-    3
-  )
   static UVLocation = new AttributeLocation(
     'uv',
     2,

--- a/src/render-core/assets/mesh.js
+++ b/src/render-core/assets/mesh.js
@@ -827,12 +827,6 @@ export class Mesh {
     return new Mesh()
   }
 
-  static Position2DLocation = new AttributeLocation(
-    'position2d',
-    0,
-    GlDataType.Float,
-    2
-  )
   static Position3DLocation = new AttributeLocation(
     'position3d',
     1,

--- a/src/render-core/assets/mesh.js
+++ b/src/render-core/assets/mesh.js
@@ -827,12 +827,6 @@ export class Mesh {
     return new Mesh()
   }
 
-  static Normal3DLocation = new AttributeLocation(
-    'normal3d',
-    5,
-    GlDataType.Float,
-    3
-  )
   static Tangent2DLocation = new AttributeLocation(
     'tangent2d',
     6,

--- a/src/render-core/assets/mesh.js
+++ b/src/render-core/assets/mesh.js
@@ -827,12 +827,6 @@ export class Mesh {
     return new Mesh()
   }
 
-  static Tangent2DLocation = new AttributeLocation(
-    'tangent2d',
-    6,
-    GlDataType.Float,
-    2
-  )
   static Tangent3DLocation = new AttributeLocation(
     'tangent3d',
     7,

--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -73,4 +73,11 @@ export class MeshAttribute {
     GlDataType.Float,
     2
   )
+
+  static Normal3D = new MeshAttribute(
+    'normal3d',
+    5,
+    GlDataType.Float,
+    3
+  )
 }

--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -94,4 +94,11 @@ export class MeshAttribute {
     GlDataType.Float,
     3
   )
+
+  static Color = new MeshAttribute(
+    'color',
+    8,
+    GlDataType.Float,
+    4
+  )
 }

--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -80,4 +80,11 @@ export class MeshAttribute {
     GlDataType.Float,
     3
   )
+
+  static Tangent2D = new MeshAttribute(
+    'tangent2d',
+    6,
+    GlDataType.Float,
+    2
+  )
 }

--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -45,4 +45,11 @@ export class MeshAttribute {
     GlDataType.Float,
     2
   )
+
+  static Position3D = new MeshAttribute(
+    'position3d',
+    1,
+    GlDataType.Float,
+    3
+  )
 }

--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -38,4 +38,11 @@ export class MeshAttribute {
     this.type = type
     this.size = size
   }
+
+  static Position2D = new MeshAttribute(
+    'position2d',
+    0,
+    GlDataType.Float,
+    2
+  )
 }

--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -87,4 +87,11 @@ export class MeshAttribute {
     GlDataType.Float,
     2
   )
+
+  static Tangent3D = new MeshAttribute(
+    'tangent3d',
+    7,
+    GlDataType.Float,
+    3
+  )
 }

--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -66,4 +66,11 @@ export class MeshAttribute {
     GlDataType.Float,
     2
   )
+
+  static Normal2D = new MeshAttribute(
+    'normal2d',
+    4,
+    GlDataType.Float,
+    2
+  )
 }

--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -52,4 +52,11 @@ export class MeshAttribute {
     GlDataType.Float,
     3
   )
+
+  static UV = new MeshAttribute(
+    'uv',
+    2,
+    GlDataType.Float,
+    2
+  )
 }

--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -59,4 +59,11 @@ export class MeshAttribute {
     GlDataType.Float,
     2
   )
+
+  static UVB = new MeshAttribute(
+    'uvb',
+    3,
+    GlDataType.Float,
+    2
+  )
 }


### PR DESCRIPTION
## Objective
Moves the attributes to ensure that there is semantical coherence.

## Solution
N/A

## Showcase
N/A

## Migration guide
The static attributes have been moved to `MeshAttribute` and renamed so they dont have the postfix 'Location'
For example the 2d position mesh attribute:
```diff
- Mesh.Position2DLocation
+ MeshAttribute.Position2D
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.