### PR TITLE
Add a pluginregistry to `App`

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -153,7 +153,7 @@ export class App {
    * @param {Plugin} plugin
    */
   registerPlugin(plugin) {
-    plugin.register(this)
+    this.plugins.add(plugin)
 
     return this
   }

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -11,6 +11,49 @@ import { typeid } from '../reflect/index.js'
 
 const registererror = 'Systems, plugins or resources should be registered or set before `App().run()`'
 
+export class PluginRegistry {
+
+  /**
+   * @type {Plugin[]}
+   */
+  list = []
+
+  /**
+   * @type {Set<TypeId>}
+   */
+  names = new Set()
+
+  /**
+   * @param {Plugin} plugin
+   */
+  add(plugin) {
+    this.list.push(plugin)
+    this.names.add(plugin.name())
+  }
+
+  /**
+   * @param {TypeId} plugin
+   */
+  hasTypeId(plugin) {
+    this.names.has(plugin)
+  }
+
+  /**
+   * @param {Plugin} plugin
+   */
+  has(plugin) {
+    this.hasTypeId(plugin.name())
+  }
+
+  /**
+   * @param {App} app 
+   */
+  register(app){
+    for (let i = 0; i < this.list.length; i++) {
+      this.list[i].register(app)
+    }
+  }
+}
 export class App {
 
   /**

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -58,6 +58,12 @@ export class App {
 
   /**
    * @private
+   * @type {PluginRegistry}
+   */
+  plugins = new PluginRegistry()
+
+  /**
+   * @private
    * @type {World}
    */
   world = new World()

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,5 +1,4 @@
 /** @import { SystemFunc } from '../ecs/index.js' */
-/** @import { HandleProvider, Parser } from '../asset/index.js' */
 /** @import { Constructor,TypeId } from '../reflect/index.js'*/
 
 import { World, Scheduler, Executor, ComponentHooks, RAFExecutor, ImmediateExecutor } from '../ecs/index.js'
@@ -136,7 +135,7 @@ export class App {
 
     for (let i = 0; i < this.systemsevents.length; i++) {
       const ev = this.systemsevents[i]
-
+      
       this.systemBuilder.add(ev)
     }
 
@@ -213,12 +212,12 @@ export class Plugin {
   /**
    * @param {App} _app
    */
-  register(_app){}
+  register(_app) { }
 
   /**
    * @returns {TypeId}
    */
-  name(){
+  name() {
 
     // SAFETY: `this.constructor` can be casted into a `Contructor`
     return typeid(/** @type {Constructor}*/(this.constructor))

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -132,7 +132,7 @@ export class App {
    * @returns {this}
    */
   run() {
-    this.initialized = true
+    this.plugins.register(this)
 
     for (let i = 0; i < this.systemsevents.length; i++) {
       const ev = this.systemsevents[i]
@@ -144,6 +144,7 @@ export class App {
 
     this.systemBuilder.pushToScheduler(this.scheduler)
     this.scheduler.run(this.world)
+    this.initialized = true
 
     return this
   }


### PR DESCRIPTION
## Objective
An app currently does not store what plugins have been registered onto it but treats them like throwaway objects that can be garbage collected after they have been registered.This is quite limiting as there is no way to add some features which require that the plugins be stored.

Introducing the `PluginRegistry` which stores the plugins registered into an app.This allows the app to do more operations on the plugins other than just registering them.

### Future Work
 - Add a way for plugins require other plugins.
 - Ensure unique plugins are registered only once.
 - Add a method to check which plugins have been registered.
 - Add plugin cleanup after registration.
 - Add a method to do operations after the plugin has been registered.

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.