### PR TITLE
Validate parent-children hierarchies

### DIFF
--- a/src/hierarchy/hooks/index.js
+++ b/src/hierarchy/hooks/index.js
@@ -66,6 +66,9 @@ export function addSelfToChildren(entity, world) {
     const child = children.list[i]
     const parent = world.get(child, Parent)
 
+    if(child.equals(entity)){
+      throws(`THe entity ${entity.id()} cannot be its own parent!`)
+    }
     if (!parent) {
       world.insert(child, [new Parent(entity)])
     } else {


### PR DESCRIPTION
## Objective
Ensures that an entity cannot be its own child or parent by throwing an error if the condition is true.

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.