### PR TITLE
Type world resource manipulation methods

### DIFF
--- a/src/asset/plugins/asset.js
+++ b/src/asset/plugins/asset.js
@@ -2,6 +2,7 @@
 /** @import { HandleProvider } from '../core/index.js' */
 
 import { App } from '../../app/index.js'
+import { typeidGeneric } from '../../reflect/index.js'
 import { Assets } from '../core/index.js'
 import { AssetLoadFail, AssetLoadSuccess } from '../events/index.js'
 import { AssetBasePath } from '../resources/index.js'
@@ -47,7 +48,6 @@ export class AssetPlugin {
    */
   register(app) {
     const { asset, handleprovider, path } = this
-    const name = this.asset.name.toLowerCase()
     const world = app.getWorld()
 
 
@@ -56,8 +56,14 @@ export class AssetPlugin {
     app
       .registerEvent(AssetLoadSuccess)
       .registerEvent(AssetLoadFail)
-    world.setResourceByName(`assetbasepath<${name}>`, new AssetBasePath(path))
-    world.setResourceByName(`assets<${name}>`, new Assets(asset.default, handleprovider))
+    world.setResourceByTypeId(
+      typeidGeneric(AssetBasePath, [this.asset]),
+      new AssetBasePath(path)
+    )
+    world.setResourceByTypeId(
+      typeidGeneric(Assets, [this.asset]),
+      new Assets(asset.default, handleprovider)
+    )
   }
 }
 

--- a/src/asset/plugins/parser.js
+++ b/src/asset/plugins/parser.js
@@ -1,4 +1,5 @@
 import { App, AppSchedule } from '../../app/index.js'
+import { typeidGeneric } from '../../reflect/index.js'
 import { Parser } from '../core/index.js'
 import { generateParserSystem } from '../systems/index.js'
 
@@ -36,12 +37,11 @@ export class AssetParserPlugin {
    */
   register(app) {
     const { asset, parser } = this
-    const name = asset.name.toLowerCase()
 
     app
-      .registerSystem(AppSchedule.Update, generateParserSystem(name))
+      .registerSystem(AppSchedule.Update, generateParserSystem(asset))
       .getWorld()
-      .setResourceByName(`parser<${name}>`, parser)
+      .setResourceByTypeId(typeidGeneric(Parser, [asset]), parser)
   }
 }
 

--- a/src/asset/systems/loader.js
+++ b/src/asset/systems/loader.js
@@ -1,3 +1,4 @@
+/** @import {Constructor} from '../../reflect/index.js' */
 import { Device } from '../../device/index.js'
 import { World } from '../../ecs/index.js'
 import { Events } from '../../event/index.js'
@@ -5,33 +6,34 @@ import { getFileExtension } from '../../utils/index.js'
 import { Assets, Parser } from '../core/index.js'
 import { AssetLoadFail, AssetLoadSuccess } from '../events/index.js'
 import { AssetBasePath } from '../resources/index.js'
+import { typeidGeneric } from '../../reflect/index.js'
 
 /**
  * @template T
- * @param {string} name
+ * @param {Constructor<T>} type
  */
-export function generateParserSystem(name) {
+export function generateParserSystem(type) {
 
   /**
    * @param {World} world
    */
   return async function loadToAssets(world) {
-
-    /** @type {Assets<T>} */
-    const assets = world.getResourceByName(`assets<${name}>`)
     const device = world.getResource(Device)
 
+    /** @type {Assets<T>} */
+    const assets = world.getResourceByTypeId(typeidGeneric(Assets, [type]))
+
     /** @type {Parser<T>} */
-    const parser = world.getResourceByName(`parser<${name}>`)
+    const parser = world.getResourceByTypeId(typeidGeneric(Parser, [type]))
 
     /** @type {Events<AssetLoadSuccess>} */
-    const success = world.getResourceByName('events<assetloadsuccess>')
+    const success = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadSuccess]))
 
     /** @type {Events<AssetLoadFail>} */
-    const fail = world.getResourceByName('events<assetloadfail>')
+    const fail = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadFail]))
 
     /** @type {AssetBasePath<T>} */
