### PR TITLE
Fix world panicking when invalid entity is removed

### DIFF
--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -179,6 +179,8 @@ export class World {
 
     const { archid, index } = location
 
+    if (archid === -1 || index === -1) return
+
     // TODO - Use a method that iterates through componentlists to call remove hook.
     const extracted = this.table.extract(archid, index)
 


### PR DESCRIPTION
## Objective
 - Fixes #4 
 - Fixes #2

## Solution
Invalid enrities are ignored when trying to remove them from the world.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.