### PR TITLE
Add component hooks for `Parent` and `Children`

### DIFF
--- a/src/hierarchy/components/children.js
+++ b/src/hierarchy/components/children.js
@@ -3,7 +3,7 @@
 export class Children {
 
   /**
-   * @private
+   * @public
    * @type {Entity[]}
    */
   list = []

--- a/src/hierarchy/components/children.js
+++ b/src/hierarchy/components/children.js
@@ -8,6 +8,14 @@ export class Children {
    */
   list = []
 
+   
+  /**
+   * @param {Entity[]} children
+   */
+  constructor(children = []){
+    this.list = children
+  }
+
   /**
    * @param {Entity} entity
    */

--- a/src/hierarchy/components/parent.js
+++ b/src/hierarchy/components/parent.js
@@ -3,7 +3,7 @@
 export class Parent {
 
   /**
-   * @private
+   * @public
    * @type {Entity}
    */
   entity

--- a/src/hierarchy/hooks/index.js
+++ b/src/hierarchy/hooks/index.js
@@ -43,3 +43,29 @@ export function removeSelfFromParent(entity, world) {
 
   children?.remove(entity)
 }
+
+/**
+ * Component hook that ensures the children of
+ * an entity have the parent component referencing
+ * the entity.
+ * 
+ * @type {ComponentHook}
+ */
+export function addSelfToChildren(entity, world) {
+  const children = world.get(entity, Children)
+
+  if (!children) {
+    return
+  }
+
+  for (let i = 0; i < children.list.length; i++) {
+    const child = children.list[i]
+    const parent = world.get(child, Parent)
+
+    if (!parent) {
+      world.insert(child, [new Parent(entity)])
+    } else {
+      parent.entity = entity
+    }
+  }
+}

--- a/src/hierarchy/hooks/index.js
+++ b/src/hierarchy/hooks/index.js
@@ -1,0 +1,28 @@
+/** @import {ComponentHook} from '../../ecs/index.js' */
+
+import { Children, Parent } from '../components/index.js'
+
+
+/**
+ * Component hook that ensures when a child 
+ * entity is spawned, the parent list is 
+ * updated.
+ * 
+ * @type {ComponentHook}
+ */
+export function addSelfToParent(entity, world) {
+  const parent = world.get(entity, Parent)
+
+  if (!parent) return
+
+  const children = world.get(parent.entity, Children)
+
+  if (children) {
+    children?.add(entity)
+  } else {
+
+    // Immediate insertion as insert commands on 
+    // `EntityCommands` will override each other.
+    world.insert(parent.entity, [new Children([entity])])
+  }
+}

--- a/src/hierarchy/hooks/index.js
+++ b/src/hierarchy/hooks/index.js
@@ -69,3 +69,24 @@ export function addSelfToChildren(entity, world) {
     }
   }
 }
+
+/**
+ * Component hook that ensures when the parent
+ * is despawned, the children entities are also
+ * despawned 'recursively'.
+ * 
+ * @type {ComponentHook}
+ */
+export function despawnChildren(entity, world) {
+  const children = world.get(entity, Children)
+
+  if (!children) {
+    return
+  }
+
+  for (let i = 0; i < children.list.length; i++) {
+    const child = children.list[i]
+
+    world.remove(child)
+  }
+}

--- a/src/hierarchy/hooks/index.js
+++ b/src/hierarchy/hooks/index.js
@@ -26,3 +26,20 @@ export function addSelfToParent(entity, world) {
     world.insert(parent.entity, [new Children([entity])])
   }
 }
+
+/**
+ * Component hook that ensures when a child 
+ * entity is despawned, the parent list is 
+ * updated.
+ * 
+ * @type {ComponentHook}
+ */
+export function removeSelfFromParent(entity, world) {
+  const parent = world.get(entity, Parent)
+
+  if (!parent) return
+
+  const children = world.get(parent.entity, Children)
+
+  children?.remove(entity)
+}

--- a/src/hierarchy/plugin.js
+++ b/src/hierarchy/plugin.js
@@ -1,5 +1,7 @@
 import { App } from '../app/index.js'
+import { ComponentHooks } from '../ecs/index.js'
 import { Children, Parent } from './components/index.js'
+import { addSelfToChildren, despawnChildren, addSelfToParent, removeSelfFromParent } from './hooks/index.js'
 
 export class HierarchyPlugin {
 
@@ -9,6 +11,16 @@ export class HierarchyPlugin {
   register(app) {
     app
       .registerType(Children)
+      .setComponentHooks(Children, new ComponentHooks(
+        addSelfToChildren,
+        despawnChildren,
+        null
+      ))
       .registerType(Parent)
+      .setComponentHooks(Parent, new ComponentHooks(
+        addSelfToParent,
+        removeSelfFromParent,
+        null
+      ))
   }
 }


### PR DESCRIPTION
## Objective
Makes the fields holding the entity references in the components public to enable use of the component hooks.

Adds component hooks which does the following:
 - Updates the parent's children list when a child is spawned or despawned.
 - Updates the children's reference to the parent when the parent is spawned in.
 - Despawns the children of an entity when it is despawned.

> [!Important] 
> These rules do not apply when the components are updated when already inserted.

## Solution
N/A

## Showcase
```typescript
const world = new World()

// In this case, a children component referencing e2 and e3 will
// be inserted.
const e1 = world.create()
const e2 = world.create([new Parent(e1)])
const e2 = world.create([new Parent(e1)])

// In this case, a parent componenent referencing e3 will be 
// inserted in both e1 and e2
const e1 = world.create()
const e2 = world.create()
const e2 = world.create([new Children([e1, e2])])

// if the other component already inserted, it will be updated accordingly.
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.