### PR TITLE
Ensure buttons cannot be released if not previously pressed.

### DIFF
--- a/src/input-core/core/buttons.js
+++ b/src/input-core/core/buttons.js
@@ -36,8 +36,9 @@ export class Buttons {
    * @param {T} button
    */
   release(button) { 
-    this.innerJustReleased.add(button)
-    this.innerPressed.delete(button)
+    if(this.innerPressed.delete(button)){
+      this.innerJustReleased.add(button)
+    }
   }
 
   /**


### PR DESCRIPTION
## Objective
Adds a condition whereby a button cannot be released if it were not pressed before.

## Solution
Check to see if button is pressed before releasing it.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.