### PR TITLE
Add audio asset events

### DIFF
--- a/src/audio/events/audio.js
+++ b/src/audio/events/audio.js
@@ -1,5 +1,8 @@
-import { AssetAdded } from '../../asset/index.js'
+import { AssetAdded, AssetModified } from '../../asset/index.js'
 import { Audio } from '../assets/index.js'
 
 /** @augments AssetAdded<Audio> */
 export class AudioAdded extends AssetAdded {}
+
+/** @augments AssetModified<Audio> */
+export class AudioModified extends AssetModified {}

--- a/src/audio/events/audio.js
+++ b/src/audio/events/audio.js
@@ -1,0 +1,5 @@
+import { AssetAdded } from '../../asset/index.js'
+import { Audio } from '../assets/index.js'
+
+/** @augments AssetAdded<Audio> */
+export class AudioAdded extends AssetAdded {}

--- a/src/audio/events/audio.js
+++ b/src/audio/events/audio.js
@@ -1,4 +1,4 @@
-import { AssetAdded, AssetModified } from '../../asset/index.js'
+import { AssetAdded, AssetDropped, AssetModified } from '../../asset/index.js'
 import { Audio } from '../assets/index.js'
 
 /** @augments AssetAdded<Audio> */
@@ -6,3 +6,6 @@ export class AudioAdded extends AssetAdded {}
 
 /** @augments AssetModified<Audio> */
 export class AudioModified extends AssetModified {}
+
+/** @augments AssetDropped<Audio> */
+export class AudioDropped extends AssetDropped {}

--- a/src/audio/events/index.js
+++ b/src/audio/events/index.js
@@ -1,0 +1,1 @@
+export * from './audio.js'

--- a/src/audio/plugin.js
+++ b/src/audio/plugin.js
@@ -1,6 +1,7 @@
 import { App, Plugin } from '../app/index.js'
 import { AssetParserPlugin, AssetPlugin } from '../asset/index.js'
 import { Audio } from './assets/index.js'
+import { AudioAdded, AudioDropped, AudioModified } from './events/index.js'
 import { AudioCommands, AudioParser } from './resources/index.js'
 
 export class AudioPlugin extends Plugin {
@@ -14,7 +15,12 @@ export class AudioPlugin extends Plugin {
     app
       .setResource(handler)
       .registerPlugin(new AssetPlugin({
-        asset:Audio
+        asset:Audio,
+        events:{
+          added:AudioAdded,
+          modified:AudioModified,
+          dropped:AudioDropped
+        }
       }))
       .registerPlugin(new AssetParserPlugin({
         asset:Audio,


### PR DESCRIPTION
## Objective
 - Implements #208 for audio assets, in this case, only for `Audio` asset type.

## Solution
N/A

## Showcase
If applicable,show how to use the feature being added.Recordings and screenshots can be added.

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.