### PR TITLE
Add `Device.isPc`

### DIFF
--- a/src/device/resources/device.js
+++ b/src/device/resources/device.js
@@ -31,6 +31,14 @@ export class Device {
       this.platform === PlatformOS.Ios
     )
   }
+
+  isPc() {
+    return (
+      this.platform === PlatformOS.Linux ||
+      this.platform === PlatformOS.Mac ||
+      this.platform === PlatformOS.Windows
+    )
+  }
 }
 
 export class DeviceCapabilities {


### PR DESCRIPTION
## Objective
Add a method to check if the current device is a personal computer device.

## Solution
N/A

## Showcase
```typescript
const device = new Device()

if(device.isPc()) {
  // do something related to mobile
}
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.