### PR TITLE
Add asset dropping

### DIFF
--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -1,7 +1,7 @@
 /** @import {AssetId} from '../types/index.js' */
 /** @import {Constructor} from '../../reflect/index.js'*/
 import { DenseList } from '../../datastructures/index.js'
-import { AssetAdded, AssetEvent, AssetModified } from '../events/assets.js'
+import { AssetAdded, AssetDropped, AssetEvent, AssetModified } from '../events/assets.js'
 
 /**
  * @template T
@@ -193,6 +193,21 @@ export class Assets {
     if (events.length) this.events = []
 
     return events
+  }
+
+  /**
+   * @param {Handle<T>} handle
+   */
+  drop(handle){
+    const entry = this.getEntry(handle)
+    
+    entry.refCount -= 1
+
+    if(entry.refCount <= 0){
+      entry.asset = undefined
+      this.assets.recycle(handle.index)
+      this.events.push(new AssetDropped(this.type, handle.id()))
+    }
   }
 }
 

--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -67,6 +67,9 @@ export class Assets {
    */
   set(handle, asset) {
     const entry = this.getEntry(handle)
+
+    if(!entry) return
+
     const oldAsset = entry.asset
 
     entry.asset = asset

--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -258,6 +258,10 @@ export class Handle {
 
     return new Handle(assets, index)
   }
+
+  drop(){
+    this.assets.drop(this)
+  }
 }
 
 /**

--- a/src/asset/tests/asset.test.js
+++ b/src/asset/tests/asset.test.js
@@ -1,7 +1,7 @@
 import { test, describe } from "node:test";
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { Assets,Handle } from "../core/index.js";
-import { AssetAdded, AssetModified } from "../events/assets.js";
+import { AssetAdded, AssetDropped, AssetModified } from "../events/assets.js";
 
 describe("Testing `Assets`", () => {
     test('`Assets.add` adds the asset correctly', () => {
@@ -265,5 +265,16 @@ describe("Testing `Assets`", () => {
         deepStrictEqual(events[1], new AssetAdded(String, handle2.id()))
         deepStrictEqual(events[2], new AssetModified(String, handle1.id()))
         deepStrictEqual(events[3], new AssetModified(String, handle2.id()))
+    })
+
+    test('Assets provides the right event when asset is dropped', () => {
+        const assets = new Assets(String)
+        const asset = "Wima engine"
+
+        const handle = assets.add(asset)
+        assets.drop(handle)
+        const events = assets.flushEvents()
+
+        deepStrictEqual(events[1], new AssetDropped(String, handle.id()))
     })
 })

--- a/src/asset/tests/handle.test.js
+++ b/src/asset/tests/handle.test.js
@@ -81,4 +81,49 @@ describe('Testing `Handle`',()=>{
         deepStrictEqual(entry2.refCount,1)
         deepStrictEqual(entry3.refCount,1)
     })
+
+    test('`Handle.drop` removes asset (case 1)', () => {
+        const assets = new Assets(String)
+        const asset = "Wima engine"
+
+        const handle = assets.add(asset)
+        handle.drop()
+        const actual = assets.get(handle)
+
+        deepStrictEqual(actual, undefined)
+    })
+
+    test('`Handle.drop` removes asset (case 2)', () => {
+        const assets = new Assets(String)
+        const asset = "Wima engine"
+
+        const handle = assets.add(asset)
+        handle.clone()
+        handle.clone()
+
+        handle.drop()
+        handle.drop()
+        handle.drop()
+
+        const actual = assets.get(handle)
+
+        deepStrictEqual(actual, undefined)
+    })
+
+    test('`Handle.drop` does not remove asset prematurely', () => {
+        const assets = new Assets(String)
+        const asset = "Wima engine"
+
+        const handle = assets.add(asset)
+
+        handle.clone()
+        handle.clone()
+
+        handle.drop()
+        handle.drop()
+        
+        const actual = assets.get(handle)
+
+        deepStrictEqual(actual, asset)
+    })
 })


### PR DESCRIPTION
## Objective

Introduces asset dropping functionality to the asset management system.Assets are now properly released from memory when no active handles remain, ensuring efficient resource usage without risking premature deletion.

Previously, the asset system could load and track assets but had no safe mechanism to drop them when they were no longer needed. This lead to:
 - Increased memory usage over time
 - Inability to free unused resources in long-running sessions

**Tests**
Added unit tests for:
  * Dropping asset with no handles.
  * Dropping asset with active handles.
  * Multiple handles released in different orders.
  * `AssetDropped` event is emitted when an asset is dropped.

## Solution
N/A

## Showcase
```typescript
class MyAsset {}
const assets = new Assets(MyAsset)

const handle = assets.add(new MyAsset())

// This will indicate that this handle has been dropped and will drop the actual asset too if this is the only handle to the asset remaining.
handle.drop()
```

## Migration guide
N/A

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.