### PR TITLE
Fix webgl binding program after modifying state and refactor.

### DIFF
--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -109,11 +109,11 @@ function render(world) {
 
       assert(ubo, `The uniform buffer for material '${material.constructor.name}' is not set up.` )
 
+      gl.useProgram(pipeline.program)
       pipeline.setUniformMatrix3x4(gl, 'model', transform)
       gl.bindBuffer(gl.UNIFORM_BUFFER, ubo.buffer)
       gl.bufferSubData(gl.UNIFORM_BUFFER, 0, data)
       gl.bindVertexArray(gpumesh)
-      gl.useProgram(pipeline.program)
 
       const indices = mesh.getIndices()
       const count = mesh.getAttribute('position3d')?.data.length

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -125,6 +125,7 @@ function render(world) {
         if (positions === undefined) return
   
         const count = positions.data.length
+
         gl.drawArrays(gl.TRIANGLES, 0, count / 3)
       }
     })

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -116,12 +116,15 @@ function render(world) {
       gl.bindVertexArray(gpumesh)
 
       const indices = mesh.getIndices()
-      const count = mesh.getAttribute('position3d')?.data.length
-
-      if (count === undefined) return
+      
       if (indices) {
         gl.drawElements(gl.TRIANGLES, indices.length, gl.UNSIGNED_SHORT, 0)
       } else {
+        const positions = mesh.getAttribute('position3d')
+        
+        if (positions === undefined) return
+  
+        const count = positions.data.length
         gl.drawArrays(gl.TRIANGLES, 0, count / 3)
       }
     })


### PR DESCRIPTION
## Objective
 - Ensures that a webgl program is bound before state changes which are supposed to affect it.
 - Refactor code to `render` system to only pull position data from the mesh only if indices are missing.

## Solution
Bind program before any state changes.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.