### PR TITLE
Change some math constants

### DIFF
--- a/src/math/constants.js
+++ b/src/math/constants.js
@@ -2,6 +2,6 @@ export const { PI } = Math
 export const TAU = Math.PI * 2
 export const HALF_PI = Math.PI / 2
 export const DEG2RAD = Math.PI / 180
-export const epilson = 0.0000001
 export const RAD2DEG = 180 / Math.PI
+export const epilson = 0.0000001
 export const SQRT2 = Math.sqrt(2)

--- a/src/math/constants.js
+++ b/src/math/constants.js
@@ -1,5 +1,5 @@
 export const { PI } = Math
-export const TWO_PI = Math.PI * 2
+export const TAU = Math.PI * 2
 export const HALF_PI = Math.PI / 2
 export const DEG2RAD = Math.PI / 180
 export const epilson = Math.pow(2, -53)

--- a/src/math/constants.js
+++ b/src/math/constants.js
@@ -2,6 +2,6 @@ export const { PI } = Math
 export const TAU = Math.PI * 2
 export const HALF_PI = Math.PI / 2
 export const DEG2RAD = Math.PI / 180
-export const epilson = Math.pow(2, -53)
+export const epilson = 0.0000001
 export const RAD2DEG = 180 / Math.PI
 export const SQRT2 = Math.sqrt(2)


### PR DESCRIPTION
## Objective
 - Changes `epilson` to be greater than it used to be.
 - Renames `TWO_PI` to `TAU`

## Solution
N/A

## Showcase
N/A

## Migration guide
Update accordingly.

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.