### PR TITLE
Add typestore getorset methods

### DIFF
--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -1,4 +1,3 @@
-/** @import { ComponentId } from './typedef/index.js'*/
 /** @import { Constructor, TypeId } from '../reflect/index.js'*/
 
 import { ArchetypeTable } from './tables/index.js'
@@ -350,9 +349,10 @@ export class World {
    * @param {ComponentHooks} hooks
    */
   setComponentHooks(component, hooks) {
-    const info = this.typestore.get(component)
+    const id = this.typestore.getOrSet(component)
+    const info = this.typestore.getById(id)
 
-    assert(info, `The component "${component.name}" has not been registered.Use \`World.registerType()\` to add it.`)
+    assert(info, `Internal error:The component "${component.name}" has not been registered somehow.`)
     info.setHooks(hooks)
   }
 

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -106,6 +106,15 @@ export class TypeStore {
   }
 
   /**
+   * @template T
+   * @param {Constructor<T>} component
+   * @returns {number}
+   */
+  getOrSet(component){
+    return this.getOrSetByTypeId(typeid(component))
+  }
+
+  /**
    * @param {TypeId} typeid
    */
   getOrSetByTypeId(typeid){

--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -106,6 +106,13 @@ export class TypeStore {
   }
 
   /**
+   * @param {TypeId} typeid
+   */
+  getOrSetByTypeId(typeid){
+    return this.getIdByTypeId(typeid) || this.setByTypeId(typeid)
+  }
+
+  /**
    * @returns {Iterable<ComponentInfo>}
    */
   getInfos(){


### PR DESCRIPTION
## Objective
Adds the ability to set a type into a `TypeStore` if it isn't there when getting its information.

## Solution
N/A

## Showcase
```typescript
class MyType {}
const typestore = new TypeStore()

const id = typestore.getOrSet(MyType)
// or this
const id = typestore.getOrSetByTypeId(typeid((MyType))
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.