### PR TITLE
Remove deprecated methods on app

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -133,24 +133,6 @@ export class App {
 
     return this
   }
-  /**
-   * @deprecated
-   * @template T
-   * @param {Function} asset
-   * @param {HandleProvider<T>} [handleprovider]
-   */
-  registerAsset(asset, handleprovider) {
-    this.registerPlugin(new AssetPlugin({
-
-      // this function will be removed so the cast does not 
-      // matter much
-      // eslint-disable-next-line object-shorthand
-      asset:/** @type {any}*/(asset),
-      handleprovider
-    }))
-
-    return this
-  }
 
   /**
    * @deprecated

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -7,7 +7,6 @@ import { World, Scheduler, Executor, ComponentHooks, RAFExecutor, ImmediateExecu
 import { assert } from '../logger/index.js'
 import { AppSchedule } from './schedules.js'
 import { SchedulerBuilder, SystemConfig } from './core/index.js'
-import { AssetParserPlugin, AssetPlugin } from '../asset/plugins/index.js'
 
 const registererror = 'Systems, plugins or resources should be registered or set before `App().run()`'
 
@@ -130,25 +129,6 @@ export class App {
    */
   registerType(type) {
     this.world.registerType(type)
-
-    return this
-  }
-
-  /**
-   * @deprecated
-   * @template T
-   * @param {Function} asset 
-   * @param {Parser<T>} parser 
-   */
-  registerAssetParser(asset, parser) {
-    this.registerPlugin(new AssetParserPlugin({
-        
-      // this function will be removed so the cast does not 
-      // matter much
-      // eslint-disable-next-line object-shorthand
-      asset:/** @type {any}*/(asset),
-      parser
-    }))
 
     return this
   }

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -4,8 +4,7 @@
 /** @import { Constructor } from '../reflect/index.js'*/
 
 import { World, Scheduler, Executor, ComponentHooks, RAFExecutor, ImmediateExecutor } from '../ecs/index.js'
-import { EventPlugin } from '../event/index.js'
-import { assert, deprecate } from '../logger/index.js'
+import { assert } from '../logger/index.js'
 import { AppSchedule } from './schedules.js'
 import { SchedulerBuilder, SystemConfig } from './core/index.js'
 import { AssetParserPlugin, AssetPlugin } from '../asset/plugins/index.js'
@@ -134,23 +133,6 @@ export class App {
 
     return this
   }
-
-  /**
-   * @deprecated
-   * @template {Function} T
-   * @param {T} event
-   */
-  registerEvent(event) {
-    deprecate('App.registerEvent()', 'EventPlugin')
-    this.registerPlugin(
-
-      // @ts-ignore
-      new EventPlugin({ event })
-    )
-
-    return this
-  }
-
   /**
    * @deprecated
    * @template T

--- a/src/asset/plugins/asset.js
+++ b/src/asset/plugins/asset.js
@@ -2,6 +2,7 @@
 /** @import { HandleProvider } from '../core/index.js' */
 
 import { App } from '../../app/index.js'
+import { EventPlugin } from '../../event/plugin.js'
 import { typeidGeneric } from '../../reflect/index.js'
 import { Assets } from '../core/index.js'
 import { AssetLoadFail, AssetLoadSuccess } from '../events/index.js'
