### PR TITLE
Fix regressions archetype table separation introduced

### DIFF
--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -182,7 +182,7 @@ export class World {
     const combinedIds = [...existingIds, ...newIds]
     const [newTableId, newTable, newArchetypeId] = this.resolve(combinedIds)
 
-    if (newTableId == oldTableId) {
+    if (newTableId === oldTableId) {
       oldTable.insertUnchecked(index, newIds, components)
     } else {
       const newIndex = oldTable.moveTo(newTable, index)

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -181,18 +181,23 @@ export class World {
     const existingIds = oldArchetype.types
     const combinedIds = [...existingIds, ...newIds]
     const [newTableId, newTable, newArchetypeId] = this.resolve(combinedIds)
-    const newIndex = oldTable.moveTo(newTable, index)
-    const swapped = /** @type {Entity | null}*/ (oldTable.get(typeid(Entity), index))
 
-    newTable.insertUnchecked(newIndex, newIds, components)
-    location.tableId = newTableId
-    location.archetypeId = newArchetypeId
-    location.index = newIndex
+    if (newTableId == oldTableId) {
+      oldTable.insertUnchecked(index, newIds, components)
+    } else {
+      const newIndex = oldTable.moveTo(newTable, index)
+      const swapped = /** @type {Entity | null}*/ (oldTable.get(typeid(Entity), index))
 
-    if (swapped) {
-      const swappedlocation = /** @type {EntityLocation} */ (this.entities.get(swapped.index))
-      
-      swappedlocation.index = index
+      newTable.insertUnchecked(newIndex, newIds, components)
+      location.tableId = newTableId
+      location.archetypeId = newArchetypeId
+      location.index = newIndex
+
+      if (swapped) {
+        const swappedlocation = /** @type {EntityLocation} */ (this.entities.get(swapped.index))
+  
+        swappedlocation.index = index
+      }
     }
 
     this.callAddComponentHook(entity, newIds)

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -118,8 +118,8 @@ export class World {
       return [tableId, table, id, arch]
     }
 
-    const [tableId, table] = this.tables.resolveTableFor(typeIds)
-    const newArchetype = new Archetype(tableId, typeIds)
+    const [tableId, table] = this.tables.resolveTableFor(actualTypeIds)
+    const newArchetype = new Archetype(tableId, actualTypeIds)
     const id = this.archetypes.set(newArchetype)
 
     return [tableId, table, id, newArchetype]


### PR DESCRIPTION
## Objective
Addresses critical logical and performance regressions and soundness issues in the ECS world. 
 - The regression was introduced by #243 and was fixed by #159 previously.
 
## Solution
- **Fixed Archetype Resolution**: Deduplicated type IDs are used to create creating new archetypes, preventing duplicate component types from causing incorrect archetype matching.
- **Optimized Component Insertion**: When inserting components into an existing entity, the system now checks if the operation can be performed within the same table instead of always moving to a new table. This eliminates unnecessary data movement when the table structure doesn't change.


## Showcase
The improvements are most noticeable in scenarios with frequent component additions and dublicate components:

## Migration Guide
No breaking changes were introduced.

## Checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
