### PR TITLE
Remove `Dimension`

### DIFF
--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -47,15 +47,3 @@ export function swapRemove(arr, index) {
  * @param {T} _args
  */
 export function noop(..._args){}
-
-/**
- * Represents the dimension.
- * 
- * @readonly
- * @enum {number}
- */
-export const Dimension = {
-  Both:0,
-  Two:1,
-  Three:2
-}


### PR DESCRIPTION
## Objective
No longer needed as plugins are now split to 2d and 3d versions.

## Solution
N/A

## Showcase
N/A

## Migration guide
Remove all uses of `Dimension`

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.