### PR TITLE
Rename `Handle.handle` to `Handle.index`

### DIFF
--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -65,7 +65,7 @@ export class Assets {
    * @returns {T}
    */
   getByHandle(handle) {
-    const asset = this.assets.get(handle.handle)
+    const asset = this.assets.get(handle.index)
 
     assert(asset, 'The handle provided is invalid!Did you try to create your own handle?')
 
@@ -77,7 +77,7 @@ export class Assets {
    * @param {T} asset
    */
   setByHandle(handle, asset) {
-    this.assets.set(handle.handle, asset)
+    this.assets.set(handle.index, asset)
   }
 
   /**

--- a/src/asset/core/handle.js
+++ b/src/asset/core/handle.js
@@ -7,7 +7,7 @@ export class Handle {
    * @readonly
    * @type {number}
    */
-  handle
+  index
 
   /**
    * @type {T | undefined}
@@ -15,10 +15,11 @@ export class Handle {
   #placeholder
 
   /**
-   * @param {number} handle 
+   * @param {number} index 
    */
-  constructor(handle){
-    this.handle = handle
+  constructor(index){
+    this.index = index
+
 
     // so that ts does not complain about an unused property.
     if(this.#placeholder)this.#placeholder = undefined

--- a/src/render-canvas2d/plugin.js
+++ b/src/render-canvas2d/plugin.js
@@ -79,13 +79,13 @@ function renderToCanvas(world) {
       const handle = /** @type {CanvasImageMaterial} */(material).image
 
       // TODO: Does this create a new `ImageElement` every frame its image is not found? 
-      if (!textures.has(handle.handle)) {
+      if (!textures.has(handle.index)) {
         const pic = images.getByHandle(handle)
         const image = document.createElement('img')
         const blob = new Blob([pic.raw.buffer])
 
         image.src = URL.createObjectURL(blob)
-        image.onload = () => textures.set(handle.handle, image)
+        image.onload = () => textures.set(handle.index, image)
 
         return
       }
@@ -180,7 +180,7 @@ function renderText(ctx, material) {
  */
 function renderImage(ctx, material, textures) {
   const { image, width, height, frameX, frameY, divisionX, divisionY } = material
-  const texture = textures.get(image.handle)
+  const texture = textures.get(image.index)
 
   if (!texture) return
 

--- a/src/render-webgl/hooks/material.js
+++ b/src/render-webgl/hooks/material.js
@@ -43,7 +43,7 @@ export function materialAddHook(entity, world) {
   const gl = canvas.getContext('webgl2')
 
   if (!gl) return warn('WebGL 2.0 context is not created or is lost.')
-  if (renderpipelines.has(handle.handle)) return
+  if (renderpipelines.has(handle.index)) return
 
   const material = materials.getByHandle(handle)
   const vertex = createShader(gl, material.vertex(), ShaderStage.Vertex)

--- a/src/render-webgl/hooks/mesh.js
+++ b/src/render-webgl/hooks/mesh.js
@@ -34,10 +34,10 @@ export function meshAddHook(entity, world) {
   const gl = canvas.getContext('webgl2')
 
   if (!gl) return warn('WebGL 2.0 context is not created or is lost.')
-  if (meshcache.has(handle.handle)) return
+  if (meshcache.has(handle.index)) return
 
   const mesh = meshes.getByHandle(handle)
   const vao = createVAO(gl, mesh, attributeMap)
 
-  meshcache.set(handle.handle, vao)
+  meshcache.set(handle.index, vao)
 }

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -98,7 +98,7 @@ function render(world) {
     query.each(([transform, meshhandle, materialhandle]) => {
       const mesh = meshes.getByHandle(meshhandle)
       const material = materials.getByHandle(materialhandle)
-      const gpumesh = gpumeshes.get(meshhandle.handle)
+      const gpumesh = gpumeshes.get(meshhandle.index)
       const pipeline = programs.get(materialhandle.handle)
 
       // @ts-ignore


### PR DESCRIPTION
## Objective
Stated in the title.

## Solution
N/A

## Showcase
N/A

## Migration guide
```typescript
const handle = new Handle<SomeAsset>()

// before
const index = handle.handle

// after
const index = handle.index
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.