### PR TITLE
Add resource aliases

### DIFF
--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -319,6 +319,15 @@ export class World {
 
   /**
    * @template T
+   * @param {TypeId} id 
+   * @param {Constructor<T>} alias 
+   */
+  setResourceAlias(id, alias) {
+    this.resourceAliases.set(typeid(alias), id)
+  }
+
+  /**
+   * @template T
    * @param {Constructor<T>} type
    */
   registerType(type) {

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -24,6 +24,12 @@ export class World {
 
   /**
    * @private
+   * @type {Map<TypeId,TypeId>}
+   */
+  resourceAliases = new Map()
+
+  /**
+   * @private
    * @type {TypeStore}
    */
   typestore = new TypeStore()
@@ -137,9 +143,9 @@ export class World {
     this.table.remove(archid, index)
 
     const [combinedid, combined] = this.resolveCombine(
-      idextract, 
+      idextract,
       extract,
-      ids, 
+      ids,
       components
     )
 

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -278,7 +278,7 @@ export class World {
    * @param {new (...args:any[])=>T} resourceType
    * @returns {T}
    */
-  getResource(resourceType) {    
+  getResource(resourceType) {
     return this.getResourceByTypeId(typeid(resourceType))
   }
 
@@ -290,9 +290,19 @@ export class World {
   getResourceByTypeId(id) {
     const resource = this.resources[id]
 
-    assert(resource, `The resource \`${id}\` does not exist in the world.`)
+    if (resource) {
+      return resource
+    }
 
-    return this.resources[id]
+    const aliasedid = this.resourceAliases.get(id)
+
+    assert(aliasedid, `The resource or resource alias \`${id}\` is non existent.`)
+
+    const aliasedResource = this.resources[aliasedid]
+
+    assert(aliasedResource, `The resource alias \`${id}\` points to a non-existent resource \`${aliasedid}\`.`)
+
+    return aliasedResource
   }
 
   /**


### PR DESCRIPTION
## Objective
When we have a generic resource e.g `MyResource<T>` which can contain multiple types of `T`, and we want to preserve this when setting the resource, we need to use the following methods to set and get it
```typescript
const typeid = typeidGeneric(MyResource,[Number]

world.getResourceByTypeId(typeid,new MyResource<number>())
const resource = world.getResourceByTypeId<MyResource<number>>(typeid)
```
The issue we have is when getting the resource we need to use `World.getResourceByTypeId` which poses some issues:
 - The returned type isnt guaranteed by the typesystem to be what is expected as we need to cast it.
 - The verbosity of having to get the resource.

I introduce resource aliases to fix this issue by using resource aliases.We now just use `World.getResource` with the type alias as shown in the [showcase](##Showcase)

 > [!Important]
 >  - The resource alias should be the same type as the resource being aliased otherwise it will bring about undefined behaviour.
 >  - The alias should extend the resource being aliased without extra properties or methods added to it.
 >
 > All of the above are not enforced hence be careful when setting resource aliases.

## Solution
N/A

## Showcase
This example shows how we use resource aliases.
```typescript
class MyResource<T> {}
class MyNumberResource extends MyResource<number> {}
class MyStringResource extends MyResource<string> {}

const world = new World()
const id1 = typeidGeneric(MyResource,[Number])
const id2 = typeidGeneric(MyResource,[String])

// we register the resources here
world.setResourceByTypeId(id1, new MyResource<number>())
world.setResourceByTypeId(id2, new MyResource<string>())

// we can now set the alias here
world.setResourceAlias(id1, MyNumberResource)
world.setResourceAlias(id2, MyStringResource)

// we get the resource now through the alias
const resource1 = world.getResource(MyNumberResource)
const resource2 = world.getResource(MyStringResource)
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.