### PR TITLE
Remove resource type registering in `App.setResource`

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -203,7 +203,6 @@ export class App {
   setResource(resource) {
     assert(!this.initialized, registererror)
     this
-      .registerType(resource.constructor)
       .world.setResource(resource)
 
     return this


### PR DESCRIPTION
## Objective
Resource types are no longer automatically registered by the app when setting the resource.
Resource types must now be registered explicitly in an app.

## Solution
N/A

## Showcase
N/A

## Migration guide
```typescript
class MyResource {}
const app = new App()

// before
app.setResource(new MyResource())

// after
app
  .setResource(new MyResource())
  .registerType(MyResource)
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.