### PR TITLE
Add `Handle.id()`

### DIFF
--- a/src/asset/core/handle.js
+++ b/src/asset/core/handle.js
@@ -1,3 +1,5 @@
+/** @import {AssetId} from '../types/index.js' */
+
 /**
  * @template T
  */
@@ -22,5 +24,12 @@ export class Handle {
 
     // so that ts does not complain about an unused property.
     if(this.#placeholder)this.#placeholder = undefined
+  }
+
+  /**
+   * @returns {AssetId}
+   */
+  id(){
+    return /** @type {AssetId}*/(this.index)
   }
 }


### PR DESCRIPTION
## Objective
`Handle.id` was returns the unique identifier for the asset in the form of `AssetId`.
This is useful to get a safe hashable key that can be used in `Map`s and `Set`s as mentioned in
 - #143

## Solution
N/A

## Showcase
```typescript
const handle = new Handle<SomeAsset>(12)
const id = handle.id()

// you can now use id to do stuff like
//  1. Using it as a key to a map
const map = new Map<AssetId, SomeAsset>()

map.set(id,someAsset)

// 2. Store in a hash ser
const set = new Set<AssetId>()

set.add(id)
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.