### PR TITLE
Add all non conficting plugins to `DefaultPlugin`

### DIFF
--- a/src/misc/plugin.js
+++ b/src/misc/plugin.js
@@ -1,7 +1,21 @@
-import { Transform2DPlugin, Transform3DPlugin } from '../transform/index.js'
 import { App, Plugin } from '../app/index.js'
-import { TimePlugin } from '../time/index.js'
 import { ProfilerPlugin } from '../profiler/index.js'
+import { AudioPlugin } from '../audio/index.js'
+import { CommandsPlugin } from '../command/index.js'
+import { Damping2DPlugin, Damping3DPlugin } from '../damping/index.js'
+import { DevicePlugin } from '../device/index.js'
+import { Gravity2DPlugin, Gravity3DPlugin } from '../gravity/index.js'
+import { HierarchyPlugin } from '../hierarchy/index.js'
+import { InputPlugin } from '../input/index.js'
+import { EulerIntegrator2DPlugin, EulerIntegrator3DPlugin } from '../integrator/index.js'
+import { Movable2DPlugin, Movable3DPlugin } from '../movable/index.js'
+import { Physics2DPlugin } from '../physics/index.js'
+import { RenderCorePlugin } from '../render-core/index.js'
+import { StoragePlugin } from '../storage/index.js'
+import { TimePlugin } from '../time/index.js'
+import { Transform2DPlugin, Transform3DPlugin } from '../transform/index.js'
+import { DefaultTweenPlugin } from '../tween/index.js'
+import { WindowPlugin } from '../window/index.js'
 
 export class DefaultPlugin extends Plugin {
 
@@ -10,9 +24,27 @@ export class DefaultPlugin extends Plugin {
    */
   register(app) {
     app
+      .registerPlugin(new TimePlugin())
+      .registerPlugin(new DevicePlugin())
+      .registerPlugin(new StoragePlugin())
+      .registerPlugin(new AudioPlugin())
+      .registerPlugin(new InputPlugin())
+      .registerPlugin(new HierarchyPlugin())
+      .registerPlugin(new Movable2DPlugin())
+      .registerPlugin(new Movable3DPlugin())
+      .registerPlugin(new Gravity2DPlugin())
+      .registerPlugin(new Gravity3DPlugin())
+      .registerPlugin(new Physics2DPlugin())
+      .registerPlugin(new Damping2DPlugin())
+      .registerPlugin(new Damping3DPlugin())
+      .registerPlugin(new DefaultTweenPlugin())
       .registerPlugin(new Transform2DPlugin())
       .registerPlugin(new Transform3DPlugin())
-      .registerPlugin(new TimePlugin())
+      .registerPlugin(new EulerIntegrator2DPlugin())
+      .registerPlugin(new EulerIntegrator3DPlugin())
       .registerPlugin(new ProfilerPlugin())
+      .registerPlugin(new RenderCorePlugin())
+      .registerPlugin(new WindowPlugin())
+      .registerPlugin(new CommandsPlugin())
   }
 }


### PR DESCRIPTION
## Objective
Adds all plugins which do not confict with each other to `DefaultPlugin`. The plugin should encompass most (if not all) capabilities provided by the engine.

## Solution
N/A

## Showcase
You can now use the plugin to register core plugins without registering them one by one.
```typescript
const app = new App()
  .registerPlugin(new DefaultPlugin())
  .run()
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.