### PR TITLE
Add aliases for audio assets.

### DIFF
--- a/src/audio/plugin.js
+++ b/src/audio/plugin.js
@@ -1,7 +1,8 @@
 import { App, Plugin } from '../app/index.js'
-import { AssetParserPlugin, AssetPlugin } from '../asset/index.js'
+import { AssetParserPlugin, AssetPlugin, Assets } from '../asset/index.js'
+import { typeidGeneric } from '../reflect/index.js'
 import { Audio } from './assets/index.js'
-import { AudioCommands, AudioParser } from './resources/index.js'
+import { AudioCommands, AudioParser, AudioAssets } from './resources/index.js'
 
 export class AudioPlugin extends Plugin {
 
@@ -9,18 +10,21 @@ export class AudioPlugin extends Plugin {
    * @param {App} app
    */
   register(app) {
+    const world = app.getWorld()
     const handler = new AudioCommands()
 
     app
       .setResource(handler)
       .registerPlugin(new AssetPlugin({
-        asset:Audio
+        asset: Audio
       }))
       .registerPlugin(new AssetParserPlugin({
-        asset:Audio,
-        parser:new AudioParser()
+        asset: Audio,
+        parser: new AudioParser()
       }))
     window.addEventListener('pointerdown', resumeAudio)
+
+    world.setResourceAlias(typeidGeneric(Assets, [Audio]), AudioAssets)
 
     /** */
     function resumeAudio() {

--- a/src/audio/resources/aliases.js
+++ b/src/audio/resources/aliases.js
@@ -1,0 +1,7 @@
+import { Audio } from '../assets/index.js'
+import { Assets } from '../../asset/index.js'
+
+/**
+ * @augments {Assets<Audio>}
+ */
+export class AudioAssets extends Assets { }

--- a/src/audio/resources/index.js
+++ b/src/audio/resources/index.js
@@ -1,2 +1,3 @@
 export * from './command.js'
 export * from './parser.js'
+export * from './aliases.js'


### PR DESCRIPTION
## Objective
Adds an alias for `Assets<Audio>` which can be directly used to fetch audio resource instead of using the typeid of the resource.

## Solution
N/A

## Showcase
```typescript
// now gets audio assets
const audioAssets = world.getResource(AudioAssets)
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.