### PR TITLE
Add `World.removeResource`

### DIFF
--- a/src/ecs/entities/index.js
+++ b/src/ecs/entities/index.js
@@ -1,3 +1,4 @@
 export * from './entities.js'
 export * from './location.js'
 export * from './entity.js'
+export * from './entitycell.js'

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -27,7 +27,7 @@ export class World {
 
   /**
    * @private
-   * @type {Record<string,any>}
+   * @type {Record<TypeId,any>}
    */
   resources = {}
 
@@ -387,6 +387,14 @@ export class World {
     const id = typeid(/** @type {Constructor<T>} */(resource.constructor))
 
     this.setResourceByTypeId(id, resource)
+  }
+
+  /**
+   * @param {TypeId} typeId
+   */
+  removeResourceByTypeId(typeId){
+    delete this.resources[typeId]
+    this.resourceAliases.delete(typeId)
   }
 
   /**

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -390,6 +390,14 @@ export class World {
   }
 
   /**
+   * @template T
+   * @param {Constructor<T>} type
+   */
+  removeResource(type){
+    this.removeResourceByTypeId(typeid(type))
+  }
+
+  /**
    * @param {TypeId} typeId
    */
   removeResourceByTypeId(typeId){

--- a/src/ecs/tests/world.test.js
+++ b/src/ecs/tests/world.test.js
@@ -1,5 +1,5 @@
 import { test, describe } from "node:test";
-import { deepStrictEqual } from "node:assert";
+import { deepStrictEqual, throws } from "node:assert";
 import { World } from "../registry.js";
 import { typeid } from "../../reflect/index.js";
 import { Entity } from "../entities/entity.js";
@@ -72,6 +72,22 @@ describe("Testing `World`", () => {
     const resource = world.getResourceByTypeId(typeid(TestResource))
 
     deepStrictEqual(resource,new TestResource())
+  })
+
+  test('Removing a resource on a world.', () => {
+    const world = new World()
+    world.setResource(new TestResource())
+    world.removeResource(TestResource)
+
+    throws(()=>world.getResource(TestResource))
+  })
+
+  test('Removing a resource on a world by `TypeId`.', () => {
+    const world = new World()
+    world.setResource(new TestResource())
+    world.removeResourceByTypeId(typeid(TestResource))
+
+    throws(()=>world.getResource(TestResource))
   })
 
   test('Resource aliases point to correct resource.', () => {


### PR DESCRIPTION
## Objective
Introduces the ability to remove resources from the `World` class, either by their type or TypeId.

## Solution
New methods `removeResource()` and `removeResourceByTypeId()` have been added to the `World`. These methods allow resources to be deleted from a world. Unit tests have been added to verify both removal methods and ensure that attempting to access a removed resource throws an error.

## Showcase
Here’s how to use the new resource removal methods:

```js
// Create world and add a resource
const world = new World();
world.setResource(new TestResource());

// Remove by type
world.removeResource(TestResource);

world.removeResourceByTypeId(typeid(TestResource));
```
## Migration guide
No breaking changes introduced.

## Checklist
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.