### PR TITLE
Make `Window.getWindow` fallable

### DIFF
--- a/src/physics/systems/debugger.js
+++ b/src/physics/systems/debugger.js
@@ -81,6 +81,9 @@ export function drawVelocity(world) {
   const window = /** @type {[Entity,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
+
+  if (!canvas) return
+
   const ctx = canvas.getContext('2d')
 
   if (!ctx) return

--- a/src/physics/systems/debugger.js
+++ b/src/physics/systems/debugger.js
@@ -18,6 +18,9 @@ export function drawBounds(world) {
   const window = /** @type {[Entity,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
+
+  if (!canvas) return
+
   const ctx = canvas.getContext('2d')
 
   if (!ctx) return

--- a/src/physics/systems/debugger.js
+++ b/src/physics/systems/debugger.js
@@ -187,10 +187,13 @@ export function drawContacts(world) {
   const window = /** @type {[Entity,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
+
+  if(!canvas) return
+
   const ctx = canvas.getContext('2d')
 
   if (!ctx) return
-  
+
 
   for (let i = 0; i < clmd.length; i++) {
     const [p1, p2] = clmd[i].contactData.contactPoints

--- a/src/physics/systems/debugger.js
+++ b/src/physics/systems/debugger.js
@@ -150,6 +150,9 @@ export function drawArms(world) {
   const window = /** @type {[Entity,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
+
+  if(!canvas) return
+
   const ctx = canvas.getContext('2d')
 
   if (!ctx) return

--- a/src/physics/systems/debugger.js
+++ b/src/physics/systems/debugger.js
@@ -54,6 +54,9 @@ export function drawPosition(world) {
   const window = /** @type {[Entity,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
+
+  if (!canvas) return
+
   const ctx = canvas.getContext('2d')
 
   if (!ctx) return

--- a/src/physics/systems/debugger.js
+++ b/src/physics/systems/debugger.js
@@ -106,6 +106,9 @@ export function drawShapes(world) {
   const window = /** @type {[Entity,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
+
+  if(!canvas) return
+
   const ctx = canvas.getContext('2d')
 
   if (!ctx) return

--- a/src/render-canvas2d/plugin.js
+++ b/src/render-canvas2d/plugin.js
@@ -50,6 +50,9 @@ function renderToCanvas(world) {
   if (!camera) return warn('Please add a camera to the scene.')
 
   const canvas = canvases.getWindow(window[0])
+
+  if(!canvas) return
+
   const ctx = canvas.getContext('2d')
 
   const offsetX = window[1].getWidth() / 2
@@ -82,6 +85,9 @@ function renderToCanvas(world) {
       // TODO: Does this create a new `ImageElement` every frame its image is not found? 
       if (!textures.has(handle.index)) {
         const pic = images.getByHandle(handle)
+
+        if(!pic) return
+
         const image = document.createElement('img')
         const blob = new Blob([pic.raw.buffer])
 

--- a/src/render-webgl/hooks/material.js
+++ b/src/render-webgl/hooks/material.js
@@ -38,6 +38,9 @@ export function materialAddHook(entity, world) {
 
   /** @type {HTMLCanvasElement}*/
   const canvas = canvases.getWindow(window[0])
+
+  if(!canvas) return
+
   const gl = canvas.getContext('webgl2')
 
   if (!gl) return warn('WebGL 2.0 context is not created or is lost.')
@@ -55,5 +58,5 @@ export function materialAddHook(entity, world) {
 
   validateProgram(gl, program)
   pipe.init(gl, ubos)
-  renderpipelines.set(handle.handle, pipe)
+  renderpipelines.set(handle.index, pipe)
 }

--- a/src/render-webgl/hooks/mesh.js
+++ b/src/render-webgl/hooks/mesh.js
@@ -6,6 +6,7 @@ import { createVAO } from '../core/function.js'
 import { MainWindow, Windows, Window } from '../../window/index.js'
 import { warn } from '../../logger/index.js'
 import { MeshCache, AttributeMap } from '../resources/index.js'
+import { typeidGeneric } from '../../reflect/index.js'
 
 // TODO - In the future,use the `AssetAdded` event to build gpu representation instead
 
@@ -19,10 +20,10 @@ export function meshAddHook(entity, world) {
   const attributeMap = world.getResource(AttributeMap)
 
   /** @type {Assets<Mesh>} */
-  const meshes = world.getResourceByTypeId('assets<mesh>')
+  const meshes = world.getResourceByTypeId(typeidGeneric(Assets, [Mesh]))
 
   /** @type {MeshCache<WebGLVertexArrayObject>} */
-  const meshcache = world.getResourceByTypeId('meshcache')
+  const meshcache = world.getResource(MeshCache)
   const windows = new Query(world, [Entity, Window, MainWindow])
   const canvases = world.getResource(Windows)
 
@@ -31,6 +32,9 @@ export function meshAddHook(entity, world) {
   if (!window) return warn('Please define the main window for rendering.')
 
   const canvas = canvases.getWindow(window[0])
+
+  if(!canvas) return
+
   const gl = canvas.getContext('webgl2')
 
   if (!gl) return warn('WebGL 2.0 context is not created or is lost.')

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -174,10 +174,15 @@ function registerBuffers(world) {
 
   /** @type {HTMLCanvasElement}*/
   const canvas = canvases.getWindow(window[0])
+
+  if (!canvas) return
+
   const gl = canvas.getContext('webgl2')
 
   if (!gl) return warn('WebGL 2.0 context is not created or is lost.')
 
-  ubos.create(gl, 'Camera', 128)
+  if (!ubos.get('Camera'))
+    ubos.create(gl, 'Camera', 128)
+  if (!ubos.get('WebglBasicMaterial'))
   ubos.create(gl, 'WebglBasicMaterial', 32)
 }

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -25,9 +25,9 @@ export class WebglRendererPlugin extends Plugin {
       .setResource(new UBOCache())
       .setResource(new ClearColor())
       .setResource(attribute)
+      .registerSystem(AppSchedule.Update, registerBuffers)
       .registerSystem(AppSchedule.Update, render)
       .registerSystem(AppSchedule.Update, resizegl)
-      .registerSystem(AppSchedule.Startup, registerBuffers)
       .setComponentHooks(MaterialHandle, new ComponentHooks(materialAddHook))
       .setComponentHooks(MeshHandle, new ComponentHooks(meshAddHook))
   }

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -77,13 +77,16 @@ function render(world) {
   if (!window) return warn('Please define the main window for rendering.')
 
   const canvas = canvases.getWindow(window[0])
+
+  if (!canvas) return
+
   const gl = canvas.getContext('webgl2')
 
   if (!gl) return warn('WebGL 2.0 context is not created or is lost.')
 
   gl.clearColor(clearColor.r, clearColor.g, clearColor.b, clearColor.a)
   gl.clear(gl.COLOR_BUFFER_BIT)
-  
+
   cameras.each(([transform, camera]) => {
     const projection = camera.projectionMatrix()
     const cameraUniform = ubos.get('Camera')
@@ -100,7 +103,7 @@ function render(world) {
       const mesh = meshes.getByHandle(meshhandle)
       const material = materials.getByHandle(materialhandle)
       const gpumesh = gpumeshes.get(meshhandle.index)
-      const pipeline = programs.get(materialhandle.handle)
+      const pipeline = programs.get(materialhandle.index)
 
       // @ts-ignore
       // SAFETY: BasicMaterial has the method.
@@ -108,7 +111,7 @@ function render(world) {
       const data = material.asUniformBind()
       const ubo = ubos.get(material.constructor.name)
 
-      assert(ubo, `The uniform buffer for material '${material.constructor.name}' is not set up.` )
+      assert(ubo, `The uniform buffer for material '${material.constructor.name}' is not set up.`)
 
       gl.useProgram(pipeline.program)
       pipeline.setUniformMatrix3x4(gl, 'model', transform)
@@ -117,14 +120,14 @@ function render(world) {
       gl.bindVertexArray(gpumesh)
 
       const indices = mesh.getIndices()
-      
+
       if (indices) {
         gl.drawElements(gl.TRIANGLES, indices.length, gl.UNSIGNED_SHORT, 0)
       } else {
         const positions = mesh.getAttribute('position3d')
-        
+
         if (positions === undefined) return
-  
+
         const count = positions.data.length
 
         gl.drawArrays(gl.TRIANGLES, 0, count / 3)

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -150,6 +150,9 @@ function resizegl(world) {
   if (!window) return
 
   const canvas = canvases.getWindow(window[0])
+
+  if (!canvas) return
+
   const gl = canvas.getContext('webgl2')
 
   if (!gl) return

--- a/src/window-dom/hooks/window.js
+++ b/src/window-dom/hooks/window.js
@@ -49,6 +49,7 @@ export function closeWindow(entity, world) {
   const windows = world.getResource(Windows)
   const canvas = windows.getWindow(entity)
   
+  if(!canvas) return
   canvas.remove()
   windows.delete(entity)
 }

--- a/src/window-dom/systems/executeCommands.js
+++ b/src/window-dom/systems/executeCommands.js
@@ -15,6 +15,7 @@ export function executeWindowCommands(world) {
   for (let i = 0; i < buffer.length; i++) {
     const command = buffer[i]
     const canvas = canvases.getWindow(command.entity)
+    if(!canvas) return
     const [window] = /** @type {[Window]} */(windows.get(command.entity))
 
     execute(command, canvas, window)

--- a/src/window/resources/windows.js
+++ b/src/window/resources/windows.js
@@ -12,13 +12,11 @@ export class Windows {
 
   /**
    * @param {Entity} entity
-   * @returns {HTMLCanvasElement}
+   * @returns {HTMLCanvasElement | undefined}
    */
   getWindow(entity){
     const window = this.entities.get(entity.id())
     
-    assert(window, 'the provided window entity does not have a corresponding canvas element.')
-
     return window
   }
 


### PR DESCRIPTION
## Objective
The method shpuld not throw an error when the window isn't available.

## Solution
N/A

## Showcase
N/A

## Migration guide
You now have to check if the returned value is undefined.
```typescript
const windows = new Windows()
const window = windows.getWindow(entity)

// before
window.getContext('2d')

// after
if(window) {
  window.getContext('2d')
}
```

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.