### PR TITLE
Prevent overwriting `TypeStore` when setting types

### DIFF
--- a/src/ecs/typestore.js
+++ b/src/ecs/typestore.js
@@ -34,6 +34,10 @@ export class TypeStore {
    * @returns {ComponentId}
    */
   setByTypeId(id){
+    const hasid = this.map.get(id)
+
+    if(hasid) return hasid
+
     const compId = this.list.length
 
     this.map.set(id, compId)


### PR DESCRIPTION
## Objective
When setting of a component type in a `TypeStore` multiple times, the component's info is overwritten with the new one thus completely throws away whatever was registered into the info, for example the component hooks.

This seeks to solve that issue.

## Solution
Early return when the component type is already registered when setting it.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.