### PR TITLE
Change `World.get` to use component type instead of component name.

### DIFF
--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -244,11 +244,12 @@ export class World {
   /**
    * @template T
    * @param {Entity} entity
-   * @param { string  } compName
+   * @param { new (...args:any[])=> T} type
    * @returns {T | null}
    */
-  get(entity, compName) {
+  get(entity, type) {
     const location = this.entities.get(entity.index)
+    const compName = type.name.toLowerCase()
 
     if(!location) return null
 

--- a/src/physics/hooks/physicsproperties.js
+++ b/src/physics/hooks/physicsproperties.js
@@ -1,5 +1,5 @@
 /** @import { ComponentHook } from '../../ecs/index.js'*/
-import { Collider2D } from '../components/index.js'
+import { Collider2D, PhysicsProperties } from '../components/index.js'
 import { warn } from '../../logger/index.js'
 
 
@@ -7,11 +7,14 @@ import { warn } from '../../logger/index.js'
  * @type {ComponentHook}
  */
 export function physicspropertiesAddHook(entity, world) {
-  const component = world.get(entity, 'physicsproperties')
-  const collider = world.get(entity, 'collider2d')
+
+  // SAFETY: Component guranteed to be there as this is its
+  // component hook
+  const component = /** @type {PhysicsProperties}*/(world.get(entity, PhysicsProperties))
+  const collider = world.get(entity, Collider2D)
 
   if (!collider)return warn(`No \`Collider2D\` component detected on entity ${entity}.Note that this entity's body will misbehave.`)
-  
+
   const mass = component.invmass ? 1 / component.invmass : 0
   const inertia = Collider2D.calcInertia(collider, mass)
 

--- a/src/physics/systems/debugger.js
+++ b/src/physics/systems/debugger.js
@@ -145,8 +145,10 @@ export function drawArms(world) {
   ctx.beginPath()
 
   for (let i = 0; i < contacts.length; i++) {
-    const posA = world.get(contacts[i].entityA, 'transform')[0].position
-    const posB = world.get(contacts[i].entityB, 'transform')[0].position
+    const posA = world.get(contacts[i].entityA, Position2D)
+    const posB = world.get(contacts[i].entityB, Position2D)
+
+    if(!posA || !posB ) return
 
     for (let j = 0; j < contacts[i].contactData.contactNo; j++) {
       drawArmRaw(ctx, posA, contacts[i].contactData.contactPoints[j])

--- a/src/render-webgl/hooks/material.js
+++ b/src/render-webgl/hooks/material.js
@@ -1,7 +1,7 @@
 /** @import {ComponentHook } from "../../ecs/index.js" */
 import { Query, Entity } from '../../ecs/index.js'
-import { Assets, Handle } from '../../asset/index.js'
-import { Material, ProgramCache, ShaderStage } from '../../render-core/index.js'
+import { Assets } from '../../asset/index.js'
+import { Material, MaterialHandle, ProgramCache, ShaderStage } from '../../render-core/index.js'
 import { createShader, createProgram, validateProgram, validateShader, WebglRenderPipeline } from '../core/index.js'
 import { MainWindow, Windows, Window } from '../../window/index.js'
 import { warn } from '../../logger/index.js'
@@ -14,13 +14,10 @@ import { AttributeMap, UBOCache } from '../resources/index.js'
  */
 export function materialAddHook(entity, world) {
 
-  /** @type {Handle<Material>} */
-  const handle = world.get(entity, 'materialhandle')
-
-  /** @type {AttributeMap} */
+  // SAFETY: Component is guaranteed as this is its component hook
+  const handle = /** @type {MaterialHandle}*/(world.get(entity, MaterialHandle))
+  
   const attributeMap = world.getResource(AttributeMap)
-
-  /** @type {UBOCache} */
   const ubos = world.getResource(UBOCache)
 
   /** @type {Assets<Material>} */

--- a/src/render-webgl/hooks/mesh.js
+++ b/src/render-webgl/hooks/mesh.js
@@ -1,7 +1,7 @@
 /** @import { ComponentHook } from "../../ecs/index.js" */
 import { Query, Entity } from '../../ecs/index.js'
-import { Assets, Handle } from '../../asset/index.js'
-import { Mesh } from '../../render-core/index.js'
+import { Assets } from '../../asset/index.js'
+import { Mesh, MeshHandle } from '../../render-core/index.js'
 import { createVAO } from '../core/function.js'
 import { MainWindow, Windows, Window } from '../../window/index.js'
 import { warn } from '../../logger/index.js'
@@ -13,10 +13,10 @@ import { MeshCache, AttributeMap } from '../resources/index.js'
  * @type {ComponentHook} 
  */
 export function meshAddHook(entity, world) {
-  const attributeMap = world.getResource(AttributeMap)
 
-  /** @type {Handle<Mesh>} */
-  const handle = world.get(entity, 'meshhandle')
+  // SAFETY: Component is guaranteed as this is its component hook
+  const handle = /** @type {MeshHandle} */(world.get(entity, MeshHandle))
+  const attributeMap = world.getResource(AttributeMap)
 
   /** @type {Assets<Mesh>} */
   const meshes = world.getResourceByName('assets<mesh>')

--- a/src/window-dom/hooks/window.js
+++ b/src/window-dom/hooks/window.js
@@ -8,7 +8,9 @@ import { setUpKeyboardEvents, setupMouseEvents, setUpTouchEvents, setUpWindowEve
  * @type {ComponentHook}
  */
 export function openWindow(entity, world) {
-  const window = /** @type {Window}*/(world.get(entity, 'window'))
+
+  // SAFETY: Component is guaranteed as this is its component hook
+  const window = /** @type {Window}*/(world.get(entity, Window))
   const windows = world.getResource(Windows)
   let element
 


### PR DESCRIPTION
## Objective
 - Change `World.get` to use component type instead of component name.
 - Updates dependents

## Solution
If applicable,explain the solution taken and why it was taken.

## Showcase
If applicable,show how to use the feature being added.Recordings and screenshots can be added.

## Migration guide
Incase of breaking changes,what do users need to do to migrate to next version?

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.