### PR TITLE
Implement `BasicMaterial` rendering on webgl

### DIFF
--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -4,11 +4,13 @@ import { ComponentHooks, Entity, Query, World } from '../ecs/index.js'
 import { Events } from '../event/index.js'
 import { assert, warn } from '../logger/index.js'
 import { typeid, typeidGeneric } from '../reflect/index.js'
-import { MeshAttribute, Camera, Material, MaterialHandle, Mesh, MeshHandle, ProgramCache, Meshed } from '../render-core/index.js'
+import { MeshAttribute, Camera, Material, MaterialHandle, Mesh, MeshHandle, ProgramCache, BasicMaterial, Meshed } from '../render-core/index.js'
 import { GlobalTransform3D } from '../transform/index.js'
 import { MainWindow, Window, WindowResize, Windows } from '../window/index.js'
 import { materialAddHook, meshAddHook, meshAddHook2 } from './hooks/index.js'
+import { WebglMaterialPlugin } from './plugins/index.js'
 import { AttributeMap, ClearColor, MeshCache, UBOCache, WebglProgramCache } from './resources/index.js'
+import { basicMaterial3DFragment, basicMaterial3DVertex } from './shaders/index.js'
 
 export class WebglRendererPlugin extends Plugin {
 
@@ -32,6 +34,11 @@ export class WebglRendererPlugin extends Plugin {
       .registerSystem(AppSchedule.Update, registerBuffers)
       .registerSystem(AppSchedule.Update, render)
       .registerSystem(AppSchedule.Update, resizegl)
+      .registerPlugin(new WebglMaterialPlugin({
+        material: BasicMaterial,
+        vertex3d: basicMaterial3DVertex,
+        fragment3d: basicMaterial3DFragment
+      }))
   }
 }
 

--- a/src/render-webgl/shaders/basic.js
+++ b/src/render-webgl/shaders/basic.js
@@ -1,0 +1,17 @@
+export const basicMaterial3DVertex =
+  `#version 300 es
+#pragma vscode_glsllint_stage: vert
+precision mediump float;
+
+in vec3 position3d;
+
+uniform Camera {
+  mat4 view;
+  mat4 projection;
+} camera;
+uniform mat3x4 model;
+
+void main(){
+  gl_Position = camera.projection * camera.view * transpose(mat4(model)) * vec4(position3d,1.0);
+}
+`

--- a/src/render-webgl/shaders/basic.js
+++ b/src/render-webgl/shaders/basic.js
@@ -15,3 +15,20 @@ void main(){
   gl_Position = camera.projection * camera.view * transpose(mat4(model)) * vec4(position3d,1.0);
 }
 `
+export const basicMaterial3DFragment =
+  `#version 300 es
+#pragma vscode_glsllint_stage: frag
+precision mediump float;
+
+uniform BasicMaterial {
+  vec4 color;
+} material;
+
+out vec4 output_color;
+
+void main(){
+  vec4 base_color = material.color;
+  
+  output_color = vec4(base_color.rgb,1.0);
+}
+`

--- a/src/render-webgl/shaders/index.js
+++ b/src/render-webgl/shaders/index.js
@@ -1,2 +1,3 @@
 export * from './basic_vertex.js'
 export * from './basic_fragment.js'
+export * from './basic.js'


### PR DESCRIPTION
## Objective
Renders entities with `BasicMaterial` onto a canvas using WebGL.
Only works with 3d entities but will be extended to 2d in the future.

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.