### PR TITLE
Fix `invert` method of matrices not modifying calling object.

### DIFF
--- a/src/math/matrix2.js
+++ b/src/math/matrix2.js
@@ -178,7 +178,7 @@ export class Matrix2 {
    * @returns {this}
    */
   invert() {
-    Matrix2.invert(this)
+    Matrix2.invert(this, this)
 
     return this
   }

--- a/src/math/matrix3.js
+++ b/src/math/matrix3.js
@@ -221,7 +221,7 @@ export class Matrix3 {
    * @returns {this}
    */
   invert() {
-    Matrix3.invert(this)
+    Matrix3.invert(this, this)
 
     return this
   }

--- a/src/math/matrix4.js
+++ b/src/math/matrix4.js
@@ -299,7 +299,7 @@ export class Matrix4 {
    * @returns {this}
    */
   invert() {
-    Matrix4.invert(this)
+    Matrix4.invert(this,this)
 
     return this
   }

--- a/src/math/matrix4.js
+++ b/src/math/matrix4.js
@@ -299,7 +299,7 @@ export class Matrix4 {
    * @returns {this}
    */
   invert() {
-    Matrix4.invert(this,this)
+    Matrix4.invert(this, this)
 
     return this
   }


### PR DESCRIPTION
## Objective
 - Fixes a bug introduced by #192 where instance method `invert` does not store its results into the calling object.

## Solution
Ensure results are stored in the calling object.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.