### PR TITLE
Add `Events.count`

### DIFF
--- a/src/event/core/events.js
+++ b/src/event/core/events.js
@@ -69,4 +69,8 @@ export class Events {
   write(data) {
     this.buffer.push(new CEvent(data))
   }
+
+  count(){
+    return this.buffer.length
+  }
 }


### PR DESCRIPTION
## Objective
Count the number of events in an `Events`.

## Solution
N/A

## Showcase
```typescript
class MyEvent {}
const events = new Events<MyEvent>()

events.add(new MyEvent())
events.add(new MyEvent())

events.count() // returns 2
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.