### PR TITLE
Change `World.setComponentHooks` to use component type instead of component name.

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -186,11 +186,12 @@ export class App {
   }
 
   /**
-   * @param {Function} component
+   * @template T
+   * @param {new (...args:any[])=>T} component
    * @param {ComponentHooks} hooks
    */
   setComponentHooks(component, hooks) {
-    this.world.setComponentHooks(component.name.toLowerCase(), hooks)
+    this.world.setComponentHooks(component, hooks)
 
     return this
   }

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -316,10 +316,12 @@ export class World {
   }
 
   /**
-   * @param {string} componentname
+   * @template T
+   * @param {new ()=>T} component
    * @param {ComponentHooks} hooks
    */
-  setComponentHooks(componentname, hooks) {
+  setComponentHooks(component, hooks) {
+    const componentname = component.name.toLowerCase()
     const info = this.typestore.get(componentname)
 
     assert(info, `The component "${componentname}" has not been registered.Use \`World.registerType()\` to add it.`)


### PR DESCRIPTION
## Objective
 - Change `World.setComponentHooks` to use component type instead of component name.
 - Update dependents of `World.setComponentHooks`

## Solution
N/A

## Showcase
N/A

## Migration guide
Before:
```typescript
class Component {}

world.setComponentHook("component",new ComponentHooks())
```
After:
```typescript
class Component {}

world.setComponentHook(Component,new ComponentHooks())
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.