### PR TITLE
Make `ArchetypeTable.extract` fallible.

### DIFF
--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -226,13 +226,18 @@ export class World {
     const { archid, index } = location
 
     // TODO - Use a method that iterates through componentlists to call remove hook.
-    const [extractid] = this.table.extract(archid, index)
+    const extracted = this.table.extract(archid, index)
 
-    this.callRemoveComponentHook(entity, extractid)
+    if(extracted){
+      const [extractid] = extracted
+
+      this.callRemoveComponentHook(entity, extractid)
+    }
+
     this.table.remove(archid, index)
 
     // SAFETY: Because `Entity` is guaranteed to have a `ComponentId` of 0.
-    const swapped = /** @type {Entity}*/(this.table.get(archid, index, 0))
+    const swapped = /** @type {Entity | null}*/(this.table.get(archid, index, 0))
 
     location.archid = -1
     location.index = -1

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -174,7 +174,11 @@ export class World {
 
     assert(ids, `Cannot insert "${components.map((e) => `\`${e.constructor.name}\``).join(', ')}" into \`World\`.Ensure that all of them are registered properly using \`World.registerType()\``)
 
-    const [idextract, extract] = this.table.extract(archid, index)
+    const extracted = this.table.extract(archid, index)
+
+    assert(extracted, 'Invalid extraction on insert')
+
+    const [idextract, extract] = extracted
 
     this.table.remove(archid, index)
 

--- a/src/ecs/tables/archetypetable.js
+++ b/src/ecs/tables/archetypetable.js
@@ -1,6 +1,5 @@
 /** @import { ComponentId, ArchetypeId, ArchetypeFilter } from '../typedef/index.js'*/
 import { swapRemove } from '../../utils/index.js'
-import { assert } from '../../logger/index.js'
 
 /**
  * Contains entities with the same set of components.
@@ -165,14 +164,14 @@ export class ArchetypeTable {
   /**
    * @param {ArchetypeId} id
    * @param {number} index
-   * @returns {[ComponentId[],unknown[]]}
+   * @returns {[ComponentId[],unknown[]] | null}
    */
   extract(id, index) {
     const keys = []
     const components = []
     const archetype = this.list[id]
 
-    assert(archetype, 'Tried to extract from a non existent archetype.')
+    if(!archetype) return null
 
     for (const [key, list] of archetype.components) {
       keys.push(key)


### PR DESCRIPTION
## Objective
The method should not throw an error when archetype is not found but should return null when the archetype is not found.

## Solution
N/A

## Showcase
N/A

## Migration guide
Before:
```typescript
try {
  const components = archetypetable.extract(/* components to extract */)
  // do something to the components
}catch(){
  // do something when components are not in the table.
}
```

After:
```typescript
const components = archetypetable.extract(/* components to extract */)

if(components){
  // do something to the components
}else{
  // do something when components are not in the table.
}
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.