### PR TITLE
Add enabling/disabling events autoclearing in `EventPlugin`

### DIFF
--- a/src/event/plugin.js
+++ b/src/event/plugin.js
@@ -22,9 +22,10 @@ export class EventPlugin {
    * @param {{ event: Constructor; autoClearEvent?:boolean; }} options
    */
   constructor(options) {
-    const { event } = options
+    const { event, autoClearEvent = true } = options
 
     this.event = event
+    this.autoClearEvent = autoClearEvent
   }
 
   /**
@@ -41,6 +42,8 @@ export class EventPlugin {
     
     // TODO - Once system ordering is implemented,remove this
     // and `App.systemsevents`.
-    app.systemsevents.push(new SystemConfig(makeEventClear(name), AppSchedule.Update))
+    if (this.autoClearEvent) {
+      app.systemsevents.push(new SystemConfig(makeEventClear(name), AppSchedule.Update))
+    }
   }
 }

--- a/src/event/plugin.js
+++ b/src/event/plugin.js
@@ -13,7 +13,13 @@ export class EventPlugin {
   event
 
   /**
-   * @param {{ event: Constructor; }} options
+   * @readonly
+   * @type {boolean}
+   */
+  autoClearEvent
+
+  /**
+   * @param {{ event: Constructor; autoClearEvent?:boolean; }} options
    */
   constructor(options) {
     const { event } = options


### PR DESCRIPTION
## Objective
This gives the user the ability to turn off automatic clearing of events and manually do it themselves.
This option is added as sometimes events are missed inside systems as events do not live in the entire frame of a schedule when using the automatic clearing system.
The event clearing system is enabled by default.

## Solution
N/A

## Showcase
```typescript
class MyEvent {}

const event = new EventPlugin({
  event:MyEvent,
  // disables autoclear.
  autoClearEvent:false
})

```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.