### PR TITLE
Use types in `TypeStore`

### DIFF
--- a/src/ecs/query.js
+++ b/src/ecs/query.js
@@ -62,13 +62,12 @@ export class Query {
    */
   constructor(registry, componentTypes) {
     this.registry = registry
-    const descriptors = componentTypes.map((type) => type.name.toLowerCase())
 
-    for (let i = 0; i < descriptors.length; i++) {
+    for (let i = 0; i < componentTypes.length; i++) {
       this.components[i] = []
     }
 
-    this.descriptors = registry.getComponentIdsByName(descriptors)
+    this.descriptors = registry.getComponentIds(componentTypes)
     this.update(registry.getTable())
   }
 

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -118,21 +118,20 @@ export class World {
 
     // SAFETY: the entity was reserved in this function so we know its there.
     const location = /** @type {EntityLocation}*/(this.entities.get(entityIndex))
-    const ids = this.getComponentIds(components)
+
+    // SAFETY:Object constructors can be casted from `Function` to `Constructor`
+    const types = /** @type {Constructor[]} */(components.map((c) => c.constructor))
+    const ids = this.getComponentIds(types)
     const entity = new Entity(entityIndex)
-    
-    assert(ids, `Cannot insert "${components.map((e) => `\`${e.constructor.name}\``).join(', ')}" into \`ArchetypeTable\`.Ensure that all of them are registered properly using \`World.registerType()\``)
-    
+    const [id, tableIndex] = this.table.insert(components, ids)
+
     ids.push(0)
     components.push(entity)
-    
-    const [id, tableIndex] = this.table.insert(components, ids)
-    
 
     location.archid = id
     location.index = tableIndex
     this.callAddComponentHook(entity, ids)
-    
+
     return entity
   }
 

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -138,20 +138,19 @@ export class World {
   /**
    * Inserts components into an entity.
    *
-   * @template {{}[]} T
+   * @template {object[]} T
    * @param {Entity} entity
    * @param {[...T]} components - The entity to add.
    */
   insert(entity, components) {
     const location = this.entities.get(entity.index)
-    
+
     assert(location, 'Cannot insert to an entity not created on the world.Use `World.create()` then try to insert the given entity into the world.')
 
+    // SAFETY:Object constructors can be casted from `Function` to `Constructor`
+    const types = /** @type {Constructor[]} */(components.map((c) => c.constructor))
     const { archid, index } = location
-    const ids = this.getComponentIds(components)
-
-    assert(ids, `Cannot insert "${components.map((e) => `\`${e.constructor.name}\``).join(', ')}" into \`World\`.Ensure that all of them are registered properly using \`World.registerType()\``)
-
+    const ids = this.getComponentIds(types)
     const extracted = this.table.extract(archid, index)
 
     assert(extracted, 'Invalid extraction on insert')
@@ -169,7 +168,7 @@ export class World {
     location.archid = id
     location.index = newIndex
 
-    if (swapped){
+    if (swapped) {
       const swappedlocation = /** @type {EntityLocation} */(this.entities.get(swapped.index))
 
       swappedlocation.index = index

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -54,8 +54,7 @@ export class World {
     const ids = []
 
     for (let i = 0; i < components.length; i++) {
-      const name = components[i].constructor.name.toLowerCase()
-      const id = this.typestore.getId(name)
+      const id = this.typestore.getId(components[i])
 
       assert(id !== void 0, `The component "${name}" has not been registered into the \`World\`.Use \`World.registerType()\`to add it.`)
 

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -308,10 +308,9 @@ export class World {
    * @param {ComponentHooks} hooks
    */
   setComponentHooks(component, hooks) {
-    const componentname = component.name.toLowerCase()
-    const info = this.typestore.get(componentname)
+    const info = this.typestore.get(component)
 
-    assert(info, `The component "${componentname}" has not been registered.Use \`World.registerType()\` to add it.`)
+    assert(info, `The component "${component.name}" has not been registered.Use \`World.registerType()\` to add it.`)
     info.setHooks(hooks)
   }
 

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -235,14 +235,13 @@ export class World {
    */
   get(entity, type) {
     const location = this.entities.get(entity.index)
-    const compName = type.name.toLowerCase()
 
-    if(!location) return null
+    if (!location) return null
 
     const { archid, index } = location
-    const id = this.typestore.getId(compName)
+    const id = this.typestore.getId(type)
 
-    assert(id, `The component ${compName} is not registered into the \`World\`.Use \`World.registerType()\` to register it.`)
+    assert(id, `The component ${type.name} is not registered into the \`World\`.Use \`World.registerType()\` to register it.`)
 
     return this.table.get(archid, index, id)
   }

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -67,28 +67,6 @@ export class World {
   }
 
   /**
-   * @param {string[]} names
-   * @returns {ComponentId[]}
-   */
-  getComponentIdsByName(names) {
-
-    /** @type {ComponentId[]} */
-    const ids = []
-
-    for (let i = 0; i < names.length; i++) {
-      const name = names[i]
-      const id = this.typestore.getId(name)
-
-      assert(id !== void 0, `The component "${name}" has not been registered into the \`World\`.Use \`App.registerType()\` or \`World.registerType()\`to add it.`)
-
-      // @ts-ignore
-      ids.push(id)
-    }
-
-    return ids
-  }
-
-  /**
    * @private
    * @param {Entity} entity 
    * @param {ComponentId[]} ids

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -198,14 +198,14 @@ export class World {
   remove(entity) {
     const location = this.entities.get(entity.index)
 
-    if(!location) return
+    if (!location) return
 
     const { archid, index } = location
 
     // TODO - Use a method that iterates through componentlists to call remove hook.
     const extracted = this.table.extract(archid, index)
 
-    if(extracted){
+    if (extracted) {
       const [extractid] = extracted
 
       this.callRemoveComponentHook(entity, extractid)
@@ -220,7 +220,7 @@ export class World {
     location.index = -1
     this.entities.recycle(entity.index)
 
-    if (swapped){
+    if (swapped) {
       const swappedlocation = /** @type {EntityLocation} */(this.entities.get(swapped.index))
 
       swappedlocation.index = index

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -79,4 +79,12 @@ export class TypeStore {
   getId(type) {
     return this.map.get(typeid(type))
   }
+
+  /**
+   * 
+   * @returns {Iterable<ComponentInfo>}
+   */
+  getInfos(){
+    return this.list
+  }
 }

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -43,6 +43,14 @@ export class TypeStore {
   }
 
   /**
+   * @param {ComponentId} id
+   * @returns {boolean}
+   */
+  hasId(id) {
+    return id < this.list.length && id >= 0
+  }
+
+  /**
    * @template T
    * @param {Constructor<T>} type
    * @returns {ComponentInfo | undefined}

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -1,7 +1,8 @@
 /** @import { ComponentId } from './typedef/index.js'*/
-/** @import { TypeId } from '../reflect/index.js'*/
+/** @import { Constructor,TypeId } from '../reflect/index.js'*/
 
 import { ComponentInfo } from './component/index.js'
+import { typeid } from '../reflect/index.js'
 
 export class TypeStore {
 
@@ -18,15 +19,16 @@ export class TypeStore {
   list = []
 
   /**
-   * @param {Function} componentClass
+   * @template T
+   * @param {Constructor<T>} type
    * @returns {ComponentId}
    */
-  set(componentClass) {
+  set(type) {
     const id = this.list.length
-    const name = componentClass.name.toLowerCase()
+    const typeId = typeid(type)
 
-    this.map.set(name, id)
-    this.list.push(new ComponentInfo(id, name))
+    this.map.set(typeId, id)
+    this.list.push(new ComponentInfo(id, typeId))
 
     return id
   }

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -34,11 +34,12 @@ export class TypeStore {
   }
 
   /**
-   * @param {string} name
+   * @template T
+   * @param {Constructor<T>} type
    * @returns {boolean}
    */
-  has(name) {
-    return this.map.has(name)
+  has(type) {
+    return this.map.has(typeid(type))
   }
 
   /**

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -81,7 +81,6 @@ export class TypeStore {
   }
 
   /**
-   * 
    * @returns {Iterable<ComponentInfo>}
    */
   getInfos(){

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -12,6 +12,7 @@ export class TypeStore {
   map = new Map()
 
   /**
+   * @private
    * @type {Array<ComponentInfo>}
    */
   list = []

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -43,11 +43,12 @@ export class TypeStore {
   }
 
   /**
-   * @param {string} name
+   * @template T
+   * @param {Constructor<T>} type
    * @returns {ComponentInfo | undefined}
    */
-  get(name) {
-    const id = this.getId(name)
+  get(type) {
+    const id = this.getId(type)
 
     if (id === void 0) return undefined
 

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -1,10 +1,13 @@
 /** @import { ComponentId } from './typedef/index.js'*/
+/** @import { TypeId } from '../reflect/index.js'*/
+
 import { ComponentInfo } from './component/index.js'
 
 export class TypeStore {
 
   /**
-   * @type {Map<string,ComponentId>}
+   * @private
+   * @type {Map<TypeId,ComponentId>}
    */
   map = new Map()
 

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -64,10 +64,11 @@ export class TypeStore {
   }
 
   /**
-   * @param {string} name
+   * @template T
+   * @param {Constructor<T>} type
    * @returns {ComponentId | undefined}
    */
-  getId(name) {
-    return this.map.get(name)
+  getId(type) {
+    return this.map.get(typeid(type))
   }
 }


### PR DESCRIPTION
## Objective
This ensures that instead of just using the type name directly, the type is used instead to get component information.
This also makes the fields of the `TypeStore` private to avoid tampering with its internals.

## Solution
N/A

## Showcase
N/A

## Migration guide
Use the type instead of the type name in the methods of `TypeStore`.
E.g:
```typescript
class MyType {}
const typestore = new TypeStore()

// before
typestore.set(MyType.name)
const info = typestore.get(MyType.name)

// after
typestore.set(MyType)
const info = typestore.get(MyType)
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.