### PR TITLE
Remove custom handle providers

### DIFF
--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -180,15 +180,6 @@ export class Assets {
 
 /**
  * @template T
- * @param {number} id 
- * @returns {Handle<T>}
- */
-function defaultHandler(id) {
-  return new Handle(id)
-}
-
-/**
- * @template T
  * @callback HandleProvider
  * @param {number} id
  * @returns {Handle<T>}

--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -40,17 +40,9 @@ export class Assets {
   events = []
 
   /**
-   * @protected
-   * @type {HandleProvider<T>}
-   */
-  createHandle
-
-  /**
    * @param {Constructor<T>} type
-   * @param {(HandleProvider<T>)} handler
    */
-  constructor(type, handler = defaultHandler) {
-    this.createHandle = handler
+  constructor(type) {
     this.type = type
   }
 
@@ -60,7 +52,7 @@ export class Assets {
    */
   add(asset) {
     const id = this.assets.reserve()
-    const handle = this.createHandle(id)
+    const handle = new Handle(id)
 
     this.assets.set(id, asset)
     this.events.push(new AssetAdded(this.type, handle.id()))
@@ -156,10 +148,10 @@ export class Assets {
     const id = this.assets.reserve()
 
     this.assets.set(id, undefined)
-    this.uuids.set(path, this.createHandle(id))
+    this.uuids.set(path, new Handle(id))
     this.toLoad.push(path)
 
-    return this.createHandle(id)
+    return new Handle(id)
   }
 
   // TODO: Move to asset server when it is implemented

--- a/src/asset/plugins/asset.js
+++ b/src/asset/plugins/asset.js
@@ -35,21 +35,14 @@ export class AssetPlugin extends Plugin {
   events
 
   /**
-   * @readonly
-   * @type {HandleProvider<T> | undefined}
-   */
-  handleprovider
-
-  /**
    * @param {AssetPluginOptions<T>} options
    */
   constructor(options) {
     super()
-    const { path = '', asset, handleprovider, events } = options
+    const { path = '', asset, events } = options
 
     this.asset = asset
     this.events = events
-    this.handleprovider = handleprovider
     this.path = path
   }
 
@@ -57,7 +50,7 @@ export class AssetPlugin extends Plugin {
    * @param {App} app
    */
   register(app) {
-    const { asset, handleprovider, path, events } = this
+    const { asset, path, events } = this
     const world = app.getWorld()
 
 
@@ -91,7 +84,7 @@ export class AssetPlugin extends Plugin {
     )
     world.setResourceByTypeId(
       typeidGeneric(Assets, [asset]),
-      new Assets(asset, handleprovider)
+      new Assets(asset)
     )
   }
 
@@ -105,7 +98,6 @@ export class AssetPlugin extends Plugin {
  * @typedef AssetPluginOptions
  * @property {string} [path]
  * @property {Constructor<T>} asset
- * @property {HandleProvider<T>} [handleprovider]
  * @property {AssetEvents<T>} [events]
  */
 

--- a/src/render-core/components/material.js
+++ b/src/render-core/components/material.js
@@ -2,11 +2,6 @@ import { Material } from '../assets/index.js'
 import { Handle } from '../../asset/index.js'
 
 /**
- * @augments {Handle<Material>}
- */
-export class MaterialHandle extends Handle {}
-
-/**
  * @template {Material} T
  */
 export class Material2D {

--- a/src/render-core/components/mesh.js
+++ b/src/render-core/components/mesh.js
@@ -1,11 +1,6 @@
 import { Handle } from '../../asset/index.js'
 import { Mesh } from '../assets/index.js'
 
-/**
- * @augments {Handle<Mesh>}
- */
-export class MeshHandle extends Handle { }
-
 export class Meshed {
 
   /**

--- a/src/render-core/plugin.js
+++ b/src/render-core/plugin.js
@@ -60,7 +60,7 @@ export class RenderCorePlugin extends Plugin {
         }
       }))
       .registerPlugin(new AssetPlugin({
-        asset: Material,
+        asset: Material
       }))
       .registerPlugin(new AssetPlugin({
         asset: BasicMaterial,

--- a/src/render-core/plugin.js
+++ b/src/render-core/plugin.js
@@ -1,6 +1,6 @@
 import { App, Plugin } from '../app/index.js'
 import { AssetParserPlugin, AssetPlugin, Assets } from '../asset/index.js'
-import { BasicMaterial2D, BasicMaterial3D, Camera, MaterialHandle, Meshed, MeshHandle } from './components/index.js'
+import { BasicMaterial2D, BasicMaterial3D, Camera, Meshed } from './components/index.js'
 import { Material, Mesh, Shader, Image, BasicMaterial } from './assets/index.js'
 import { BasicMaterialAssets, ImageAssets, ImageParser, MeshAssets } from './resources/index.js'
 import { Material2DPlugin, Material3DPlugin } from './plugins/index.js'
@@ -29,8 +29,6 @@ export class RenderCorePlugin extends Plugin {
     const world = app.getWorld()
 
     app
-      .registerType(MeshHandle)
-      .registerType(MaterialHandle)
       .registerType(Meshed)
       .registerType(Camera)
       .registerPlugin(new AssetPlugin({
@@ -51,8 +49,7 @@ export class RenderCorePlugin extends Plugin {
           added: MeshAdded,
           modified: MeshModified,
           dropped: MeshDropped
-        },
-        handleprovider: (id) => new MeshHandle(id)
+        }
       }))
       .registerPlugin(new AssetPlugin({
         asset: Shader,
@@ -64,7 +61,6 @@ export class RenderCorePlugin extends Plugin {
       }))
       .registerPlugin(new AssetPlugin({
         asset: Material,
-        handleprovider: (id) => new MaterialHandle(id)
       }))
       .registerPlugin(new AssetPlugin({
         asset: BasicMaterial,


### PR DESCRIPTION
## Objective
 - Implements #52

## Solution
N/A

## Showcase
N/A

## Migration guide
You should no longer use custom handles but wrap handles in your own classes.

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.