### PR TITLE
Add `typeidGeneric`

### DIFF
--- a/src/reflect/core/typeid.js
+++ b/src/reflect/core/typeid.js
@@ -7,3 +7,26 @@
 export function typeid(type) {
   return type.name
 }
+
+/**
+ * @template T
+ * @template {Constructor[]} U
+ * @param {Constructor<T>} type 
+ * @param {U} types
+ * @returns {TypeId}
+ */
+export function typeidGeneric(type, types) {
+  if(!types.length){
+    return typeid(type)
+  }
+
+  let name = `${type.name}<`
+  
+  for (let i = 0; i < types.length - 1; i++) {
+    name += `${types[i]},`
+  }
+
+  name += `${types[types.length - 1].name}>`
+ 
+  return name
+}


### PR DESCRIPTION
## Objective
The function can be used to get the typeid of a type with generics one level deep

## Solution
N/A

## Showcase
```typescript
class MyType<T> {}
class SubType {}

// The typeid of `MyType<SubType>`
const typeid = typeidGeneric(MyType,[SubType])
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.