### PR TITLE
Implement 2d and 3d transform propagation

### DIFF
--- a/demos/demos/transform/2d/propagate.js
+++ b/demos/demos/transform/2d/propagate.js
@@ -1,8 +1,6 @@
 import {
   Demo,
   World,
-  Affine2,
-  Vector2,
   VirtualClock,
   BasicMaterial,
   BasicMaterial2D,
@@ -14,12 +12,13 @@ import {
   Parent,
   Query,
   Children,
-  Rotary,
-  Position2D,
   Orientation2D,
-  Scale2D,
   BasicMaterialAssets,
-  MeshAssets
+  MeshAssets,
+  without,
+  has,
+  PI,
+  QUARTER_PI
 } from 'wima'
 import { addDefaultCamera2D } from '../../utils.js'
 
@@ -46,7 +45,6 @@ function addMeshes(world) {
       ...createTransform2D(),
       new Meshed(mesh),
       new BasicMaterial2D(material),
-      new Root(),
       new Cleanup()
     ])
     .build()
@@ -54,7 +52,7 @@ function addMeshes(world) {
   const child = commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(200),
+      ...createTransform2D(200, 0, 0, 0.5, 0.5),
       new Meshed(mesh),
       new BasicMaterial2D(material),
       new Parent(parent),
@@ -65,7 +63,7 @@ function addMeshes(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(),
+      ...createTransform2D(200, 0, 0, 0.5, 0.5),
       new Meshed(mesh),
       new BasicMaterial2D(material),
       new Cleanup(),
@@ -80,60 +78,14 @@ function addMeshes(world) {
  * @param {World} world
  */
 function update(world) {
-  const root = new Query(world, [Position2D, Orientation2D, Scale2D, Children, Root]).single()
-  const parents = new Query(world, [Position2D, Orientation2D, Scale2D, Children])
-  const children = new Query(world, [Position2D, Orientation2D, Scale2D, Parent])
-  const elapsed = world.getResource(VirtualClock).getElapsed()
+  const parent = new Query(world, [Orientation2D], [has(Children), without(Parent)]).single()
+  const child = new Query(world, [Orientation2D], [has(Children), has(Parent)]).single()
+  const grandChild = new Query(world, [Orientation2D], [has(Parent), without(Children)]).single()
+  const delta = world.getResource(VirtualClock).getDelta()
 
-  const parentTransform = Affine2.compose(
-    new Vector2(0, 0),
-    Rotary.fromAngle(elapsed * 0.5),
-    Vector2.splat(1)
-  )
-  const childTransform = Affine2.compose(
-    new Vector2(200, 0),
-    Rotary.fromAngle(elapsed * 0.5),
-    Vector2.splat(0.5)
-  )
+  if(!parent || !child || !grandChild) return
 
-  const grandChildTransform = Affine2.compose(
-    new Vector2(200, 0),
-    Rotary.identity(),
-    Vector2.splat(0.5)
-  )
-  const childFinalTransform = Affine2.multiply(parentTransform, childTransform)
-  const grandChildFinalTransform = Affine2.multiply(childFinalTransform, grandChildTransform)
-
-  if (!root) return
-
-  const [parPosition, parOrientation, parScale] = root
-  const [finparPosition, finparOrientation, finparScale] = parentTransform.decompose()
-
-  parPosition.copy(finparPosition)
-  parOrientation.value = Rotary.toAngle(finparOrientation)
-  parScale.copy(finparScale)
-
-  const child = parents.get(root[3].list[0])
-
-  if (!child) return
-
-  const [childPosition, childOrientation, childScale] = child
-  const [finChildPosition, finChildOrientation, finChildScale] = childFinalTransform.decompose()
-
-  childPosition.copy(finChildPosition)
-  childOrientation.value = Rotary.toAngle(finChildOrientation)
-  childScale.copy(finChildScale)
-
-  const grandChild = children.get(child[3].list[0])
-
-  if (!grandChild) return
-
-  const [grChildPosition, grChildOrientation, grChildScale] = grandChild
-  const [fingrChildPosition, fingrChildOrientation, fingrChildScale] = grandChildFinalTransform.decompose()
-
-  grChildPosition.copy(fingrChildPosition)
-  grChildOrientation.value = Rotary.toAngle(fingrChildOrientation)
-  grChildScale.copy(fingrChildScale)
+  parent[0].value += QUARTER_PI * delta
+  child[0].value += QUARTER_PI * delta
+  grandChild[0].value += PI * delta
 }
-
-class Root { }

--- a/demos/demos/transform/3d/propagate.js
+++ b/demos/demos/transform/3d/propagate.js
@@ -1,8 +1,6 @@
 import {
   Demo,
   World,
-  Affine3,
-  Vector3,
   VirtualClock,
   BasicMaterial,
   BasicMaterial3D,
@@ -15,11 +13,12 @@ import {
   Parent,
   Query,
   Children,
-  Scale3D,
-  Position3D,
   Orientation3D,
   BasicMaterialAssets,
-  MeshAssets
+  MeshAssets,
+  has,
+  QUARTER_PI,
+  without
 } from 'wima'
 import { addDefaultCamera3D } from '../../utils.js'
 
@@ -46,15 +45,14 @@ function addMeshes(world) {
       ...createTransform3D(),
       new Meshed(mesh),
       new BasicMaterial3D(material),
-      new Root(),
       new Cleanup()
     ])
     .build()
-  
+
   const child = commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(),
+      ...createTransform3D(1, 0, 0, 0, 0, 0, 0.5, 0.5, 0.5),
       new Meshed(mesh),
       new BasicMaterial3D(material),
       new Parent(parent),
@@ -65,14 +63,14 @@ function addMeshes(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(),
+      ...createTransform3D(0.5, 0, 0, 0, 0, 0, 0.5, 0.5, 0.5),
       new Meshed(mesh),
       new BasicMaterial3D(material),
       new Cleanup(),
       new Parent(child)
     ])
     .build()
-  
+
 }
 
 // TODO: Revisit when transform propagation lands.
@@ -80,60 +78,14 @@ function addMeshes(world) {
  * @param {World} world
  */
 function update(world) {
-  const root = new Query(world, [Position3D, Orientation3D, Scale3D, Children, Root]).single()
-  const parents = new Query(world, [Position3D, Orientation3D, Scale3D, Children])
-  const children = new Query(world, [Position3D, Orientation3D, Scale3D, Parent])
-  const elapsed = world.getResource(VirtualClock).getElapsed()
+  const parent = new Query(world, [Orientation3D], [has(Children), without(Parent)]).single()
+  const child = new Query(world, [Orientation3D], [has(Children), has(Parent)]).single()
+  const grandChild = new Query(world, [Orientation3D], [has(Parent), without(Children)]).single()
+  const delta = world.getResource(VirtualClock).getDelta()
+  
+  if (!parent || !child || !grandChild) return
 
-  const parentTransform = Affine3.compose(
-    new Vector3(0, 0),
-    Quaternion.rotateZ(elapsed * 0.5),
-    Vector3.splat(1)
-  )
-  const childTransform = Affine3.compose(
-    new Vector3(1, 0),
-    Quaternion.rotateZ(elapsed * 0.5),
-    Vector3.splat(0.5)
-  )
-
-  const grandChildTransform = Affine3.compose(
-    new Vector3(0.5, 0),
-    Quaternion.identity(),
-    Vector3.splat(0.5)
-  )
-  const childFinalTransform = Affine3.multiply(parentTransform, childTransform)
-  const grandChildFinalTransform = Affine3.multiply(childFinalTransform, grandChildTransform)
-
-  if (!root) return
-
-  const [parPosition, parOrientation, parScale] = root
-  const [finparPosition, finparOrientation, finparScale] = parentTransform.decompose()
-
-  parPosition.copy(finparPosition)
-  parOrientation.copy(finparOrientation)
-  parScale.copy(finparScale)
-
-  const child = parents.get(root[3].list[0])
-
-  if (!child) return
-
-  const [childPosition, childOrientation, childScale] = child
-  const [finChildPosition, finChildOrientation, finChildScale] = childFinalTransform.decompose()
-
-  childPosition.copy(finChildPosition)
-  childOrientation.copy(finChildOrientation)
-  childScale.copy(finChildScale)
-
-  const grandChild = children.get(child[3].list[0])
-
-  if (!grandChild) return
-
-  const [grChildPosition, grChildOrientation, grChildScale] = grandChild
-  const [fingrChildPosition, fingrChildOrientation, fingrChildScale] = grandChildFinalTransform.decompose()
-
-  grChildPosition.copy(fingrChildPosition)
-  grChildOrientation.copy(fingrChildOrientation)
-  grChildScale.copy(fingrChildScale)
+  parent[0].multiply(Quaternion.fromEuler(0, 0, QUARTER_PI * delta))
+  child[0].multiply(Quaternion.fromEuler(0, 0, QUARTER_PI * delta))
+  grandChild[0].multiply(Quaternion.fromEuler(0, 0, QUARTER_PI * delta))
 }
-
-class Root {}

--- a/src/hierarchy/components/children.js
+++ b/src/hierarchy/components/children.js
@@ -1,5 +1,10 @@
 /** @import { Entity } from '../../ecs/index.js' */
 
+import { VisitEntities } from '../../relationship/index.js'
+
+/**
+ * @implements {VisitEntities}
+ */
 export class Children {
 
   /**
@@ -28,6 +33,9 @@ export class Children {
    */
   remove(entity) {
     this.list.splice(this.list.indexOf(entity), 1)
+  }
+  visit(){
+    return this.list
   }
 
   /**

--- a/src/hierarchy/components/parent.js
+++ b/src/hierarchy/components/parent.js
@@ -1,5 +1,10 @@
 /** @import { Entity } from '../../ecs/index.js' */
 
+import { VisitEntities } from '../../relationship/index.js'
+
+/**
+ * @implements {VisitEntities}
+ */
 export class Parent {
 
   /**
@@ -13,5 +18,8 @@ export class Parent {
    */
   constructor(entity) {
     this.entity = entity
+  }
+  visit(){
+    return [this.entity]
   }
 }

--- a/src/transform/plugins/transform.js
+++ b/src/transform/plugins/transform.js
@@ -9,7 +9,7 @@ import {
   GlobalTransform3D
 } from '../components/index.js'
 import { App, AppSchedule, Plugin } from '../../app/index.js'
-import { synctransform2D, synctransform3D } from '../systems/index.js'
+import { propagateTransform2D, synctransform2D, synctransform3D } from '../systems/index.js'
 
 export class Transform2DPlugin extends Plugin {
 
@@ -23,6 +23,7 @@ export class Transform2DPlugin extends Plugin {
       .registerType(Scale2D)
       .registerType(GlobalTransform2D)
       .registerSystem(AppSchedule.Update, synctransform2D)
+      .registerSystem(AppSchedule.Update, propagateTransform2D)
   }
 }
 

--- a/src/transform/plugins/transform.js
+++ b/src/transform/plugins/transform.js
@@ -9,7 +9,7 @@ import {
   GlobalTransform3D
 } from '../components/index.js'
 import { App, AppSchedule, Plugin } from '../../app/index.js'
-import { propagateTransform2D, synctransform2D, synctransform3D } from '../systems/index.js'
+import { propagateTransform2D, propagateTransform3D, synctransform2D, synctransform3D } from '../systems/index.js'
 
 export class Transform2DPlugin extends Plugin {
 
@@ -39,6 +39,6 @@ export class Transform3DPlugin extends Plugin {
       .registerType(Scale3D)
       .registerType(GlobalTransform3D)
       .registerSystem(AppSchedule.Update, synctransform3D)
-
+      .registerSystem(AppSchedule.Update, propagateTransform3D)
   }
 }

--- a/src/transform/systems/transform.js
+++ b/src/transform/systems/transform.js
@@ -1,5 +1,7 @@
-import { Query, World } from '../../ecs/index.js'
-import { Rotary } from '../../math/index.js'
+import { Entity, has, Query, without, World } from '../../ecs/index.js'
+import { Children, Parent } from '../../hierarchy/index.js'
+import { Affine2, Rotary } from '../../math/index.js'
+import { RelationshipQuery } from '../../relationship/index.js'
 import { Position2D, Orientation2D, Scale2D, GlobalTransform2D, Position3D, Orientation3D, Scale3D, GlobalTransform3D } from '../components/index.js'
 
 /**
@@ -21,5 +23,22 @@ export function synctransform3D(world) {
 
   query.each(([position, orientation, scale, transform]) => {
     transform.compose(position, orientation, scale)
+  })
+}
+
+
+/**
+ * @param {World} world 
+ */
+export function propagateTransform2D(world) {
+  const hierachyTransforms = new RelationshipQuery(world, Children, Parent, [GlobalTransform2D])
+  const roots = new Query(world, [Entity], [has(Children), without(Parent)])
+
+  roots.each(([entity]) => {
+    hierachyTransforms.treebfs(entity, ([childTransform], [parentTransform]) => {
+      const finalTransform = Affine2.multiply(parentTransform, childTransform)
+
+      childTransform.copy(finalTransform)
+    })
   })
 }

--- a/src/transform/systems/transform.js
+++ b/src/transform/systems/transform.js
@@ -1,6 +1,6 @@
 import { Entity, has, Query, without, World } from '../../ecs/index.js'
 import { Children, Parent } from '../../hierarchy/index.js'
-import { Affine2, Rotary } from '../../math/index.js'
+import { Affine2, Affine3, Rotary } from '../../math/index.js'
 import { RelationshipQuery } from '../../relationship/index.js'
 import { Position2D, Orientation2D, Scale2D, GlobalTransform2D, Position3D, Orientation3D, Scale3D, GlobalTransform3D } from '../components/index.js'
 
@@ -37,6 +37,22 @@ export function propagateTransform2D(world) {
   roots.each(([entity]) => {
     hierachyTransforms.treebfs(entity, ([childTransform], [parentTransform]) => {
       const finalTransform = Affine2.multiply(parentTransform, childTransform)
+
+      childTransform.copy(finalTransform)
+    })
+  })
+}
+
+/**
+ * @param {World} world 
+ */
+export function propagateTransform3D(world) {
+  const hierachyTransforms = new RelationshipQuery(world, Children, Parent, [GlobalTransform3D])
+  const roots = new Query(world, [Entity], [has(Children), without(Parent)])
+
+  roots.each(([entity]) => {
+    hierachyTransforms.treebfs(entity, ([childTransform], [parentTransform]) => {
+      const finalTransform = Affine3.multiply(parentTransform, childTransform)
 
       childTransform.copy(finalTransform)
     })


### PR DESCRIPTION
## Objective
Introduces transform propagation for 2D and 3D entities, allowing hierarchical transformations to be automatically computed and applied. This eliminates the need for manual calculation of world transforms for child entities and simplifies the process of building complex nested transformations.

## Solution
The solution leverages the existing hierarchy system (using `Parent` and `Children` components) and introduces new systems that traverse the entity tree in a breadth-first manner. For each child entity, the global transform is computed by multiplying the parent's global transform with the child's local transform. This ensures that all children inherit their parent's position, rotation, and scale.

Modified `Children` and `Parent` components to implement `VisitEntities` for use in relationship queries.

## Showcase
To use transform propagation, simply attach `Parent` and `Children` components to your entities. The global transform will automatically be updated to reflect the parent's transform.

Example (2D):
```javascript
const parent = commands.spawn()
  .insertPrefab([
    ...createTransform2D(),
    new Children()
 ])
  .build()

const child = commands.spawn()
  .insertPrefab([
    ...createTransform2D(200, 0, 0, 0.5, 0.5),
    new Parent(parent)
 ])
  .build()
```

The child will now automatically rotate and scale relative to the parent.

## Migration Guide
The introduced changes bring no breaking changes, however:
- Remove any manual transform propagation code (e.g., manual multiplication of affine transforms).
- Use `GlobalTransform2D` or `GlobalTransform3D` to access the world-space transform of an entity.

## Checklist
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.