### PR TITLE
Update `Windows` to use `EntityId`

### DIFF
--- a/src/window/resources/windows.js
+++ b/src/window/resources/windows.js
@@ -1,4 +1,4 @@
-/** @import {Entity} from '../../ecs/index.js'*/
+/** @import {Entity,EntityId} from '../../ecs/index.js'*/
 
 import { assert } from '../../logger/index.js'
 
@@ -6,7 +6,7 @@ export class Windows {
 
   /**
    * @private
-   * @type {Map<number,HTMLCanvasElement>}
+   * @type {Map<EntityId,HTMLCanvasElement>}
    */
   entities = new Map()
 
@@ -15,7 +15,7 @@ export class Windows {
    * @returns {HTMLCanvasElement}
    */
   getWindow(entity){
-    const window = this.entities.get(entity.index)
+    const window = this.entities.get(entity.id())
     
     assert(window, 'the provided window entity does not have a corresponding canvas element.')
 
@@ -27,13 +27,13 @@ export class Windows {
    * @param {HTMLCanvasElement} window
    */
   setWindow(entity, window){
-    this.entities.set(entity.index, window)
+    this.entities.set(entity.id(), window)
   }
   
   /**
    * @param {Entity} entity
    */
   delete(entity){
-    this.entities.delete(entity.index)
+    this.entities.delete(entity.id())
   }
 }


### PR DESCRIPTION
## Objective
Uses the hashable alternative of `Entity` to store canvases backing windows.

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.