### PR TITLE
Change `Rotation` and `Torque` type to `Vector3`

### DIFF
--- a/src/damping/systems/index.js
+++ b/src/damping/systems/index.js
@@ -50,7 +50,6 @@ export function dampenRotation3D(world) {
   const angular = 1 - world.getResource(Angular3DDamping).value
   
   query.each(([rotation]) => {
-    rotation.w *= angular
     rotation.x *= angular
     rotation.y *= angular
     rotation.z *= angular

--- a/src/integrator/systems/euler.js
+++ b/src/integrator/systems/euler.js
@@ -1,5 +1,5 @@
 import { Query, World } from '../../ecs/index.js'
-import { Vector2, Vector3 } from '../../math/index.js'
+import { Quaternion, Vector2, Vector3 } from '../../math/index.js'
 import { Acceleration2D, Acceleration3D, Rotation2D, Rotation3D, Torque2D, Torque3D, Velocity2D, Velocity3D } from '../../movable/index.js'
 import { Orientation2D, Orientation3D, Position2D, Position3D } from '../../transform/index.js'
 
@@ -85,12 +85,14 @@ export function updateVelocityEuler3D(world) {
  */
 export function updateAngularEuler3D(world) {
   const query = new Query(world, [Rotation3D, Torque3D])
+  const dt = 1 / 60
 
   query.each(([rotation, torque]) => {
+    const temp = Vector3.multiplyScalar(torque, dt)
 
-    // doesnt integrate dt,find a way to do that.
-    rotation.multiply(torque)
-    torque.set(0, 0, 0, 0)
+
+    rotation.multiply(temp)
+    torque.set(0, 0, 0)
   })
 }
 
@@ -116,10 +118,14 @@ export function updatePositionEuler3D(world) {
  */
 export function updateOrientationEuler3D(world) {
   const query = new Query(world, [Orientation3D, Rotation3D])
+  const dt = 1 / 60 
 
   query.each(([orientation, rotation]) => {
+    const temp1 = Vector3.multiplyScalar(rotation, dt)
+    const temp = Quaternion.fromEuler(temp1.x, temp1.y, temp1.z)
 
-    // doesnt integrate dt,find a way to do that.
-    orientation.multiply(rotation)
+    orientation.multiply(temp)
+    orientation.normalize()
+    
   })
 }

--- a/src/movable/components/3d/rotation.js
+++ b/src/movable/components/3d/rotation.js
@@ -1,3 +1,3 @@
-import { Quaternion } from '../../../math/index.js'
+import { Vector3 } from '../../../math/index.js'
 
-export class Rotation3D extends Quaternion {}
+export class Rotation3D extends Vector3 {}

--- a/src/movable/components/3d/torque.js
+++ b/src/movable/components/3d/torque.js
@@ -1,3 +1,3 @@
-import { Quaternion } from '../../../math/index.js'
+import { Vector3 } from '../../../math/index.js'
 
-export class Torque3D extends Quaternion {}
+export class Torque3D extends Vector3 {}


### PR DESCRIPTION
## Objective
These components were previously `Quaternion`s but that proved to be bad as i found no direct method of integrating quaternions to allow 3D rotation.
They are now euler angles represented as `Vector3`s in XYZ order.

## Solution
N/A

## Showcase
N/A

## Migration guide
Update functionality which required the components to be `Quaternion`s with one which works with `Vector3`

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.