### PR TITLE
Rename `EventDispatch` to `Events`

### DIFF
--- a/src/asset/systems/loader.js
+++ b/src/asset/systems/loader.js
@@ -1,6 +1,6 @@
 import { Device } from '../../device/index.js'
 import { World } from '../../ecs/index.js'
-import { EventDispatch } from '../../event/index.js'
+import { Events } from '../../event/index.js'
 import { getFileExtension } from '../../utils/index.js'
 import { Assets, Parser } from '../core/index.js'
 import { AssetLoadFail, AssetLoadSuccess } from '../events/index.js'
@@ -24,10 +24,10 @@ export function generateParserSystem(name) {
     /** @type {Parser<T>} */
     const parser = world.getResourceByName(`parser<${name}>`)
 
-    /** @type {EventDispatch<AssetLoadSuccess>} */
+    /** @type {Events<AssetLoadSuccess>} */
     const success = world.getResourceByName('events<assetloadsuccess>')
 
-    /** @type {EventDispatch<AssetLoadFail>} */
+    /** @type {Events<AssetLoadFail>} */
     const fail = world.getResourceByName('events<assetloadfail>')
 
     /** @type {AssetBasePath<T>} */

--- a/src/event/core/events.js
+++ b/src/event/core/events.js
@@ -9,7 +9,7 @@ import { CEvent } from './event.js'
  * @example
  * ```typescript
  * //Creates a new event dispatcher with string as its event payload.
- * const dispatch = new EventDispatch<string>()
+ * const dispatch = new Events<string>()
  * 
  * //adds an event to dispatcher
  * dispatch.write("hello there")
@@ -23,7 +23,7 @@ import { CEvent } from './event.js'
  * dispatch.clear()
  * ```
  */
-export class EventDispatch {
+export class Events {
 
   /**
    * @private

--- a/src/event/core/index.js
+++ b/src/event/core/index.js
@@ -1,3 +1,3 @@
-export * from './dispatch.js'
+export * from './events.js'
 export * from './event.js'
 export * from './signal.js'

--- a/src/event/plugin.js
+++ b/src/event/plugin.js
@@ -1,6 +1,6 @@
 import { App, AppSchedule, SystemConfig } from '../app/index.js'
 import { makeEventClear } from './systems/index.js'
-import { EventDispatch } from './core/index.js'
+import { Events } from './core/index.js'
 
 export class EventPlugin {
 
@@ -29,7 +29,7 @@ export class EventPlugin {
     app
       .registerType(event)
       .getWorld()
-      .setResourceByName(name, new EventDispatch())
+      .setResourceByName(name, new Events())
     
     // TODO - Once system ordering is implemented,remove this
     // and `App.systemsevents`.

--- a/src/keyboard/plugin.js
+++ b/src/keyboard/plugin.js
@@ -1,7 +1,7 @@
 import { App, AppSchedule } from '../app/index.js'
 import { Keyboard } from './resources/index.js'
 import { KeyUp, KeyDown } from '../window/index.js'
-import { EventDispatch } from '../event/index.js'
+import { Events } from '../event/index.js'
 import { World } from '../ecs/index.js'
 import { KeyCode } from './core/key.js'
 
@@ -23,10 +23,10 @@ export class KeyboardPlugin {
 function updateKeyBoard(world) {
   const keyboard = world.getResource(Keyboard)
 
-  /** @type {EventDispatch<KeyDown>}*/
+  /** @type {Events<KeyDown>}*/
   const down = world.getResourceByName('events<keydown>')
 
-  /** @type {EventDispatch<KeyUp>}*/
+  /** @type {Events<KeyUp>}*/
   const up = world.getResourceByName('events<keyup>')
 
   keyboard.clearJustPressed()

--- a/src/mouse/plugin.js
+++ b/src/mouse/plugin.js
@@ -39,10 +39,10 @@ function updateMouse(world) {
 function updateMouseButtons(world) {
   const buttons = world.getResource(MouseButtons)
 
-  /** @type {EventDispatch<MouseDown>} */
+  /** @type {Events<MouseDown>} */
   const down = world.getResourceByName('events<mousedown>')
 
-  /** @type {EventDispatch<MouseUp>} */
+  /** @type {Events<MouseUp>} */
   const up = world.getResourceByName('events<mouseup>')
 
   buttons.clearJustPressed()

--- a/src/mouse/plugin.js
+++ b/src/mouse/plugin.js
@@ -2,7 +2,7 @@ import { App, AppSchedule } from '../app/index.js'
 import { Mouse, MouseButtons } from './resources/index.js'
 import { MouseButton } from './core/index.js'
 import { World } from '../ecs/index.js'
-import { EventDispatch } from '../event/index.js'
+import { Events } from '../event/index.js'
 import { MouseDown, MouseMove, MouseUp } from '../window/index.js'
 
 export class MousePlugin {
@@ -26,7 +26,7 @@ export class MousePlugin {
 function updateMouse(world) {
   const mouse = world.getResource(Mouse)
 
-  const move = /** @type {EventDispatch<MouseMove>} */(world.getResourceByName('events<mousemove>')).readLast()
+  const move = /** @type {Events<MouseMove>} */(world.getResourceByName('events<mousemove>')).readLast()
 
   if (!move) return
 

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -1,7 +1,7 @@
 import { App, AppSchedule } from '../app/index.js'
 import { Assets } from '../asset/index.js'
 import { ComponentHooks, Entity, Query, World } from '../ecs/index.js'
-import { EventDispatch } from '../event/index.js'
+import { Events } from '../event/index.js'
 import { assert, warn } from '../logger/index.js'
 import { MeshAttribute, Camera, Material, MaterialHandle, Mesh, MeshHandle, ProgramCache } from '../render-core/index.js'
 import { GlobalTransform3D } from '../transform/index.js'
@@ -141,7 +141,7 @@ function resizegl(world) {
   /** @type {Windows} */
   const canvases = world.getResource(Windows)
 
-  /** @type {EventDispatch<WindowResize>} */
+  /** @type {Events<WindowResize>} */
   const resizeEvents = world.getResourceByName('events<windowresize>')
 
   const window = windows.single()

--- a/src/touch/plugin.js
+++ b/src/touch/plugin.js
@@ -1,6 +1,6 @@
 import { App, AppSchedule } from '../app/index.js'
 import { World } from '../ecs/index.js'
-import { EventDispatch } from '../event/index.js'
+import { Events } from '../event/index.js'
 import { TouchCancel, TouchEnd, TouchMove, TouchStart } from '../window/index.js'
 import { TouchPointer } from './core/index.js'
 import { Touches } from './resources/touches.js'
@@ -24,16 +24,16 @@ export class TouchPlugin {
 function updateTouch(world) {
   const touch = world.getResource(Touches)
 
-  /** @type {EventDispatch<TouchStart>} */
+  /** @type {Events<TouchStart>} */
   const start = world.getResourceByName('events<touchstart>')
 
-  /** @type {EventDispatch<TouchMove>} */
+  /** @type {Events<TouchMove>} */
   const move = world.getResourceByName('events<touchmove>')
 
-  /** @type {EventDispatch<TouchEnd>} */
+  /** @type {Events<TouchEnd>} */
   const end = world.getResourceByName('events<touchend>')
 
-  /** @type {EventDispatch<TouchCancel>} */
+  /** @type {Events<TouchCancel>} */
   const cancel = world.getResourceByName('events<touchcancel>')  
 
   start.each((event) => {


### PR DESCRIPTION
## Objective
Rename `EventDispatch` to `Events`

## Solution
N/A

## Showcase
N/A

## Migration guide
Before:
```typescript
class MyEvent {}

const events = new EventDispatch<MyEvent>()
```
After:
```typescript
class MyEvent {}

const events = new Events<MyEvent>()
```
## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.