### PR TITLE
Add `Assets.getHandle`

### DIFF
--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -61,6 +61,18 @@ export class Assets {
   }
 
   /**
+   * @param {string} path 
+   * @returns {Handle<T> | undefined}
+   */
+  getHandle(path) {
+    const index = this.paths.get(path)
+
+    if (index !== undefined) return this.createHandle(index)
+
+    return undefined
+  }
+
+  /**
    * @param {Handle<T>} handle
    * @returns {T}
    */


### PR DESCRIPTION
## Objective
Adds a method to get a handle from assets using a path if the path exists.

## Solution
N/A

## Showcase
```typescript
const assets = new Assets<SomeAsset>()
const path = 'path/to/asset'

// the handle of the asset at the given path.
const handle = assets.getHandle(path)
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.