@@ -54,8 +55,12 @@ export class AssetPlugin {
     // TODO - Separate the events to become for each
     // asset type
     app
-      .registerEvent(AssetLoadSuccess)
-      .registerEvent(AssetLoadFail)
+      .registerPlugin(new EventPlugin({
+        event:AssetLoadSuccess
+      }))
+      .registerPlugin(new EventPlugin({
+        event:AssetLoadFail
+      }))
     world.setResourceByTypeId(
       typeidGeneric(AssetBasePath, [this.asset]),
       new AssetBasePath(path)

--- a/src/audio/plugin.js
+++ b/src/audio/plugin.js
@@ -1,5 +1,5 @@
 import { App } from '../app/index.js'
-import { Audio } from '../asset/index.js'
+import { AssetParserPlugin, AssetPlugin, Audio } from '../asset/index.js'
 import { AudioCommands, AudioParser } from './resources/index.js'
 
 export class AudioPlugin {
@@ -12,8 +12,13 @@ export class AudioPlugin {
 
     app
       .setResource(handler)
-      .registerAsset(Audio)
-      .registerAssetParser(Audio, new AudioParser())
+      .registerPlugin(new AssetPlugin({
+        asset:Audio
+      }))
+      .registerPlugin(new AssetParserPlugin({
+        asset:Audio,
+        parser:new AudioParser()
+      }))
     window.addEventListener('pointerdown', resumeAudio)
 
     /** */

--- a/src/render-core/plugin.js
+++ b/src/render-core/plugin.js
@@ -1,5 +1,5 @@
 import { App } from '../app/index.js'
-import { Image } from '../asset/index.js'
+import { AssetParserPlugin, AssetPlugin, Image } from '../asset/index.js'
 import { Camera, MaterialHandle, MeshHandle } from './components/index.js'
 import { Material, Mesh, Shader } from './assets/index.js'
 import { ImageParser } from './resources/index.js'
@@ -11,11 +11,24 @@ export class RenderCorePlugin {
    */
   register(app) {
     app
-      .registerAsset(Image)
-      .registerAssetParser(Image, new ImageParser())
-      .registerAsset(Mesh, (id) => new MeshHandle(id))
-      .registerAsset(Shader)
-      .registerAsset(Material, (id) => new MaterialHandle(id))
+      .registerPlugin(new AssetPlugin({
+        asset:Image
+      }))
+      .registerPlugin( new AssetParserPlugin({
+        asset:Image,
+        parser:new ImageParser()
+      }))
+      .registerPlugin(new AssetPlugin({
+        asset:Shader
+      }))
+      .registerPlugin(new AssetPlugin({
+        asset:Mesh,
+        handleprovider:(id) => new MeshHandle(id)
+      }))
+      .registerPlugin(new AssetPlugin({
+        asset:Material,
+        handleprovider:(id) => new MaterialHandle(id)
+      }))
       .registerType(MeshHandle)
       .registerType(MaterialHandle)
       .registerType(Camera)

--- a/src/window/plugin.js
+++ b/src/window/plugin.js
@@ -21,6 +21,7 @@ import { App, AppSchedule } from '../app/index.js'
 import { World } from '../ecs/index.js'
 import { Window, MainWindow } from './components/index.js'
 import { WindowCommands, Windows } from './resources/index.js'
+import { EventPlugin } from '../event/plugin.js'
 
 export class WindowPlugin {
 
@@ -54,23 +55,54 @@ export class WindowPlugin {
     app
       .registerType(Window)
       .registerType(MainWindow)
-      .registerEvent(WindowMove)
-      .registerEvent(WindowResize)
-      .registerEvent(KeyDown)
-      .registerEvent(KeyUp)
-      .registerEvent(MouseDown)
-      .registerEvent(MouseMove)
-      .registerEvent(MouseUp)
-      .registerEvent(MouseWheel)
-      .registerEvent(MouseEnter)
-      .registerEvent(MouseLeave)
-      .registerEvent(TouchStart)
-      .registerEvent(TouchMove)
-      .registerEvent(TouchEnd)
-      .registerEvent(TouchCancel)
-      .registerEvent(WindowResize)
-      .registerEvent(FileDrag)
-      .registerEvent(FileDrop)
+      .registerPlugin(new EventPlugin({
+        event:WindowMove
+      }))
+      .registerPlugin(new EventPlugin({
+        event:WindowResize
+      }))
+      .registerPlugin(new EventPlugin({
+        event:KeyDown
+      }))
+      .registerPlugin(new EventPlugin({
+        event:KeyUp
+      }))
+      .registerPlugin(new EventPlugin({
+        event:MouseDown
+      }))
+      .registerPlugin(new EventPlugin({
+        event:MouseUp
+      }))
+      .registerPlugin(new EventPlugin({
+        event:MouseMove
+      }))
+      .registerPlugin(new EventPlugin({
+        event:MouseWheel
+      }))
+      .registerPlugin(new EventPlugin({
+        event:MouseEnter
+      }))
+      .registerPlugin(new EventPlugin({
+        event:MouseLeave
+      }))
+      .registerPlugin(new EventPlugin({
+        event:TouchStart
+      }))
+      .registerPlugin(new EventPlugin({
+        event:TouchEnd
+      }))
+      .registerPlugin(new EventPlugin({
+        event:TouchMove
+      }))
+      .registerPlugin(new EventPlugin({
+        event:TouchCancel
+      }))
+      .registerPlugin(new EventPlugin({
+        event:FileDrag
+      }))
+      .registerPlugin(new EventPlugin({
+        event:FileDrop
+      }))
       .setResource(new Windows())
       .setResource(new WindowCommands())
 


### PR DESCRIPTION
## Objective
Removes deprecated methods on `App` which register assets and events.

## Solution
N/A

## Showcase
N/A

## Migration guide
 - Follow migration guides of #67 and #58

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.