### PR TITLE
Remove `AudioParser.placeholder`

### DIFF
--- a/src/audio/resources/parser.js
+++ b/src/audio/resources/parser.js
@@ -34,19 +34,6 @@ export class AudioParser extends Parser {
   }
 
   /**
-   * @returns {Audio}
-   */
-  placeholder() {
-    return new Audio(
-      new AudioBuffer({
-        sampleRate: 44100,
-        length: 512
-      }),
-      new ArrayBuffer(0)
-    )
-  }
-
-  /**
    * @param {Response} response
    */
   async parse(response) {


### PR DESCRIPTION
## Objective
Removes the method as it is no longer required by the `Parser` superclass.

## Solution
N/A

## Showcase
N/A

## Migration guide
You should manually construct an `Audio` instance instead.

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.