### PR TITLE
Add `PluginGroup` for creating plugin groups

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -173,3 +173,43 @@ export class Plugin {
     return typeid(/** @type {Constructor}*/(this.constructor))
   }
 }
+
+/**
+ * @abstract
+ */
+export class PluginGroup extends Plugin {
+
+  /**
+   * @private
+   * @type {Map<TypeId,Plugin>}
+   */
+  plugins = new Map()
+  constructor() {
+    super()
+  }
+
+  /**
+   * @template {Plugin} T
+   * @param {T} plugin
+   * @returns {void}
+   */
+  add(plugin) {
+    this.plugins.set(plugin.name(), plugin)
+  }
+
+  /**
+   * @param {TypeId} id
+   */
+  remove(id) {
+    this.plugins.delete(id)
+  }
+
+  /**
+   * @param {App} app
+   */
+  register(app){
+    for (const plugin of this.plugins.values()) {
+      app.registerPlugin(plugin)
+    }
+  }
+}

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,5 +1,4 @@
 /** @import { SystemFunc } from '../ecs/index.js' */
-/** @import { HandleProvider, Parser } from '../asset/index.js' */
 /** @import { Constructor,TypeId } from '../reflect/index.js'*/
 
 import { World, Scheduler, Executor, ComponentHooks, RAFExecutor, ImmediateExecutor } from '../ecs/index.js'
@@ -163,12 +162,12 @@ export class Plugin {
   /**
    * @param {App} _app
    */
-  register(_app){}
+  register(_app) { }
 
   /**
    * @returns {TypeId}
    */
-  name(){
+  name() {
 
     // SAFETY: `this.constructor` can be casted into a `Contructor`
     return typeid(/** @type {Constructor}*/(this.constructor))

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -184,9 +184,6 @@ export class PluginGroup extends Plugin {
    * @type {Map<TypeId,Plugin>}
    */
   plugins = new Map()
-  constructor() {
-    super()
-  }
 
   /**
    * @template {Plugin} T


### PR DESCRIPTION
## Objective
Introduces a new abstract class `PluginGroup` to the engine. `PluginGroup` serves as a container for managing multiple plugins.

## Solution
N/A

## Showcase
```typescript
class MyPluginGroup extends PluginGroup {
  constructor(){
    super()
    this.add(new MovablePlugin())
  }
}

const plugins = new MyPluginGroup()

// Adds transform plugin to the group
plugins.add(new TransformPlugin())

// removes transform plugin from the group
plugins.remove(typeid(TransformPlugin))
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.