### PR TITLE
Resolve duplicate component entries

### DIFF
--- a/src/ecs/tables/archetypetable.js
+++ b/src/ecs/tables/archetypetable.js
@@ -71,6 +71,15 @@ export class ArchetypeTable {
   }
 
   /**
+   * @private
+   * @param {TypeId[]} ids
+   * @returns {number}
+   */
+  getActualCompSize(ids){
+    return new Set(ids).size
+  }
+
+  /**
    * @param {ArchetypeId} id
    * @returns {Archetype | undefined}
    */

--- a/src/ecs/tables/archetypetable.js
+++ b/src/ecs/tables/archetypetable.js
@@ -61,7 +61,7 @@ export class ArchetypeTable {
    * @returns {boolean} 
    */
   archetypeHasOnly(archetype, comps) {
-    if (comps.length !== archetype.components.size) return false
+    if (this.getActualCompSize(comps) !== archetype.components.size) return false
 
     for (let i = 0; i < comps.length; i++) {
       if (!archetype.components.has(comps[i])) return false


### PR DESCRIPTION
## Objective
When a prefab with duplicate components e.g `[Position2D,Position2D]` is spawned/inserted into an entity, the archetype table does not resolve the components's as the same type.This causes a new archetype to be created which has multiple columns for the same component type.

This fixes the issue as shown in the solution.

## Solution
Ensure that unique component types are used to resolve an archetype.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.