### PR TITLE
Add `Device.isMobile`

### DIFF
--- a/src/device/resources/device.js
+++ b/src/device/resources/device.js
@@ -24,6 +24,13 @@ export class Device {
    * @type {Browser}
    */
   browser = Browser.Unknown
+
+  isMobile() {
+    return (
+      this.platform === PlatformOS.Android ||
+      this.platform === PlatformOS.Ios
+    )
+  }
 }
 
 export class DeviceCapabilities {


### PR DESCRIPTION
## Objective
Add a method to check if the current device is a mobile device.

## Solution
N/A

## Showcase
```typescript
const device = new Device()

if(device.isMobile()) {
  // do something related to mobile
}
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.