### PR TITLE
Make `Entity.index` readonly

### DIFF
--- a/src/ecs/entities/entity.js
+++ b/src/ecs/entities/entity.js
@@ -1,6 +1,7 @@
 export class Entity {
 
   /**
+   * @readonly
    * @type {number}
    */
   index


### PR DESCRIPTION
## Objective
This ensures that an `Entity` cannot be edited after it is allocated.
A user should not be able to edit an `Entity` as it could lead to creation of an invalid entity.
## Solution
N/A

## Showcase
N/A

## Migration guide
Do not edit an allocated `Entity`.

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.