### PR TITLE
Nominally type `TypeId`

### DIFF
--- a/src/reflect/core/typeid.js
+++ b/src/reflect/core/typeid.js
@@ -5,7 +5,7 @@
  * @returns {TypeId}
  */
 export function typeid(type) {
-  return type.name
+  return /** @type {TypeId}*/(type.name)
 }
 
 /**

--- a/src/reflect/core/typeid.js
+++ b/src/reflect/core/typeid.js
@@ -12,7 +12,7 @@ export function typeid(type) {
  * @template T
  * @template {Constructor[]} U
  * @param {Constructor<T>} type 
- * @param {U} types
+ * @param {[...U]} types
  * @returns {TypeId}
  */
 export function typeidGeneric(type, types) {
@@ -23,10 +23,10 @@ export function typeidGeneric(type, types) {
   let name = `${type.name}<`
   
   for (let i = 0; i < types.length - 1; i++) {
-    name += `${types[i]},`
+    name += `${types[i].name},`
   }
 
   name += `${types[types.length - 1].name}>`
  
-  return name
+  return /** @type {TypeId}*/(name)
 }

--- a/src/reflect/types/typeid.js
+++ b/src/reflect/types/typeid.js
@@ -1,4 +1,4 @@
 /**
- * @typedef {string} TypeId
+ * @typedef {string & { __brand:'TypeId' }} TypeId
  */
 export default {}


### PR DESCRIPTION
## Objective
This prevents any other type from being assigned to it.
This is helpful in enforcing type invariance for functions/classes using it.

## Solution
N/A

## Showcase
N/A

## Migration guide
You can no longer assign a string to a `TypeId`.
```typescript
// Will throw a type error
const id:TypeId = "myid"
```
 > [!Note]
 > This is upheld by typescript and not enforced in runtime.

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.