### PR TITLE
Make `Timer` a component

### DIFF
--- a/src/time/components/index.js
+++ b/src/time/components/index.js
@@ -1,0 +1,1 @@
+export * from './timer.js'

--- a/src/time/components/timer.js
+++ b/src/time/components/timer.js
@@ -1,4 +1,4 @@
-import { clamp } from '../math/index.js'
+import { clamp } from '../../math/index.js'
 
 export class Timer {
 

--- a/src/time/index.js
+++ b/src/time/index.js
@@ -1,4 +1,4 @@
+export * from './components/index.js'
 export * from './clock.js'
-export * from './timer.js'
 export * from './plugin.js'
 export * from './resource/index.js'

--- a/src/time/plugin.js
+++ b/src/time/plugin.js
@@ -1,18 +1,21 @@
 import { World } from '../ecs/index.js'
+import { AppSchedule, App, Plugin } from '../app/index.js'
+import { updateTimers } from './systems/index.js'
 import { VirtualClock } from './resource/index.js'
-import { App, Plugin } from '../app/app.js'
-import { AppSchedule } from '../app/schedules.js'
 import { Clock } from './clock.js'
+import { Timer } from './components/timer.js'
 
-export class TimePlugin extends Plugin{
+export class TimePlugin extends Plugin {
 
   /**
    * @param {App} app
    */
   register(app) {
     app
+      .registerType(Timer)
       .setResource(new VirtualClock())
       .registerSystem(AppSchedule.Update, updateVirtualClock)
+      .registerSystem(AppSchedule.Update, updateTimers)
   }
 }
 

--- a/src/time/systems/index.js
+++ b/src/time/systems/index.js
@@ -1,0 +1,1 @@
+export * from './timer.js'

--- a/src/time/systems/timer.js
+++ b/src/time/systems/timer.js
@@ -1,0 +1,17 @@
+import { Query, World } from '../../ecs/index.js'
+import { Timer } from '../components/index.js'
+import { VirtualClock } from '../resource/index.js'
+
+
+/**
+ * @param {World} world
+ */
+export function updateTimers(world) {
+  const timers = new Query(world, [Timer])
+  const clock = world.getResource(VirtualClock)
+  const delta = clock.getDelta()
+  
+  timers.each(([timer]) => {
+    timer.update(delta)
+  })
+}

--- a/src/time/tests/timer.test.js
+++ b/src/time/tests/timer.test.js
@@ -1,5 +1,5 @@
 import { test, describe } from "node:test";
-import { Timer, TimerMode } from "../timer.js";
+import { Timer, TimerMode } from "../index.js";
 import { strictEqual } from "node:assert";
 
 describe("Testing `Timer`", () => {


### PR DESCRIPTION
## Objective
Refactors the `Timer` to become a proper ECS component. It moves the `Timer` from a standalone type to a component that can be attached to entities and automatically updated by the engine's systems.

## Solution
The solution involved restructuring the Timer implementation to follow ECS patterns:

- **Moved Timer to components**: Converted Timer to a component type
- **Added system-based updates**: Created system that automatically updates all Timer components
- **Integrated with TimePlugin**: Registered Timer as a component type and added the update system
- **Maintained API compatibility**: All existing Timer methods and functionality remain unchanged
## Showcase
The Timer now works as a proper ECS component:

```javascript
// Create entity with Timer component
commands
  .spawn()
  .insertPrefab([
    new Timer({
      mode: TimerMode.Repeat,
      duration: 10,
      speed: 1.0
    })
  ])
  .build()

// Timer is automatically updated by the engine
// No manual update calls needed
```

## Migration Guide
No breaking changes.

## Checklist
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.