### PR TITLE
Implement `BasicMaterial` on canvas2d.

### DIFF
--- a/src/render-canvas2d/core/index.js
+++ b/src/render-canvas2d/core/index.js
@@ -1,1 +1,2 @@
 export * from './materialtype.js'
+export * from './materialFuncs.js'

--- a/src/render-canvas2d/core/materialFuncs.js
+++ b/src/render-canvas2d/core/materialFuncs.js
@@ -1,0 +1,21 @@
+/** @import { Canvas2DFunction } from '../types/index.js' */
+
+import { BasicMaterial } from '../../render-core/index.js'
+import { vertices } from '../utils.js'
+
+/**
+ * @type {Canvas2DFunction<BasicMaterial>}
+ */
+export function renderBasicMaterial(ctx, material, mesh) {
+  const { color } = material
+  const positions = mesh.getAttribute('position2d')?.data
+
+  if (!positions) return
+
+  ctx.fillStyle = `rgb(${color.r * 255},${color.g * 255},${color.b * 255})`
+
+  // ctx.globalAlpha = color.a
+
+  vertices(ctx, positions, true)
+  ctx.fill()
+}

--- a/src/render-canvas2d/plugin.js
+++ b/src/render-canvas2d/plugin.js
@@ -1,14 +1,15 @@
 import { Assets } from '../asset/index.js'
 import { Entity, Query, World } from '../ecs/index.js'
 import { App, AppSchedule, Plugin } from '../app/index.js'
-import { Mesh, Material, TextureCache, Camera, MeshHandle, MaterialHandle, Image } from '../render-core/index.js'
+import { Mesh, Material, TextureCache, Camera, MeshHandle, MaterialHandle, BasicMaterial, Image } from '../render-core/index.js'
 import { MainWindow, Window, Windows } from '../window/index.js'
 import { warn } from '../logger/index.js'
 import { vertices } from './utils.js'
 import { GlobalTransform2D } from '../transform/index.js'
-import { MaterialType } from './core/index.js'
+import { MaterialType, renderBasicMaterial } from './core/index.js'
 import { CanvasImageMaterial, CanvasMeshedMaterial, CanvasTextMaterial } from './assets/materials/index.js'
 import { typeid, typeidGeneric } from '../reflect/index.js'
+import { Canvas2DMaterialPlugin } from './plugins/index.js'
 
 export class Canvas2DRendererPlugin extends Plugin{
 
@@ -19,6 +20,10 @@ export class Canvas2DRendererPlugin extends Plugin{
     app
       .setResource(new TextureCache())
       .registerSystem(AppSchedule.Update, renderToCanvas)
+      .registerPlugin(new Canvas2DMaterialPlugin({
+        material:BasicMaterial,
+        update:renderBasicMaterial
+      }))
   }
 }
 


### PR DESCRIPTION
## Objective
Renders entities with `BasicMaterial` onto a canvas using 2d context.
Only works with 2d entities.


## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.