### PR TITLE
Add methods to pack and unpack two numbers from another

### DIFF
--- a/src/algorithms/index.js
+++ b/src/algorithms/index.js
@@ -1,1 +1,2 @@
 export * from './sort/index.js'
+export * from './packnumber.js'

--- a/src/algorithms/packnumber.js
+++ b/src/algorithms/packnumber.js
@@ -1,0 +1,20 @@
+/**
+ * Packs two numbers into a single number.
+ * 
+ * #### Note
+ * This operation is should be analogous to packing two 32 bit
+ * numbers into a 64 bit number in the high and low bits.Due
+ * to language limitations, the high bits of this implementation
+ * can only be up to 2 ^ 20, otherwise the output will be garbled
+ * nonsense.
+ * 
+ * @param {number} low 
+ * @param {number} high
+ * @returns 
+ */
+export function packInto64Int(low, high) {
+
+  // We cant use bit manipulation as javascript has a 32 bit limit on
+  // manipulating "integers"
+  return (high * 2 ** 32) + low
+}

--- a/src/algorithms/packnumber.js
+++ b/src/algorithms/packnumber.js
@@ -18,3 +18,25 @@ export function packInto64Int(low, high) {
   // manipulating "integers"
   return (high * 2 ** 32) + low
 }
+
+/**
+ * Unpacks two numbers from a single number.
+ * 
+ * #### Note
+ * This operation is should be analogous to unpacking two 32 bit
+ * numbers from 64 bit number in the high and low bits.Due
+ * to language limitations, the number passed into this function
+ * can only be up to 2 ^ 53, otherwise the output will be garbled
+ * nonsense.
+ * 
+ * @param {number} value 
+ */
+export function unpackFrom64Int(value) {
+
+  // We cant use bit manipulation as javascript has a 32 bit limit on
+  // manipulating "integers"
+  const low = value % 2 ** 32
+  const high = Math.floor(value / 2 ** 32)
+
+  return [low, high]
+}

--- a/src/algorithms/tests/packNumbers.test.js
+++ b/src/algorithms/tests/packNumbers.test.js
@@ -1,0 +1,46 @@
+import { test, describe } from "node:test";
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { packInto64Int, unpackFrom64Int } from "../packnumber.js";
+
+describe("Testing pack and unpacking numbers", () => {
+  test('Testing packing number.', () => {
+    const num1 = packInto64Int(0, 0)
+    const num2 = packInto64Int(1, 0)
+    const num3 = packInto64Int(3, 0)
+    const num4 = packInto64Int(0, 1)
+    const num5 = packInto64Int(1, 1)
+    const num6 = packInto64Int(4, 1)
+    const num7 = packInto64Int(0, 3)
+    const num8 = packInto64Int(2, 3)
+
+    strictEqual(num1, 0)
+    strictEqual(num2, 1)
+    strictEqual(num3, 3)
+    strictEqual(num4, 4294967296)
+    strictEqual(num5, 4294967297)
+    strictEqual(num6, 4294967300)
+    strictEqual(num7, 12884901888)
+    strictEqual(num8, 12884901890)
+  })
+
+  test('Testing unpacking number.', () => {
+    const num1 = unpackFrom64Int(0)
+    const num2 = unpackFrom64Int(1)
+    const num3 = unpackFrom64Int(3)
+    const num4 = unpackFrom64Int(4294967296)
+    const num5 = unpackFrom64Int(4294967297)
+    const num6 = unpackFrom64Int(4294967300)
+    const num7 = unpackFrom64Int(12884901888)
+    const num8 = unpackFrom64Int(12884901890)
+
+    deepStrictEqual(num1, [0, 0])
+    deepStrictEqual(num2, [1, 0])
+    deepStrictEqual(num3, [3, 0])
+    deepStrictEqual(num4, [0, 1])
+    deepStrictEqual(num5, [1, 1])
+    deepStrictEqual(num6, [4, 1])
+    deepStrictEqual(num7, [0, 3])
+    deepStrictEqual(num8, [2, 3])
+    
+  })
+})


### PR DESCRIPTION
## Objective
Introduces a new utility feature; functions for packing and unpacking two numbers into and from a single 64-bit integer representation.

## Solution
- Due to JavaScript's limitation of representing all numbers as double-precision floating-point values and its 32-bit limit on bitwise operations, a mathematical approach was taken.
- The solution uses multiplication, division, and exponentiation to simulate the packing and unpacking of two 32-bit numbers into a single 64-bit integer value.
- This approach allows for handling numbers larger than 32 bits, with the caveat that the effective range is limited by JavaScript's safe integer precision (up to 2^53).

## Showcase
The new functions can be used to encode/decode two numbers for storage or transmission.

Packing two numbers:
```javascript
const low = 123456789;   // Represents the lower 32 bits
const high = 654321;  // Represents the higher 32 bits

const packedValue = packInto64Int(low, high);
console.log(packedValue); // Outputs a single large number: 42420001565530885
```

Unpacking the number:
```javascript
const [originalLow, originalHigh] = unpackFrom64Int(packedValue);
console.log(originalLow, originalHigh); // Outputs: 123456789, 654321
```

## Migration guide
This is a new feature addition and introduces no breaking changes to the existing API. No migration is required for existing users.

## Checklist
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (Documentation is included as JSDoc comments in the new source file)
- [x] I have added tests to cover my changes.