### PR TITLE
Make `createMovable2D` prefab parameters optional

### DIFF
--- a/src/movable/prefabs/movable2d.js
+++ b/src/movable/prefabs/movable2d.js
@@ -7,7 +7,7 @@ import { Velocity2D, Rotation2D, Acceleration2D, Torque2D } from '../components/
  * @param {number | undefined} a
  * @returns {[Position2D, Orientation2D, Scale2D, GlobalTransform2D, Velocity2D, Rotation2D, Acceleration2D, Torque2D]}
  */
-export function createMovable2D(x, y, a) {
+export function createMovable2D(x = 0, y = 0, a = 0) {
   return [new Position2D(x, y), new Orientation2D(a), new Scale2D(), new GlobalTransform2D(), new Velocity2D(), new Rotation2D(), new Acceleration2D(), new Torque2D()]
 }
 


### PR DESCRIPTION
## Objective
Make `createMovable2D` prefab parameters optional

## Solution
N/A

## Showcase
N/A

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.