### PR TITLE
Add `Assets.getById()`

### DIFF
--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -1,3 +1,5 @@
+/** @import {AssetId} from '../types/index.js' */
+
 import { DenseList } from '../../datastructures/index.js'
 import { assert } from '../../logger/index.js'
 import { Handle } from './handle.js'
@@ -70,6 +72,14 @@ export class Assets {
     assert(asset, 'The handle provided is invalid!Did you try to create your own handle?')
 
     return asset
+  }
+
+  /**
+   * @param {AssetId} id
+   * @returns {T | undefined}
+   */
+  getById(id) {
+    return this.assets.get(id)
   }
 
   /**


### PR DESCRIPTION
## Objective
Sometimes you may need to get an asset using an `AssetId` thus this method was created.

## Solution
N/A

## Showcase
```typescript
const assets. = new Assets<SomeAsset>()
const assetid = 12 as AssetId

asset.getById(assetid)
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.