### PR TITLE
Fix multi creation of same archetype in a `World`

### DIFF
--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -156,6 +156,41 @@ export class World {
   }
 
   /**
+ * @private
+ * @param {TypeId[]} ids 
+ * @param {unknown[]} components
+ * @param {TypeId[]} ids2 
+ * @param {unknown[]} components2
+ * @returns {[TypeId[],unknown[]]}
+ */
+  resolveCombine(ids, components, ids2, components2) {
+    const combineids = /**@type {TypeId[]}*/([])
+    const combinecomponents = /**@type {unknown[]}*/([])
+
+    for (let i = 0; i < ids.length; i++) {
+      const id = ids[i];
+      const component = components[i];
+
+      if (ids2.includes(id)) {
+        continue
+      }
+
+      combineids.push(id)
+      combinecomponents.push(component)
+    }
+
+    for (let i = 0; i < ids2.length; i++) {
+      const id = ids2[i];
+      const component = components2[i];
+
+      combineids.push(id)
+      combinecomponents.push(component)
+    }
+
+    return [combineids, combinecomponents]
+  }
+
+  /**
    * @template {{}[]} T
    * @param {[...T][]} entities
    */

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -137,8 +137,10 @@ export class World {
     this.table.remove(archid, index)
 
     const [combinedid, combined] = this.resolveCombine(
-      idextract, extract,
-      ids, components
+      idextract, 
+      extract,
+      ids, 
+      components
     )
 
     const [id, newIndex] = this.table.insert(combined, combinedid)
@@ -158,20 +160,20 @@ export class World {
   }
 
   /**
- * @private
- * @param {TypeId[]} ids 
- * @param {unknown[]} components
- * @param {TypeId[]} ids2 
- * @param {unknown[]} components2
- * @returns {[TypeId[],unknown[]]}
- */
+   * @private
+   * @param {TypeId[]} ids 
+   * @param {unknown[]} components
+   * @param {TypeId[]} ids2 
+   * @param {unknown[]} components2
+   * @returns {[TypeId[],unknown[]]}
+   */
   resolveCombine(ids, components, ids2, components2) {
-    const combineids = /**@type {TypeId[]}*/([])
-    const combinecomponents = /**@type {unknown[]}*/([])
+    const combineids = /** @type {TypeId[]}*/([])
+    const combinecomponents = /** @type {unknown[]}*/([])
 
     for (let i = 0; i < ids.length; i++) {
-      const id = ids[i];
-      const component = components[i];
+      const id = ids[i]
+      const component = components[i]
 
       if (ids2.includes(id)) {
         continue
@@ -182,8 +184,8 @@ export class World {
     }
 
     for (let i = 0; i < ids2.length; i++) {
-      const id = ids2[i];
-      const component = components2[i];
+      const id = ids2[i]
+      const component = components2[i]
 
       combineids.push(id)
       combinecomponents.push(component)

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -136,8 +136,10 @@ export class World {
 
     this.table.remove(archid, index)
 
-    const combined = [...components, ...extract]
-    const combinedid = [...ids, ...idextract]
+    const [combinedid, combined] = this.resolveCombine(
+      idextract, extract,
+      ids, components
+    )
 
     const [id, newIndex] = this.table.insert(combined, combinedid)
     const swapped = /** @type {Entity | null}*/(this.table.get(archid, index, typeid(Entity)))


### PR DESCRIPTION
## Objective
Sometimes the world creates duplicate archetypes when inserting components to an entity.
This fix ensures that the world does not duplicate archetypes when inserting components.

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.