### PR TITLE
Make `Plugin`(previously `ChaosPlugin`) an abstract class

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,4 +1,3 @@
-/** @import { ChaosPlugin } from './typedef/index.js' */
 /** @import { SystemFunc } from '../ecs/index.js' */
 /** @import { HandleProvider, Parser } from '../asset/index.js' */
 /** @import { Constructor,TypeId } from '../reflect/index.js'*/
@@ -101,7 +100,7 @@ export class App {
   }
 
   /**
-   * @param {ChaosPlugin} plugin
+   * @param {Plugin} plugin
    */
   registerPlugin(plugin) {
     plugin.register(this)
@@ -110,7 +109,7 @@ export class App {
   }
 
   /**
-   * @param {ChaosPlugin} debug
+   * @param {Plugin} debug
    */
   registerDebugger(debug) {
     return this.registerPlugin(debug)

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,12 +1,14 @@
 /** @import { ChaosPlugin } from './typedef/index.js' */
 /** @import { SystemFunc } from '../ecs/index.js' */
 /** @import { HandleProvider, Parser } from '../asset/index.js' */
-/** @import { Constructor } from '../reflect/index.js'*/
+/** @import { Constructor,TypeId } from '../reflect/index.js'*/
 
 import { World, Scheduler, Executor, ComponentHooks, RAFExecutor, ImmediateExecutor } from '../ecs/index.js'
 import { assert } from '../logger/index.js'
 import { AppSchedule } from './schedules.js'
 import { SchedulerBuilder, SystemConfig } from './core/index.js'
+import { typeid } from '../reflect/index.js'
+
 
 const registererror = 'Systems, plugins or resources should be registered or set before `App().run()`'
 
@@ -154,5 +156,22 @@ export class App {
       .world.setResource(resource)
 
     return this
+  }
+}
+
+export class Plugin {
+
+  /**
+   * @param {App} _app
+   */
+  register(_app){}
+
+  /**
+   * @returns {TypeId}
+   */
+  name(){
+
+    // SAFETY: `this.constructor` can be casted into a `Contructor`
+    return typeid(/** @type {Constructor}*/(this.constructor))
   }
 }

--- a/src/app/typedef/types.js
+++ b/src/app/typedef/types.js
@@ -5,9 +5,4 @@
  * @returns {void}
  */
 
-/**
- * @typedef ChaosPlugin
- * @property {RegisterFunc} register
- */
-
 export default {}

--- a/src/asset/plugins/asset.js
+++ b/src/asset/plugins/asset.js
@@ -1,7 +1,7 @@
 /** @import { Defaultable } from '../../utils/index.js' */
 /** @import { HandleProvider } from '../core/index.js' */
 
-import { App } from '../../app/index.js'
+import { App, Plugin } from '../../app/index.js'
 import { EventPlugin } from '../../event/plugin.js'
 import { typeidGeneric } from '../../reflect/index.js'
 import { Assets } from '../core/index.js'
@@ -13,7 +13,7 @@ import { AssetBasePath } from '../resources/index.js'
  * @template T
  */
 
-export class AssetPlugin {
+export class AssetPlugin extends Plugin {
 
   /**
    * @readonly
@@ -37,6 +37,7 @@ export class AssetPlugin {
    * @param {AssetPluginOptions<T>} options
    */
   constructor(options) {
+    super()
     const { path = '', asset, handleprovider } = options
 
     this.handleprovider = handleprovider
@@ -69,6 +70,10 @@ export class AssetPlugin {
       typeidGeneric(Assets, [this.asset]),
       new Assets(asset.default, handleprovider)
     )
+  }
+
+  name(){
+    return typeidGeneric(AssetPlugin, [this.asset])
   }
 }
 

--- a/src/asset/plugins/parser.js
+++ b/src/asset/plugins/parser.js
@@ -1,4 +1,5 @@
-import { App, AppSchedule } from '../../app/index.js'
+/** @import {Constructor} from '../../reflect/index.js' */
+import { App, AppSchedule, Plugin } from '../../app/index.js'
 import { typeidGeneric } from '../../reflect/index.js'
 import { Parser } from '../core/index.js'
 import { generateParserSystem } from '../systems/index.js'
@@ -8,11 +9,11 @@ import { generateParserSystem } from '../systems/index.js'
  * @template T
  */
 
-export class AssetParserPlugin {
+export class AssetParserPlugin extends Plugin {
 
   /**
    * @readonly
-   * @type {new (...args:any)=>T}
+   * @type {Constructor<T>}
    */
   asset
 
@@ -26,6 +27,7 @@ export class AssetParserPlugin {
    * @param {AssetParserPluginOptions<T>} options 
    */
   constructor(options) {
+    super()
     const { asset, parser } = options
 
     this.asset = asset
@@ -43,11 +45,15 @@ export class AssetParserPlugin {
       .getWorld()
       .setResourceByTypeId(typeidGeneric(Parser, [asset]), parser)
   }
+
+  name(){
+    return typeidGeneric(AssetParserPlugin, [this.asset])
+  }
 }
 
 /**
  * @template T
  * @typedef AssetParserPluginOptions
- * @property {new ()=>T} asset
+ * @property {Constructor<T>} asset
  * @property {Parser<T>} parser
  */

--- a/src/audio/plugin.js
+++ b/src/audio/plugin.js
@@ -1,8 +1,8 @@
-import { App } from '../app/index.js'
+import { App, Plugin } from '../app/index.js'
 import { AssetParserPlugin, AssetPlugin, Audio } from '../asset/index.js'
 import { AudioCommands, AudioParser } from './resources/index.js'
 
-export class AudioPlugin {
+export class AudioPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/broadphase/plugin.js
+++ b/src/broadphase/plugin.js
@@ -1,10 +1,10 @@
 /** @import {Broadphasable2D} from './resources/index.js'*/
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { PhysicsHitbox } from './components/index.js'
 import { CollisionPairs, Broadphase2D } from './resources/index.js'
 import { getCollisionPairs, updateBroadphase2D } from './systems/index.js'
 
-export class Broadphase2DPlugin {
+export class Broadphase2DPlugin extends Plugin {
 
   /**
    * @readonly
@@ -16,6 +16,7 @@ export class Broadphase2DPlugin {
    * @param {Broadphase2DPluginOptions} options 
    */
   constructor({ broadphase }){
+    super()
     this.innerBroadphase = broadphase
   }
 

--- a/src/command/plugin.js
+++ b/src/command/plugin.js
@@ -1,9 +1,9 @@
-import { App } from '../app/app.js'
+import { App, Plugin } from '../app/app.js'
 import { AppSchedule } from '../app/schedules.js'
 import { World } from '../ecs/index.js'
 import { EntityCommands } from './resources/index.js'
 
-export class CommandsPlugin {
+export class CommandsPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/damping/plugin.js
+++ b/src/damping/plugin.js
@@ -16,7 +16,7 @@ export class Damping2DPlugin extends Plugin {
   }
 }
 
-export class Damping3DPlugin {
+export class Damping3DPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/damping/plugin.js
+++ b/src/damping/plugin.js
@@ -1,8 +1,8 @@
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { Linear2DDamping, Angular2DDamping, Linear3DDamping, Angular3DDamping } from './resources/index.js'
 import { dampenRotation2D, dampenRotation3D, dampenVelocity2D, dampenVelocity3D } from './systems/index.js'
 
-export class Damping2DPlugin {
+export class Damping2DPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/demo/plugin.js
+++ b/src/demo/plugin.js
@@ -1,4 +1,4 @@
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { EntityCommands } from '../command/index.js'
 import { Query, World, Entity } from '../ecs/index.js'
 import { Storage } from '../storage/index.js'
@@ -9,7 +9,7 @@ import { createDropDown } from './utils.js'
 
 const storageLabel = 'demo'
 
-export class DemoPlugin {
+export class DemoPlugin extends Plugin {
 
   /**
    * @readonly
@@ -21,6 +21,7 @@ export class DemoPlugin {
    * @param {DemoPluginOptions} demos 
    */
   constructor({ demos = [] }) {
+    super()
     this.demos = demos
   }
 

--- a/src/device/plugin.js
+++ b/src/device/plugin.js
@@ -1,8 +1,8 @@
-import { App } from '../app/index.js'
+import { App, Plugin } from '../app/index.js'
 import { Browser, PlatformOS } from './core/index.js'
 import { Device } from './resources/index.js'
 
-export class DevicePlugin {
+export class DevicePlugin extends Plugin {
 
   /**
    * @param {App} app 

--- a/src/diagnostic/fpsdebugger.js
+++ b/src/diagnostic/fpsdebugger.js
@@ -1,9 +1,9 @@
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { World } from '../ecs/index.js'
 import { Timer, TimerMode, VirtualClock } from '../time/index.js'
 import { RAFTimer } from './resources/index.js'
 
-export class FPSDebugger {
+export class FPSDebugger extends Plugin {
 
   /**
    * @param {App} app

--- a/src/event/plugin.js
+++ b/src/event/plugin.js
@@ -1,11 +1,11 @@
 /** @import { Constructor } from '../reflect/index.js'*/
 
-import { App, AppSchedule, SystemConfig } from '../app/index.js'
+import { App, AppSchedule, Plugin, SystemConfig } from '../app/index.js'
 import { makeEventClear } from './systems/index.js'
 import { Events } from './core/index.js'
 import { typeidGeneric } from '../reflect/index.js'
 
-export class EventPlugin {
+export class EventPlugin extends Plugin {
 
   /**
    * @readonly
@@ -23,6 +23,7 @@ export class EventPlugin {
    * @param {{ event: Constructor; autoClearEvent?:boolean; }} options
    */
   constructor(options) {
+    super()
     const { event, autoClearEvent = true } = options
 
     this.event = event
@@ -46,5 +47,9 @@ export class EventPlugin {
     if (this.autoClearEvent) {
       app.systemsevents.push(new SystemConfig(makeEventClear(name), AppSchedule.Update))
     }
+  }
+
+  name(){
+    return typeidGeneric(EventPlugin, [this.event])
   }
 }

--- a/src/gravity/plugin.js
+++ b/src/gravity/plugin.js
@@ -29,7 +29,7 @@ export class Gravity2DPlugin extends Plugin {
   }
 }
 
-export class Gravity3DPlugin {
+export class Gravity3DPlugin extends Plugin {
 
   /**
    * @readonly
@@ -41,6 +41,7 @@ export class Gravity3DPlugin {
    * @param {Gravity3DPluginOptions} options 
    */
   constructor({ gravity = new Vector3(0, -980, 0) } = {}) {
+    super()
     this.gravity = gravity
   }
 

--- a/src/gravity/plugin.js
+++ b/src/gravity/plugin.js
@@ -1,9 +1,9 @@
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { Vector2, Vector3 } from '../math/index.js'
 import { Gravity2D, Gravity3D } from './resources/index.js'
 import { applyGravity2D, applyGravity3D } from './systems/index.js'
 
-export class Gravity2DPlugin {
+export class Gravity2DPlugin extends Plugin {
 
   /**
    * @readonly
@@ -15,6 +15,7 @@ export class Gravity2DPlugin {
    * @param {Gravity2DPluginOptions} options 
    */
   constructor({ gravity = new Vector2(0, -980) } = {}) {
+    super()
     this.gravity = gravity
   }
 

--- a/src/hierarchy/plugin.js
+++ b/src/hierarchy/plugin.js
@@ -1,9 +1,9 @@
-import { App } from '../app/index.js'
+import { App, Plugin } from '../app/index.js'
 import { ComponentHooks } from '../ecs/index.js'
 import { Children, Parent } from './components/index.js'
 import { addSelfToChildren, despawnChildren, addSelfToParent, removeSelfFromParent } from './hooks/index.js'
 
-export class HierarchyPlugin {
+export class HierarchyPlugin extends Plugin {
 
   /**
    * @param {App} app 

--- a/src/input/plugin.js
+++ b/src/input/plugin.js
@@ -1,9 +1,9 @@
-import { App } from '../app/index.js'
+import { App, Plugin } from '../app/index.js'
 import { KeyboardPlugin } from '../keyboard/index.js'
 import { MousePlugin } from '../mouse/index.js'
 import { TouchPlugin } from '../touch/index.js'
 
-export class InputPlugin {
+export class InputPlugin extends Plugin {
 
   /**
    * @type {HTMLElement}
@@ -14,6 +14,7 @@ export class InputPlugin {
    * @param {HTMLElement} target
    */
   constructor(target = document.body) {
+    super()
     this.target = target
   }
 

--- a/src/integrator/plugins/euler.js
+++ b/src/integrator/plugins/euler.js
@@ -24,7 +24,7 @@ export class EulerIntegrator2DPlugin extends Plugin {
   }
 }
 
-export class EulerIntegrator3DPlugin {
+export class EulerIntegrator3DPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/integrator/plugins/euler.js
+++ b/src/integrator/plugins/euler.js
@@ -1,4 +1,4 @@
-import { App, AppSchedule } from '../../app/index.js'
+import { App, AppSchedule, Plugin } from '../../app/index.js'
 import {
   updateAngularEuler2D,
   updateOrientationEuler2D,
@@ -10,7 +10,7 @@ import {
   updateVelocityEuler3D
 } from '../systems/index.js'
 
-export class EulerIntegrator2DPlugin {
+export class EulerIntegrator2DPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/integrator/plugins/verlet.js
+++ b/src/integrator/plugins/verlet.js
@@ -1,7 +1,7 @@
-import { App, AppSchedule } from '../../app/index.js'
+import { App, AppSchedule, Plugin } from '../../app/index.js'
 import { updatePositionVerlet2D, updateOrientationVerlet2D } from '../systems/index.js'
 
-export class VerletIntegrator2DPlugin {
+export class VerletIntegrator2DPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/keyboard/plugin.js
+++ b/src/keyboard/plugin.js
@@ -1,4 +1,4 @@
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { Keyboard } from './resources/index.js'
 import { KeyUp, KeyDown } from '../window/index.js'
 import { Events } from '../event/index.js'
@@ -6,7 +6,7 @@ import { World } from '../ecs/index.js'
 import { KeyCode } from './core/key.js'
 import { typeidGeneric } from '../reflect/index.js'
 
-export class KeyboardPlugin {
+export class KeyboardPlugin extends Plugin{
 
   /**
    * @param {App} app

--- a/src/misc/plugin.js
+++ b/src/misc/plugin.js
@@ -1,9 +1,9 @@
 import { TransformPlugin } from '../transform/index.js'
-import { App } from '../app/index.js'
+import { App, Plugin } from '../app/index.js'
 import { TimePlugin } from '../time/index.js'
 import { ProfilerPlugin } from '../profiler/index.js'
 
-export class DefaultPlugin {
+export class DefaultPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/mouse/plugin.js
+++ b/src/mouse/plugin.js
@@ -1,4 +1,4 @@
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { Mouse, MouseButtons } from './resources/index.js'
 import { MouseButton } from './core/index.js'
 import { World } from '../ecs/index.js'
@@ -7,7 +7,7 @@ import { MouseDown, MouseMove, MouseUp } from '../window/index.js'
 import { Vector2 } from '../math/index.js'
 import { typeidGeneric } from '../reflect/index.js'
 
-export class MousePlugin {
+export class MousePlugin extends Plugin{
 
   /**
    * @param {App} app

--- a/src/movable/plugins/three.js
+++ b/src/movable/plugins/three.js
@@ -4,9 +4,9 @@ import {
   Acceleration3D,
   Torque3D
 } from '../components/index.js'
-import { App } from '../../app/index.js'
+import { App, Plugin } from '../../app/index.js'
 
-export class Movable3DPlugin {
+export class Movable3DPlugin extends Plugin{
 
   /**
    * @param {App} app

--- a/src/movable/plugins/two.js
+++ b/src/movable/plugins/two.js
@@ -4,9 +4,9 @@ import {
   Acceleration2D,
   Torque2D
 } from '../components/index.js'
-import { App } from '../../app/index.js'
+import { App, Plugin } from '../../app/index.js'
 
-export class Movable2DPlugin {
+export class Movable2DPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/narrowphase/plugin.js
+++ b/src/narrowphase/plugin.js
@@ -1,4 +1,4 @@
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { Contacts, SATNarrowphase2D } from './resources/index.js'
 import { getSATContacts } from './systems/index.js'
 
@@ -6,7 +6,7 @@ import { getSATContacts } from './systems/index.js'
  * Uses the Separation Axis Theorem.
  * Best when your body shapes have few vertices.
  */
-export class NarrowPhase2DPlugin {
+export class NarrowPhase2DPlugin extends Plugin{
 
   /**
    * @param {App} app

--- a/src/physics/plugins/debugger.js
+++ b/src/physics/plugins/debugger.js
@@ -1,5 +1,5 @@
 /** @import {Entity} from '../../ecs/index.js' */
-import { App, AppSchedule } from '../../app/index.js'
+import { App, AppSchedule, Plugin } from '../../app/index.js'
 import {
   drawArms,
   drawBounds,
@@ -10,12 +10,13 @@ import {
 } from '../systems/index.js'
 
 
-export class Physics2DDebuggerPlugin {
+export class Physics2DDebuggerPlugin extends Plugin{
 
   /**
    * @param {BodyDebbuggerOptions} options
    */
   constructor(options = {}) {
+    super()
     options.drawCollisionArm = options.drawCollisionArm ?? false
     options.drawContacts = options.drawContacts ?? false
     options.drawPosition = options.drawPosition ?? false

--- a/src/physics/plugins/plugin.js
+++ b/src/physics/plugins/plugin.js
@@ -1,6 +1,5 @@
-/** @import { ChaosPlugin } from '../../app/index.js' */
 import { Broadphase2DPlugin, NaiveBroadphase2D } from '../../broadphase/index.js'
-import { App, AppSchedule } from '../../app/index.js'
+import { App, AppSchedule, Plugin } from '../../app/index.js'
 import { ComponentHooks } from '../../ecs/index.js'
 import { NarrowPhase2DPlugin } from '../../narrowphase/index.js'
 import { EulerIntegrator2DPlugin } from '../../integrator/index.js'
@@ -9,7 +8,7 @@ import { physicspropertiesAddHook } from '../hooks/index.js'
 import { Gravity2DPlugin } from '../../gravity/index.js'
 import { collisionResponse, updateBodies, updateBounds } from '../systems/index.js'
 
-export class Physics2DPlugin {
+export class Physics2DPlugin extends Plugin {
 
   /**
    * @param {Physics2DPluginOptions} options
@@ -22,6 +21,7 @@ export class Physics2DPlugin {
     narrowphase = new NarrowPhase2DPlugin(),
     integrator = new EulerIntegrator2DPlugin()
   } = {}) {
+    super()
     this.broadphase = broadphase
     this.narrowphase = narrowphase
     this.integrator = integrator
@@ -60,8 +60,8 @@ export class Physics2DPlugin {
 
 /**
  * @typedef Physics2DPluginOptions
- * @property {ChaosPlugin} [broadphase]
- * @property {ChaosPlugin} [narrowphase]
- * @property {ChaosPlugin} [integrator]
+ * @property {Plugin} [broadphase]
+ * @property {Plugin} [narrowphase]
+ * @property {Plugin} [integrator]
  * @property {boolean} [autoUpdateBounds]
  */

--- a/src/profiler/plugin.js
+++ b/src/profiler/plugin.js
@@ -1,10 +1,10 @@
 import { Profiler, ProfilerTimer } from './resources/index.js'
 import { Timer, TimerMode, VirtualClock } from '../time/index.js'
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { World } from '../ecs/index.js'
 import { warn } from '../logger/index.js'
 
-export class ProfilerPlugin {
+export class ProfilerPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/render-canvas2d/plugin.js
+++ b/src/render-canvas2d/plugin.js
@@ -1,6 +1,6 @@
 import { Image, Assets } from '../asset/index.js'
 import { Entity, Query, World } from '../ecs/index.js'
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { Mesh, Material, TextureCache, Camera, MeshHandle, MaterialHandle } from '../render-core/index.js'
 import { MainWindow, Window, Windows } from '../window/index.js'
 import { warn } from '../logger/index.js'
@@ -10,7 +10,7 @@ import { MaterialType } from './core/index.js'
 import { CanvasImageMaterial, CanvasMeshedMaterial, CanvasTextMaterial } from './assets/materials/index.js'
 import { typeid, typeidGeneric } from '../reflect/index.js'
 
-export class Canvas2DRendererPlugin {
+export class Canvas2DRendererPlugin extends Plugin{
 
   /**
    * @param {App} app

--- a/src/render-core/plugin.js
+++ b/src/render-core/plugin.js
@@ -1,10 +1,10 @@
-import { App } from '../app/index.js'
+import { App, Plugin } from '../app/index.js'
 import { AssetParserPlugin, AssetPlugin, Image } from '../asset/index.js'
 import { Camera, MaterialHandle, MeshHandle } from './components/index.js'
 import { Material, Mesh, Shader } from './assets/index.js'
 import { ImageParser } from './resources/index.js'
 
-export class RenderCorePlugin {
+export class RenderCorePlugin extends Plugin{
 
   /**
    * @param {App} app 

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -1,4 +1,4 @@
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { Assets } from '../asset/index.js'
 import { ComponentHooks, Entity, Query, World } from '../ecs/index.js'
 import { Events } from '../event/index.js'
@@ -10,7 +10,7 @@ import { MainWindow, Window, WindowResize, Windows } from '../window/index.js'
 import { materialAddHook, meshAddHook } from './hooks/index.js'
 import { AttributeMap, ClearColor, MeshCache, UBOCache } from './resources/index.js'
 
-export class WebglRendererPlugin {
+export class WebglRendererPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/storage/plugin.js
+++ b/src/storage/plugin.js
@@ -1,7 +1,7 @@
-import { App } from '../app/index.js'
+import { App, Plugin } from '../app/index.js'
 import { Session, Storage, Cookies } from './resources/index.js'
 
-export class StoragePlugin {
+export class StoragePlugin extends Plugin{
 
   /**
    * @param {App} app 

--- a/src/time/plugin.js
+++ b/src/time/plugin.js
@@ -1,10 +1,10 @@
 import { World } from '../ecs/index.js'
 import { VirtualClock } from './resource/index.js'
-import { App } from '../app/app.js'
+import { App, Plugin } from '../app/app.js'
 import { AppSchedule } from '../app/schedules.js'
 import { Clock } from './clock.js'
 
-export class TimePlugin {
+export class TimePlugin extends Plugin{
 
   /**
    * @param {App} app

--- a/src/touch/plugin.js
+++ b/src/touch/plugin.js
@@ -1,4 +1,4 @@
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { World } from '../ecs/index.js'
 import { Events } from '../event/index.js'
 import { typeidGeneric } from '../reflect/index.js'
@@ -6,7 +6,7 @@ import { TouchCancel, TouchEnd, TouchMove, TouchStart } from '../window/index.js
 import { TouchPointer } from './core/index.js'
 import { Touches } from './resources/touches.js'
 
-export class TouchPlugin {
+export class TouchPlugin extends Plugin{
 
   /**
    * @param {App} app

--- a/src/transform/plugin.js
+++ b/src/transform/plugin.js
@@ -9,10 +9,10 @@ import {
   GlobalTransform3D
 } from './components/index.js'
 import { Dimension } from '../utils/index.js'
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { Query, World } from '../ecs/index.js'
 
-export class TransformPlugin {
+export class TransformPlugin extends Plugin{
 
   /**
    * @type {TransformPluginOptions}
@@ -23,6 +23,7 @@ export class TransformPlugin {
    * @param {TransformPluginOptions} options
    */
   constructor(options = {}) {
+    super()
     options.dimension = options.dimension ?? Dimension.Both
     this.options = options
   }

--- a/src/tween/plugin.js
+++ b/src/tween/plugin.js
@@ -1,5 +1,5 @@
 /** @import {TweenLerp} from './typedef/index.js' */
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import {
   Position2DTween,
   Orientation2DTween,
@@ -14,6 +14,7 @@ import {
 import { Vector2, Quaternion, Vector3, Angle } from '../math/index.js'
 import { generateTweenFlipSystem, generateTweenRepeatTween, generateTweenTimerSystem, generateTweenUpdateSystem } from './systems/index.js'
 import { Orientation2D, Orientation3D, Position2D, Position3D, Scale2D, Scale3D } from '../transform/index.js'
+import { typeidGeneric } from '../reflect/index.js'
 
 export class DefaultTweenPlugin {
 
@@ -63,7 +64,7 @@ export class DefaultTweenPlugin {
 /**
  * @template T
  */
-export class TweenPlugin {
+export class TweenPlugin extends Plugin{
 
   /**
    * @readonly
@@ -87,6 +88,7 @@ export class TweenPlugin {
    * @param {TweenPluginOptions<T>} options 
    */
   constructor({ component, tween, interpolation }) {
+    super()
     this.component = component
     this.interpolation = interpolation
     this.tween = tween
@@ -98,10 +100,16 @@ export class TweenPlugin {
   register(app) {
     app
       .registerType(this.tween)
+      .registerType(TweenFlip)
+      .registerType(TweenRepeat)
       .registerSystem(AppSchedule.Update, generateTweenFlipSystem(this.tween))
       .registerSystem(AppSchedule.Update, generateTweenRepeatTween(this.tween))
       .registerSystem(AppSchedule.Update, generateTweenTimerSystem(this.tween))
       .registerSystem(AppSchedule.Update, generateTweenUpdateSystem(this.component, this.tween, this.interpolation))
+  }
+
+  name(){
+    return typeidGeneric(TweenPlugin, [this.component])
   }
 }
 

--- a/src/tween/plugin.js
+++ b/src/tween/plugin.js
@@ -16,15 +16,13 @@ import { generateTweenFlipSystem, generateTweenRepeatTween, generateTweenTimerSy
 import { Orientation2D, Orientation3D, Position2D, Position3D, Scale2D, Scale3D } from '../transform/index.js'
 import { typeidGeneric } from '../reflect/index.js'
 
-export class DefaultTweenPlugin {
+export class DefaultTweenPlugin extends Plugin {
 
   /**
    * @param {App} app
    */
   register(app) {
     app
-      .registerType(TweenFlip)
-      .registerType(TweenRepeat)
       .registerPlugin(new TweenPlugin({
         component: Position2D,
         tween: Position2DTween,

--- a/src/window-dom/plugin.js
+++ b/src/window-dom/plugin.js
@@ -1,10 +1,10 @@
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { ComponentHooks } from '../ecs/index.js'
 import { Window } from '../window/index.js'
 import { closeWindow, openWindow } from './hooks/index.js'
 import { executeWindowCommands } from './systems/index.js'
 
-export class DOMWindowPlugin {
+export class DOMWindowPlugin extends Plugin {
 
   /**
    * @param {App} app

--- a/src/window/plugin.js
+++ b/src/window/plugin.js
@@ -17,13 +17,13 @@ import {
   WindowMove,
   WindowResize
 } from './events/index.js'
-import { App, AppSchedule } from '../app/index.js'
+import { App, AppSchedule, Plugin } from '../app/index.js'
 import { World } from '../ecs/index.js'
 import { Window, MainWindow } from './components/index.js'
 import { WindowCommands, Windows } from './resources/index.js'
 import { EventPlugin } from '../event/plugin.js'
 
-export class WindowPlugin {
+export class WindowPlugin extends Plugin {
 
   /**
    * @readonly
@@ -44,6 +44,7 @@ export class WindowPlugin {
     initPrimaryWindow = true,
     primaryWindowOptions
   } = {}) {
+    super()
     this.initPrimaryWindow = initPrimaryWindow
     this.primaryWindowOptions = primaryWindowOptions
   }


### PR DESCRIPTION
## Objective
Make `Plugin` into abstract class.This is done to enable plugins to have default methods for future work.

## Solution
Made `Plugin` an abstract class as interfaces do not exist in javascript.

## Showcase
N/A

## Migration guide
```typescript
// before
class MyPlugin implements ChaosPlugin {}

// after
class MyPlugin extends Plugin {}
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.