### PR TITLE
Add `World.hasResource`

### DIFF
--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -370,6 +370,29 @@ export class World {
   /**
    * @template T
    * @param {TypeId} id
+   * @returns {boolean}
+   */
+  hasResourceByTypeId(id) {
+    const resource = this.resources[id]
+    
+    if (resource) {
+      return true
+    }
+    
+    const aliasedid = this.resourceAliases.get(id)
+    
+    if (!aliasedid) return false
+    
+    const aliasedResource = this.resources[aliasedid]
+    
+    if (!aliasedResource) return false
+    
+    return true
+  }
+  
+  /**
+   * @template T
+   * @param {TypeId} id
    * @param {T} resource
    * @returns {void}
    */

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -369,6 +369,15 @@ export class World {
 
   /**
    * @template T
+   * @param {Constructor<T>} resourceType
+   * @returns {boolean}
+   */
+  hasResource(resourceType) {
+    return this.hasResourceByTypeId(typeid(resourceType))
+  }
+
+  /**
+   * @template T
    * @param {TypeId} id
    * @returns {boolean}
    */

--- a/src/ecs/tests/world.test.js
+++ b/src/ecs/tests/world.test.js
@@ -3,7 +3,7 @@ import { deepStrictEqual } from "node:assert";
 import { World } from "../registry.js";
 import { typeid } from "../../reflect/index.js";
 import { Entity } from "../entities/entity.js";
-class A { 
+class A {
   number = 0
 }
 class B {
@@ -16,7 +16,7 @@ class TestResource {
   id = 12
 }
 
-class TestAlias extends TestResource {}
+class TestAlias extends TestResource { }
 
 describe("Testing `World`", () => {
   test('Entity is spawned correctly into a world.', () => {
@@ -25,7 +25,7 @@ describe("Testing `World`", () => {
     const entityCell = world.getEntity(entity)
     const components = [...entityCell.components()]
 
-    deepStrictEqual(components,[typeid(A),typeid(B),typeid(C),typeid(Entity)])
+    deepStrictEqual(components, [typeid(A), typeid(B), typeid(C), typeid(Entity)])
   })
 
   test('Entity is despawned correctly from a world.', () => {
@@ -35,7 +35,7 @@ describe("Testing `World`", () => {
     const entityCell = world.getEntity(entity)
     const components = [...entityCell.components()]
 
-    deepStrictEqual(components,[])
+    deepStrictEqual(components, [])
   })
 
   test('Components are inserted into an entity.', () => {
@@ -45,7 +45,7 @@ describe("Testing `World`", () => {
     const entityCell = world.getEntity(entity)
     const components = [...entityCell.components()]
 
-    deepStrictEqual(components,[typeid(Entity),typeid(A),typeid(B),typeid(C)])
+    deepStrictEqual(components, [typeid(Entity), typeid(A), typeid(B), typeid(C)])
   })
 
   test('Components are removed from an entity.', () => {
@@ -55,7 +55,7 @@ describe("Testing `World`", () => {
     const entityCell = world.getEntity(entity)
     const components = [...entityCell.components()]
 
-    deepStrictEqual(components,[typeid(C),typeid(Entity)])
+    deepStrictEqual(components, [typeid(C), typeid(Entity)])
   })
 
   test('Set and get correct resource on world.', () => {
@@ -63,23 +63,39 @@ describe("Testing `World`", () => {
     world.setResource(new TestResource())
     const resource = world.getResource(TestResource)
 
-    deepStrictEqual(resource,new TestResource())
+    deepStrictEqual(resource, new TestResource())
   })
 
   test('Set and get correct resource on world by `TypeId`.', () => {
     const world = new World()
-    world.setResourceByTypeId(typeid(TestResource),new TestResource())
+    world.setResourceByTypeId(typeid(TestResource), new TestResource())
     const resource = world.getResourceByTypeId(typeid(TestResource))
 
-    deepStrictEqual(resource,new TestResource())
+    deepStrictEqual(resource, new TestResource())
+  })
+
+  test('World has resource.', () => {
+    const world = new World()
+    world.setResource(new TestResource())
+
+    deepStrictEqual(world.hasResource(TestResource), true)
+    deepStrictEqual(world.hasResource(TestAlias), false)
+  })
+
+  test('World has resource by `TypeId`.', () => {
+    const world = new World()
+    world.setResource(new TestResource())
+
+    deepStrictEqual(world.hasResourceByTypeId(typeid(TestResource)), true)
+    deepStrictEqual(world.hasResourceByTypeId(typeid(TestAlias)), false)
   })
 
   test('Resource aliases point to correct resource.', () => {
     const world = new World()
     world.setResource(new TestResource())
-    world.setResourceAlias(typeid(TestResource),TestAlias)
+    world.setResourceAlias(typeid(TestResource), TestAlias)
     const resource = world.getResource(TestAlias)
 
-    deepStrictEqual(resource,new TestResource())
+    deepStrictEqual(resource, new TestResource())
   })
 })


### PR DESCRIPTION
## Objective

Adds the ability to check if a resource exists in the ECS `World`.

## Solution
The solution adds two methods to `World` to check for the existence of a resource without throwing an error if it doesn't exist. This is useful for conditional resource access and avoids the need for try-catch blocks.

- Added `hasResource` which checks by constructor type.
- Added `hasResourceByTypeId` which checks by internal type ID.
- Both methods handle resource aliases correctly, returning `true` only if the aliased resource exists.

## Showcase
Here’s how to use the new methods:

```javascript
const world = new World();
world.setResource(new TestResource());

// Check by constructor
if (world.hasResource(TestResource)) {
  const resource = world.getResource(TestResource);
  // Use resource safely
}

// Check by TypeId
const typeId = typeid(TestResource);
if (world.hasResourceByTypeId(typeId)) {
  const resource = world.getResourceByTypeId(typeId);
}
```

## Migration Guide 
No breaking changes are introduced.

## Checklist
- [x] My change requires a change to the documentation.  
- [ ] I have updated the documentation accordingly.  
- [x] I have added tests to cover my changes