### PR TITLE
Adjust default damping settings.

### DIFF
--- a/src/damping/plugin.js
+++ b/src/damping/plugin.js
@@ -9,8 +9,8 @@ export class Damping2DPlugin extends Plugin {
    */
   register(app) {
     app
-      .setResource(new Linear2DDamping(0.99))
-      .setResource(new Angular2DDamping(0.99))
+      .setResource(new Linear2DDamping(0.01))
+      .setResource(new Angular2DDamping(0.01))
       .registerSystem(AppSchedule.Update, dampenVelocity2D)
       .registerSystem(AppSchedule.Update, dampenRotation2D)
   }

--- a/src/damping/plugin.js
+++ b/src/damping/plugin.js
@@ -23,8 +23,8 @@ export class Damping3DPlugin extends Plugin {
    */
   register(app) {
     app
-      .setResource(new Linear3DDamping(0.9))
-      .setResource(new Angular3DDamping(0.9))
+      .setResource(new Linear3DDamping(0.01))
+      .setResource(new Angular3DDamping(0.01))
       .registerSystem(AppSchedule.Update, dampenVelocity3D)
       .registerSystem(AppSchedule.Update, dampenRotation3D)
   }


### PR DESCRIPTION
## Objective
Adjusts the damping for linear and angular velocity in two and three dimensions to `0.01` as the previous value was too high that it caused entities to experience high drag.

## Solution
Reduced damping coefficient.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.