### PR TITLE
Remove `Material` registration as an asset

### DIFF
--- a/src/render-core/plugin.js
+++ b/src/render-core/plugin.js
@@ -1,7 +1,7 @@
 import { App, Plugin } from '../app/index.js'
 import { AssetParserPlugin, AssetPlugin, Assets } from '../asset/index.js'
 import { BasicMaterial2D, BasicMaterial3D, Camera, Meshed } from './components/index.js'
-import { Material, Mesh, Shader, Image, BasicMaterial } from './assets/index.js'
+import { Mesh, Shader, Image, BasicMaterial } from './assets/index.js'
 import { BasicMaterialAssets, ImageAssets, ImageParser, MeshAssets } from './resources/index.js'
 import { Material2DPlugin, Material3DPlugin } from './plugins/index.js'
 import {

--- a/src/render-core/plugin.js
+++ b/src/render-core/plugin.js
@@ -60,9 +60,6 @@ export class RenderCorePlugin extends Plugin {
         }
       }))
       .registerPlugin(new AssetPlugin({
-        asset: Material
-      }))
-      .registerPlugin(new AssetPlugin({
         asset: BasicMaterial,
         events: {
           added: BasicMaterialAdded,


### PR DESCRIPTION
## Objective
Removes registration of `Material` as an asset as it is an abstract class meant to be extended by actual materials.

## Solution
N/A

## Showcase
N/A

## Migration guide
You should no longer use `Material` as an asset type

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.