### PR TITLE
Add `setTypeId`

### DIFF
--- a/src/reflect/core/typeid.js
+++ b/src/reflect/core/typeid.js
@@ -1,11 +1,25 @@
 /** @import {Constructor, TypeId,} from '../types/index.js' */
+
+/**
+ * This function converts a string to a `TypeId`.This function should be used in some special cases where a type does not actually exist on runtime e.g enums, union types e.t.c.
+ * See `typeid` or `typeidGeneric` for safer methods of getting `TypeId`s.
+ * 
+ * # Safety
+ * This function is inherently unsafe as any string can be converted to a `TypeId` without it actually having a backing type.Use sparingly or dont use it if possible.
+ * 
+ * @param {string} name
+ */
+export function setTypeId(name) {
+  return /** @type {TypeId}*/(name)
+}
+
 /**
  * @template T
  * @param {Constructor<T>} type 
  * @returns {TypeId}
  */
 export function typeid(type) {
-  return /** @type {TypeId}*/(type.name)
+  return setTypeId(type.name)
 }
 
 /**
@@ -28,5 +42,5 @@ export function typeidGeneric(type, types) {
 
   name += `${types[types.length - 1].name}>`
  
-  return /** @type {TypeId}*/(name)
+  return /** @type {TypeId}*/ (name)
 }


### PR DESCRIPTION
## Objective
Introduces a dedicated function with proper safety documentation to cast arbitrary strings into `TypeId`s.This can be used to create ids for enums, unions and any type that only exists at compile time not at runtime.

## Solution
The solution adds a new `setTypeId()` function that centralizes unsafe typeid casting to a single, well-documented function

## Showcase
The new function should be used sparingly for special cases:

```javascript
import { setTypeId } from 'wima'

// Only use for special cases where types don't exist at runtime
const enumTypeId = setTypeId("MyEnum") // Use for enums, union types, etc.

// For regular classes, continue using the safe methods:
class MyClass {}
const safeTypeId = typeid(MyClass) // Preferred method for regular types
```

## Migration Guide
No breaking changes were introduced.

## Checklist
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly (via function documentation).
- [ ] I have added tests to cover my changes.
