### PR TITLE
Make `IndexAllocator`'s index allocation generic.

### DIFF
--- a/src/datastructures/indexallocator.js
+++ b/src/datastructures/indexallocator.js
@@ -1,3 +1,6 @@
+/**
+ * @template {number} [T = number]
+ */
 export class IndexAllocator {
 
   /**
@@ -8,19 +11,19 @@ export class IndexAllocator {
 
   /**
    * @private
-   * @type {number[]}
+   * @type {T[]}
    */
   recycled = []
 
   /**
-   * @param {number} index 
+   * @param {T} index 
    */
   recycle(index){
     this.recycled.push(index)
   }
 
   /**
-   * @returns {number}
+   * @returns {T}
    */
   reserve(){
     const recycled = this.recycled.pop()
@@ -31,8 +34,11 @@ export class IndexAllocator {
 
     this.nextid += 1
 
-    return index
+    // SAFETY: T is not a concrete type but extends
+    // number
+    return /** @type {T}*/(index)
   }
+
   count(){
     return (this.nextid - 1)
   }


### PR DESCRIPTION
## Objective
The index allocator can now be of several types which extend number but arent concrete types.

## Solution
Added an optional generic parameter repesenting the indexing type.

## Showcase
```typescript
type MyIndex = number

// Allocates number
const defaultAllocator = new IndexAllocator()

// Allocates MyIndex
const myAllocator = new IndexAllocator<MyIndex>()
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.