### PR TITLE
Fix euler integration of torque into rotation in 3d

### DIFF
--- a/src/integrator/systems/euler.js
+++ b/src/integrator/systems/euler.js
@@ -90,8 +90,7 @@ export function updateAngularEuler3D(world) {
   query.each(([rotation, torque]) => {
     const temp = Vector3.multiplyScalar(torque, dt)
 
-
-    rotation.multiply(temp)
+    rotation.add(temp)
     torque.set(0, 0, 0)
   })
 }


### PR DESCRIPTION
## Objective
The issue of 3d entities not rotating was due to incorrectly integrating torque into rotation.

## Solution
Proper integration is done by adding the rotation resulting from torque instead of multiplying with the entity's rotation.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.