### PR TITLE
Modify `Events` to support double buffering

### DIFF
--- a/src/event/core/events.js
+++ b/src/event/core/events.js
@@ -29,21 +29,28 @@ export class Events {
    * @private
    * @type {CEvent<T>[]}
    */
-  buffer = []
+  writeBuffer = []
+  
+  /**
+   * @private
+   * @type {CEvent<T>[]}
+   */
+  readBuffer = []
 
   /**
    * Clear the events.
    */
   clear() {
-    this.buffer.length = 0
+    this.readBuffer = this.writeBuffer
+    this.writeBuffer = []
   }
 
   /**
    * @param {EventReader<T>} callback
    */
   each(callback) {
-    for (let i = 0; i < this.buffer.length; i++) {
-      callback(this.buffer[i])
+    for (let i = 0; i < this.readBuffer.length; i++) {
+      callback(this.readBuffer[i])
     }
   }
 
@@ -53,24 +60,24 @@ export class Events {
    * @returns {CEvent<T> | undefined}
    */
   readFirst() {
-    return this.buffer[0]
+    return this.readBuffer[0]
   }
 
   /**
    * @returns {CEvent<T> | undefined}
    */
   readLast() {
-    return this.buffer[this.buffer.length - 1]
+    return this.readBuffer[this.readBuffer.length - 1]
   }
 
   /**
    * @param {T} data
    */
   write(data) {
-    this.buffer.push(new CEvent(data))
+    this.writeBuffer.push(new CEvent(data))
   }
 
   count(){
-    return this.buffer.length
+    return this.readBuffer.length
   }
 }


### PR DESCRIPTION
## Objective
This solution was developed as some systems missed events that were emitted.This is an issue caused by system ordering where systems emitting events should occur first before any systems reading the same events.When any reading systems occur before any writing systems, they will miss all or some events emitted.

## Solution
Double buffering allows arbitrary systems reads and writes despite system ordering ensuring events are available throughout a frame once.

 > [!note]
 > The events are read one frame after they were emitted in this design.

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.