### PR TITLE
Fix frame updates of `Mouse.lastPosition`

### DIFF
--- a/src/mouse/plugin.js
+++ b/src/mouse/plugin.js
@@ -30,6 +30,7 @@ function updateMouse(world) {
   const move = /** @type {Events<MouseMove>} */(world.getResourceByName('events<mousemove>')).readLast()
 
   mouse.delta.copy(Vector2.ZERO)
+  mouse.lastPosition.copy(mouse.position)
 
   if (!move) return
 


### PR DESCRIPTION
## Objective
Ensures that mouse last position is updated.

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.