### PR TITLE
Enforce that `Handle` is dropped once

### DIFF
--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -68,7 +68,7 @@ export class Assets {
   set(handle, asset) {
     const entry = this.getEntry(handle)
 
-    if(!entry) return
+    if (!entry) return
 
     const oldAsset = entry.asset
 
@@ -121,7 +121,7 @@ export class Assets {
   get(handle) {
     const entry = this.getEntry(handle)
 
-    if(!entry) return undefined
+    if (!entry) return undefined
 
     return entry.asset
   }
@@ -145,7 +145,7 @@ export class Assets {
   getByAssetId(id) {
     const entry = this.assets.get(id)
 
-    if(!entry) return undefined
+    if (!entry) return undefined
 
     return this.assets.get(id).asset
   }
@@ -201,12 +201,12 @@ export class Assets {
   /**
    * @param {Handle<T>} handle
    */
-  drop(handle){
+  drop(handle) {
     const entry = this.getEntry(handle)
     
     entry.refCount -= 1
 
-    if(entry.refCount <= 0){
+    if (entry.refCount <= 0) {
       entry.asset = undefined
       this.assets.recycle(handle.index)
       this.events.push(new AssetDropped(this.type, handle.id()))
@@ -244,13 +244,13 @@ export class Handle {
    * @param {Assets<T>} assets 
    * @param {number} index 
    */
-  constructor(assets, index){
+  constructor(assets, index) {
     this.index = index
     this.assets = assets
 
     const entry = assets.getEntry(this)
 
-    if(entry){
+    if (entry) {
       entry.refCount += 1
     }
   }
@@ -258,11 +258,11 @@ export class Handle {
   /**
    * @returns {AssetId}
    */
-  id(){
-    return /** @type {AssetId}*/(this.index)
+  id() {
+    return /** @type {AssetId}*/ (this.index)
   }
 
-  clone(){
+  clone() {
     const { assets, index } = this
 
     return new Handle(assets, index)

--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -220,6 +220,12 @@ export class Assets {
 export class Handle {
 
   /**
+   * @private
+   * @type {boolean}
+   */
+  dropped = false
+
+  /**
    * This only exists as a channel for reference counting, do not use for any
    * other purpose!
    * @private
@@ -262,8 +268,11 @@ export class Handle {
     return new Handle(assets, index)
   }
 
-  drop(){
+  drop() {
+    if (this.dropped) return
+
     this.assets.drop(this)
+    this.dropped = true
   }
 }
 

--- a/src/asset/tests/handle.test.js
+++ b/src/asset/tests/handle.test.js
@@ -97,15 +97,15 @@ describe('Testing `Handle`',()=>{
         const assets = new Assets(String)
         const asset = "Wima engine"
 
-        const handle = assets.add(asset)
-        handle.clone()
-        handle.clone()
+        const handle1 = assets.add(asset)
+        const handle2 = handle1.clone()
+        const handle3 = handle1.clone()
 
-        handle.drop()
-        handle.drop()
-        handle.drop()
+        handle1.drop()
+        handle2.drop()
+        handle3.drop()
 
-        const actual = assets.get(handle)
+        const actual = assets.get(handle1)
 
         deepStrictEqual(actual, undefined)
     })
@@ -114,15 +114,29 @@ describe('Testing `Handle`',()=>{
         const assets = new Assets(String)
         const asset = "Wima engine"
 
-        const handle = assets.add(asset)
+        const handle1 = assets.add(asset)
+        const handle2 = handle1.clone()
+        const handle3 = handle1.clone()
 
-        handle.clone()
-        handle.clone()
-
-        handle.drop()
-        handle.drop()
+        handle2.drop()
+        handle3.drop()
         
-        const actual = assets.get(handle)
+        const actual = assets.get(handle1)
+
+        deepStrictEqual(actual, asset)
+    })
+
+    test('`Handle.drop` only drops once.', () => {
+        const assets = new Assets(String)
+        const asset = "Wima engine"
+
+        const handle1 = assets.add(asset)
+        const handle2 = handle1.clone()
+
+        handle2.drop()
+        handle2.drop()
+        
+        const actual = assets.get(handle1)
 
         deepStrictEqual(actual, asset)
     })


### PR DESCRIPTION
## Objective
Enhances the asset management by modifying  `Handle`s to only decrement its asset internal reference count once ensuring that the asset does not  drop prematurely when handle is dropped multiple times. The changes made improve safety and reliability of the asset system.

## Solution
N/A

## Showcase
N/A

## Migration guide
If you depended on the behaviour that a handle can be dropped more than once, ensure you no longer rely on that behaviour.

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.