### PR TITLE
Improve `Query` component generic

### DIFF
--- a/src/ecs/query.js
+++ b/src/ecs/query.js
@@ -1,4 +1,4 @@
-/** @import { ComponentId, ArchetypeId } from './typedef/index.js'*/
+/** @import { ArchetypeId } from './typedef/index.js'*/
 /** @import { Constructor, TypeId } from '../reflect/index.js'*/
 
 import { Entity } from './entities/index.js'
@@ -28,8 +28,7 @@ import { typeid } from '../reflect/index.js'
  * // are available
  * ```
  * 
- * @template {InstanceTypeTuple<U>} T
- * @template {Constructor[]} U 
+ * @template {unknown[]} T
  */
 export class Query {
 
@@ -59,7 +58,7 @@ export class Query {
 
   /**
    * @param {World} registry
-   * @param {[...U]} componentTypes
+   * @param {[...TupleConstructor<T>]} componentTypes
    */
   constructor(registry, componentTypes) {
     this.registry = registry

--- a/src/ecs/query.js
+++ b/src/ecs/query.js
@@ -227,3 +227,8 @@ export class Query {
  * @param {[...T]} components2
  * @returns {void}
  */
+
+/**
+ * @template {unknown[]} T
+ * @typedef {{[K in keyof T]:Constructor<T[K]>}} TupleConstructor
+ */

--- a/src/ecs/query.js
+++ b/src/ecs/query.js
@@ -227,8 +227,3 @@ export class Query {
  * @param {[...T]} components2
  * @returns {void}
  */
-
-/**
- * @template {Constructor[]} T
- * @typedef {{[K in keyof T]:InstanceType<T[K]>}} InstanceTypeTuple
- */


### PR DESCRIPTION
## Objective
Currently `Query` has two redundant generic parameters which are used to represent components to be fetched i.e:
```typescript
Query<[SomeComponent],[typeof SomeComponent]>
```
As seen, the second generic is coupled to the first parameter(the second parameter is constructor type of the first)
This PR focuses on removing the redundancy thus improves usability of `Query`

## Solution
Combines the two generics into one to remove the redundancy by using type utilities.

## Showcase
N/A

## Migration guide
```typescript
class MyComponent {}

const world = new World()

// before
function readQuery(query:Query<[MyComponent],[typeof MyComponent]>) {
}

// after
function readQuery(query:Query<[MyComponent]>) {
}
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.