### PR TITLE
Add methods which consume `TypeId` to `TypeStore`

### DIFF
--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -34,6 +34,19 @@ export class TypeStore {
   }
 
   /**
+   * @param {TypeId} id 
+   * @returns {ComponentId}
+   */
+  setByTypeId(id){
+    const compId = this.list.length
+
+    this.map.set(id, compId)
+    this.list.push(new ComponentInfo(compId, id))
+
+    return compId
+  }
+
+  /**
    * @template T
    * @param {Constructor<T>} type
    * @returns {boolean}

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -24,13 +24,9 @@ export class TypeStore {
    * @returns {ComponentId}
    */
   set(type) {
-    const id = this.list.length
     const typeId = typeid(type)
 
-    this.map.set(typeId, id)
-    this.list.push(new ComponentInfo(id, typeId))
-
-    return id
+    return this.setByTypeId(typeId)
   }
 
   /**

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -65,11 +65,7 @@ export class TypeStore {
    * @returns {ComponentInfo | undefined}
    */
   get(type) {
-    const id = this.getId(type)
-
-    if (id === void 0) return undefined
-
-    return this.getById(id)
+    return this.getByTypeId(typeid(type))
   }
 
   /**

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -85,6 +85,17 @@ export class TypeStore {
   }
 
   /**
+   * @param {TypeId} typeId
+   */
+  getByTypeId(typeId){
+    const id = this.getIdByTypeId(typeId)
+
+    if (id === void 0) return undefined
+
+    return this.getById(id)
+  }
+
+  /**
    * @template T
    * @param {Constructor<T>} type
    * @returns {ComponentId | undefined}

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -93,7 +93,7 @@ export class TypeStore {
    * @returns {ComponentId | undefined}
    */
   getId(type) {
-    return this.map.get(typeid(type))
+    return this.getIdByTypeId(typeid(type))
   }
 
   /**

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -105,6 +105,15 @@ export class TypeStore {
   }
 
   /**
+   * @template T
+   * @param {TypeId} id
+   * @returns {ComponentId | undefined}
+   */
+  getIdByTypeId(id) {
+    return this.map.get(id)
+  }
+
+  /**
    * @returns {Iterable<ComponentInfo>}
    */
   getInfos(){


### PR DESCRIPTION
## Objective
This enables use to use the type id to do operations on the typestore.This is useful when we have the type id but not the actual type.

## Solution
N/A

## Showcase
```typescript
class MyType {}

const store = new TypeStore()
const typeId = typeid(MyType)

typeid.setByTypeId(typeid)
typeid.getByTypeId(typeid)
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.