-    const baseUrl = world.getResourceByName(`assetbasepath<${name}>`)
+    const baseUrl = world.getResourceByTypeId(typeidGeneric(AssetBasePath, [type]))
 
     const paths = assets.flushToLoad()
 

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -263,7 +263,11 @@ export class World {
    * @param {T} resource
    */
   setResource(resource) {
-    this.resources[resource.constructor.name.toLowerCase()] = resource
+
+    // SAFETY: An object's costructor is constructible
+    const id = typeid(/** @type {Constructor<T>} */(resource.constructor))
+
+    this.setResourceByTypeId(id, resource)
   }
 
   /**

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -242,11 +242,15 @@ export class World {
 
   /**
    * @template T
-   * @param {string} name
+   * @param {TypeId} id
    * @returns {T}
    */
-  getResourceByName(name) {
-    return this.resources[name]
+  getResourceByTypeId(id) {
+    const resource = this.resources[id]
+
+    assert(resource, `The resource \`${id}\` does not exist in the world.`)
+
+    return this.resources[id]
   }
 
   /**

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -231,13 +231,8 @@ export class World {
    * @param {new (...args:any[])=>T} resourceType
    * @returns {T}
    */
-  getResource(resourceType) {
-    const { name } = resourceType
-    const resource = this.resources[name.toLowerCase()]
-
-    assert(resource, `The resource \`${name}\` does not exist in the world.`)
-
-    return resource
+  getResource(resourceType) {    
+    return this.getResourceByTypeId(typeid(resourceType))
   }
 
   /**

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -255,12 +255,12 @@ export class World {
 
   /**
    * @template T
-   * @param {string} name
+   * @param {TypeId} id
    * @param {T} resource
    * @returns {void}
    */
-  setResourceByName(name, resource) {
-    this.resources[name] = resource
+  setResourceByTypeId(id, resource) {
+    this.resources[id] = resource
   }
 
   /**

--- a/src/event/plugin.js
+++ b/src/event/plugin.js
@@ -3,6 +3,7 @@
 import { App, AppSchedule, SystemConfig } from '../app/index.js'
 import { makeEventClear } from './systems/index.js'
 import { Events } from './core/index.js'
+import { typeidGeneric } from '../reflect/index.js'
 
 export class EventPlugin {
 
@@ -33,12 +34,12 @@ export class EventPlugin {
    */
   register(app) {
     const { event } = this
-    const name = `events<${event.name.toLowerCase()}>`
+    const name = typeidGeneric(Events, [this.event])
     
     app
       .registerType(event)
       .getWorld()
-      .setResourceByName(name, new Events())
+      .setResourceByTypeId(name, new Events())
     
     // TODO - Once system ordering is implemented,remove this
     // and `App.systemsevents`.

--- a/src/event/systems/index.js
+++ b/src/event/systems/index.js
@@ -1,11 +1,12 @@
 /** @import {SystemFunc} from '../../ecs/index.js'*/
+/** @import {TypeId} from '../../reflect/index.js'*/
 /**
- * @param {string} name 
+ * @param {TypeId} id 
  * @returns {SystemFunc}
  */
-export function makeEventClear(name) {
+export function makeEventClear(id) {
   return function clearEvents(world) {
-    const dispatch = world.getResourceByName(name)
+    const dispatch = world.getResourceByTypeId(id)
 
     dispatch.clear()
   }

--- a/src/keyboard/plugin.js
+++ b/src/keyboard/plugin.js
@@ -4,6 +4,7 @@ import { KeyUp, KeyDown } from '../window/index.js'
 import { Events } from '../event/index.js'
 import { World } from '../ecs/index.js'
 import { KeyCode } from './core/key.js'
+import { typeidGeneric } from '../reflect/index.js'
 
 export class KeyboardPlugin {
 
@@ -24,10 +25,10 @@ function updateKeyBoard(world) {
   const keyboard = world.getResource(Keyboard)
 
   /** @type {Events<KeyDown>}*/
-  const down = world.getResourceByName('events<keydown>')
+  const down = world.getResourceByTypeId(typeidGeneric(Events, [KeyDown]))
 
   /** @type {Events<KeyUp>}*/
-  const up = world.getResourceByName('events<keyup>')
+  const up = world.getResourceByTypeId(typeidGeneric(Events, [KeyUp]))
 
   keyboard.clearJustPressed()
   keyboard.clearJustReleased()

--- a/src/mouse/plugin.js
+++ b/src/mouse/plugin.js
@@ -5,6 +5,7 @@ import { World } from '../ecs/index.js'
 import { Events } from '../event/index.js'
 import { MouseDown, MouseMove, MouseUp } from '../window/index.js'
 import { Vector2 } from '../math/index.js'
+import { typeidGeneric } from '../reflect/index.js'
 
 export class MousePlugin {
 
@@ -27,7 +28,7 @@ export class MousePlugin {
 function updateMouse(world) {
   const mouse = world.getResource(Mouse)
 
-  const move = /** @type {Events<MouseMove>} */(world.getResourceByName('events<mousemove>')).readLast()
+  const move = /** @type {Events<MouseMove>} */(world.getResourceByTypeId(typeidGeneric(Events, [MouseMove]))).readLast()
 
   mouse.delta.copy(Vector2.ZERO)
   mouse.lastPosition.copy(mouse.position)
@@ -45,10 +46,10 @@ function updateMouseButtons(world) {
   const buttons = world.getResource(MouseButtons)
 
   /** @type {Events<MouseDown>} */
-  const down = world.getResourceByName('events<mousedown>')
+  const down = world.getResourceByTypeId(typeidGeneric(Events, [MouseDown]))
 
   /** @type {Events<MouseUp>} */
-  const up = world.getResourceByName('events<mouseup>')
+  const up = world.getResourceByTypeId(typeidGeneric(Events, [MouseUp]))
 
   buttons.clearJustPressed()
   buttons.clearJustReleased()

--- a/src/render-canvas2d/plugin.js
+++ b/src/render-canvas2d/plugin.js
@@ -8,6 +8,7 @@ import { vertices } from './utils.js'
 import { GlobalTransform2D } from '../transform/index.js'
 import { MaterialType } from './core/index.js'
 import { CanvasImageMaterial, CanvasMeshedMaterial, CanvasTextMaterial } from './assets/materials/index.js'
+import { typeid, typeidGeneric } from '../reflect/index.js'
 
 export class Canvas2DRendererPlugin {
 
@@ -27,16 +28,16 @@ export class Canvas2DRendererPlugin {
 function renderToCanvas(world) {
 
   /** @type {Assets<Mesh>} */
-  const meshes = world.getResourceByName('assets<mesh>')
+  const meshes = world.getResourceByTypeId(typeidGeneric(Assets, [Mesh]))
 
   /** @type {Assets<Material>} */
-  const materials = world.getResourceByName('assets<material>')
+  const materials = world.getResourceByTypeId(typeidGeneric(Assets, [Material]))
 
   /** @type {Assets<Image>} */
-  const images = world.getResourceByName('assets<image>')
+  const images = world.getResourceByTypeId(typeidGeneric(Assets, [Image]))
 
   /** @type {TextureCache<HTMLImageElement>} */
-  const textures = world.getResourceByName('texturecache')
+  const textures = world.getResourceByTypeId(typeid(TextureCache))
   const query = new Query(world, [GlobalTransform2D, MeshHandle, MaterialHandle])
   const camQuery = new Query(world, [GlobalTransform2D, Camera])
   const windows = new Query(world, [Entity, Window, MainWindow])

--- a/src/render-webgl/hooks/material.js
+++ b/src/render-webgl/hooks/material.js
@@ -6,6 +6,7 @@ import { createShader, createProgram, validateProgram, validateShader, WebglRend
 import { MainWindow, Windows, Window } from '../../window/index.js'
 import { warn } from '../../logger/index.js'
 import { AttributeMap, UBOCache } from '../resources/index.js'
+import { typeid, typeidGeneric } from '../../reflect/index.js'
 
 
 // TODO - In the future,use the `AssetAdded` event to build gpu representation instead
@@ -21,10 +22,10 @@ export function materialAddHook(entity, world) {
   const ubos = world.getResource(UBOCache)
 
   /** @type {Assets<Material>} */
-  const materials = world.getResourceByName('assets<material>')
+  const materials = world.getResourceByTypeId(typeidGeneric(Assets, [Material]))
 
   /** @type {ProgramCache<WebGLProgram>} */
-  const renderpipelines = world.getResourceByName('programcache')
+  const renderpipelines = world.getResourceByTypeId(typeid(ProgramCache))
 
   const windows = new Query(world, [Entity, Window, MainWindow])
 

--- a/src/render-webgl/hooks/mesh.js
+++ b/src/render-webgl/hooks/mesh.js
@@ -19,10 +19,10 @@ export function meshAddHook(entity, world) {
   const attributeMap = world.getResource(AttributeMap)
 
   /** @type {Assets<Mesh>} */
-  const meshes = world.getResourceByName('assets<mesh>')
+  const meshes = world.getResourceByTypeId('assets<mesh>')
 
   /** @type {MeshCache<WebGLVertexArrayObject>} */
-  const meshcache = world.getResourceByName('meshcache')
+  const meshcache = world.getResourceByTypeId('meshcache')
   const windows = new Query(world, [Entity, Window, MainWindow])
   const canvases = world.getResource(Windows)
 

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -3,6 +3,7 @@ import { Assets } from '../asset/index.js'
 import { ComponentHooks, Entity, Query, World } from '../ecs/index.js'
 import { Events } from '../event/index.js'
 import { assert, warn } from '../logger/index.js'
+import { typeid, typeidGeneric } from '../reflect/index.js'
 import { MeshAttribute, Camera, Material, MaterialHandle, Mesh, MeshHandle, ProgramCache } from '../render-core/index.js'
 import { GlobalTransform3D } from '../transform/index.js'
 import { MainWindow, Window, WindowResize, Windows } from '../window/index.js'
@@ -54,16 +55,16 @@ function registerDefaultAttributeLocs(attributeMap) {
 function render(world) {
 
   /** @type {Assets<Mesh>} */
-  const meshes = world.getResourceByName('assets<mesh>')
+  const meshes = world.getResourceByTypeId(typeidGeneric(Assets, [Mesh]))
 
   /** @type {Assets<Material>} */
-  const materials = world.getResourceByName('assets<material>')
+  const materials = world.getResourceByTypeId(typeidGeneric(Assets, [Material]))
 
   /** @type {ProgramCache<WebGLProgram>} */
-  const programs = world.getResourceByName('programcache')
+  const programs = world.getResourceByTypeId(typeid(ProgramCache))
 
   /** @type {MeshCache<WebGLVertexArrayObject>} */
-  const gpumeshes = world.getResourceByName('meshcache')
+  const gpumeshes = world.getResourceByTypeId(typeid(MeshCache))
   const ubos = world.getResource(UBOCache)
   const canvases = world.getResource(Windows)
   const clearColor = world.getResource(ClearColor)
@@ -142,7 +143,7 @@ function resizegl(world) {
   const canvases = world.getResource(Windows)
 
   /** @type {Events<WindowResize>} */
-  const resizeEvents = world.getResourceByName('events<windowresize>')
+  const resizeEvents = world.getResourceByTypeId(typeidGeneric(Events, [WindowResize]))
 
   const window = windows.single()
 

--- a/src/touch/plugin.js
+++ b/src/touch/plugin.js
@@ -1,6 +1,7 @@
 import { App, AppSchedule } from '../app/index.js'
 import { World } from '../ecs/index.js'
 import { Events } from '../event/index.js'
+import { typeidGeneric } from '../reflect/index.js'
 import { TouchCancel, TouchEnd, TouchMove, TouchStart } from '../window/index.js'
 import { TouchPointer } from './core/index.js'
 import { Touches } from './resources/touches.js'
@@ -25,16 +26,16 @@ function updateTouch(world) {
   const touch = world.getResource(Touches)
 
   /** @type {Events<TouchStart>} */
-  const start = world.getResourceByName('events<touchstart>')
+  const start = world.getResourceByTypeId(typeidGeneric(Events, [TouchStart]))
 
   /** @type {Events<TouchMove>} */
-  const move = world.getResourceByName('events<touchmove>')
+  const move = world.getResourceByTypeId(typeidGeneric(Events, [TouchMove]))
 
   /** @type {Events<TouchEnd>} */
-  const end = world.getResourceByName('events<touchend>')
+  const end = world.getResourceByTypeId(typeidGeneric(Events, [TouchEnd]))
 
   /** @type {Events<TouchCancel>} */
-  const cancel = world.getResourceByName('events<touchcancel>')  
+  const cancel = world.getResourceByTypeId(typeidGeneric(Events, [TouchCancel]))  
 
   start.each((event) => {
     const { data } = event

--- a/src/window-dom/core/file.js
+++ b/src/window-dom/core/file.js
@@ -1,4 +1,6 @@
 import { World } from '../../ecs/index.js'
+import { Events } from '../../event/index.js'
+import { typeidGeneric } from '../../reflect/index.js'
 import { FileDrop, FileDrag } from '../../window/index.js'
 
 /**
@@ -7,13 +9,17 @@ import { FileDrop, FileDrag } from '../../window/index.js'
  */
 export function setUpFileEvents(world, target) {
   target.addEventListener('dragover', (event) => {
-    const dispatch = world.getResourceByName('events<filedrag>')
+
+    /** @type {Events<FileDrag>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [FileDrag]))
 
     dispatch.write(new FileDrag(event))
     event.preventDefault()
   })
   target.addEventListener('drop', (event) => {
-    const dispatch = world.getResourceByName('events<filedrop>')
+
+    /** @type {Events<FileDrop>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [FileDrop]))
 
     dispatch.write(new FileDrop(event))
     event.preventDefault()

--- a/src/window-dom/core/keyboard.js
+++ b/src/window-dom/core/keyboard.js
@@ -1,4 +1,6 @@
 import { World } from '../../ecs/index.js'
+import { Events } from '../../event/index.js'
+import { typeidGeneric } from '../../reflect/index.js'
 import { KeyDown, KeyUp } from '../../window/index.js'
 
 /**
@@ -7,12 +9,16 @@ import { KeyDown, KeyUp } from '../../window/index.js'
  */
 export function setUpKeyboardEvents(world, target) {
   target.addEventListener('keyup', (event) => {
-    const dispatch = world.getResourceByName('events<keyup>')
+
+    /** @type {Events<KeyUp>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [KeyUp]))
 
     dispatch.write(new KeyUp(event))
   })
   target.addEventListener('keydown', (event) => {
-    const dispatch = world.getResourceByName('events<keydown>')
+
+    /** @type {Events<KeyDown>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [KeyDown]))
 
     dispatch.write(new KeyDown(event))
   })

--- a/src/window-dom/core/mouse.js
+++ b/src/window-dom/core/mouse.js
@@ -1,4 +1,6 @@
 import { World } from '../../ecs/index.js'
+import { Events } from '../../event/index.js'
+import { typeidGeneric } from '../../reflect/index.js'
 import { MouseDown, MouseUp, MouseMove, MouseWheel, MouseEnter, MouseLeave } from '../../window/index.js'
 
 /**
@@ -7,32 +9,44 @@ import { MouseDown, MouseUp, MouseMove, MouseWheel, MouseEnter, MouseLeave } fro
  */
 export function setupMouseEvents(world, target) {
   target.addEventListener('mousedown', (e) => {
-    const dispatch = world.getResourceByName('events<mousedown>')
+
+    /** @type {Events<MouseDown>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [MouseDown]))
 
     dispatch.write(new MouseDown(e))
   })
   target.addEventListener('mouseup', (e) => {
-    const dispatch = world.getResourceByName('events<mouseup>')
+
+    /** @type {Events<MouseUp>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [MouseUp]))
 
     dispatch.write(new MouseUp(e))
   })
   target.addEventListener('mousemove', (e) => {
-    const dispatch = world.getResourceByName('events<mousemove>')
+
+    /** @type {Events<MouseMove>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [MouseMove]))
 
     dispatch.write(new MouseMove(e))
   })
   target.addEventListener('wheel', (e) => {
-    const dispatch = world.getResourceByName('events<mousewheel>')
+
+    /** @type {Events<MouseWheel>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [MouseWheel]))
 
     dispatch.write(new MouseWheel(e))
   })
   target.addEventListener('mouseenter', (e) => {
-    const dispatch = world.getResourceByName('events<mouseenter>')
+
+    /** @type {Events<MouseEnter>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [MouseEnter]))
 
     dispatch.write(new MouseEnter(e))
   })
   target.addEventListener('mouseleave', (e) => {
-    const dispatch = world.getResourceByName('events<mouseleave>')
+
+    /** @type {Events<MouseLeave>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [MouseLeave]))
 
     dispatch.write(new MouseLeave(e))
   })

--- a/src/window-dom/core/touch.js
+++ b/src/window-dom/core/touch.js
@@ -1,4 +1,6 @@
 import { World } from '../../ecs/index.js'
+import { Events } from '../../event/index.js'
+import { typeidGeneric } from '../../reflect/index.js'
 import { TouchCancel, TouchEnd, TouchMove, TouchStart } from '../../window/index.js'
 
 /**
@@ -7,28 +9,36 @@ import { TouchCancel, TouchEnd, TouchMove, TouchStart } from '../../window/index
  */
 export function setUpTouchEvents(world, target) {
   target.addEventListener('touchstart', (e) => {
-    const dispatch = world.getResourceByName('events<touchstart>')
+
+    /** @type {Events<TouchStart>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [TouchStart]))
 
     for (let i = 0; i < e.changedTouches.length; i++) {
       dispatch.write(new TouchStart(e.changedTouches[i]))
     }
   })
   target.addEventListener('touchmove', (e) => {
-    const dispatch = world.getResourceByName('events<touchmove>')
+
+    /** @type {Events<TouchMove>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [TouchMove]))
     
     for (let i = 0; i < e.changedTouches.length; i++) {
       dispatch.write(new TouchMove(e.changedTouches[i]))
     }
   })
   target.addEventListener('touchcancel', (e) => {
-    const dispatch = world.getResourceByName('events<touchcancel>')
+
+    /** @type {Events<TouchCancel>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [TouchCancel]))
 
     for (let i = 0; i < e.changedTouches.length; i++) {
       dispatch.write(new TouchCancel(e.changedTouches[i]))
     }
   })
   target.addEventListener('touchend', (e) => {
-    const dispatch = world.getResourceByName('events<touchend>')
+
+    /** @type {Events<TouchEnd>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [TouchEnd]))
 
     for (let i = 0; i < e.changedTouches.length; i++) {
       dispatch.write(new TouchEnd(e.changedTouches[i]))

--- a/src/window-dom/core/window.js
+++ b/src/window-dom/core/window.js
@@ -1,4 +1,6 @@
 import { World } from '../../ecs/index.js'
+import { Events } from '../../event/index.js'
+import { typeidGeneric } from '../../reflect/index.js'
 import { WindowResize } from '../../window/index.js'
 
 /**
@@ -7,7 +9,9 @@ import { WindowResize } from '../../window/index.js'
  */
 export function setUpWindowEvents(world, target) {
   target.addEventListener('resize', (event) => {
-    const dispatch = world.getResourceByName('events<windowresize>')
+
+    /** @type {Events<WindowResize>} */
+    const dispatch = world.getResourceByTypeId(typeidGeneric(Events, [WindowResize]))
 
     dispatch.write(new WindowResize(event))
   }) 


### PR DESCRIPTION
## Objective
Ensure that the resources can only be set or gotten by the typeid of a type instead of arbitrary string.

## Solution
N/A

## Showcase
N/A

## Migration guide
`World.getResource` and `World.setResource` have not changed their function signatures hence can be used in the same way.

```typescript
class MyResource()

const world = new World()

// before
world.setResourceByName("myresource",new MyResource())
const res1 = world.getResourceByName<MyResource>("myresource")

// after
world.setResourceByTypeId(typeid(MyResource),new MyResource())
const res1 = world.getResourceByName<MyResource>(typeid(MyResource))
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.