### PR TITLE
Fix inconsistent children despawn.

### DIFF
--- a/src/hierarchy/hooks/index.js
+++ b/src/hierarchy/hooks/index.js
@@ -84,7 +84,8 @@ export function despawnChildren(entity, world) {
     return
   }
 
-  for (let i = 0; i < children.list.length; i++) {
+  // Do not change this loop as children are despawned.
+  for (let i = children.list.length - 1; i >= 0; i--) {
     const child = children.list[i]
 
     world.remove(child)


### PR DESCRIPTION
## Objective
Children of an entity are despawned in an inconsistent manner i.e some children remain in the world although are supposed to be despawned.

This is a subtle bug caused by removing a child from the parent's `Children` when iterating over it.

## Solution
Despawn children starting from the last one.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.