### PR TITLE
Add common collections type info to reflection

### DIFF
--- a/src/reflect/core/info.js
+++ b/src/reflect/core/info.js
@@ -271,3 +271,35 @@ export class MapInfo extends TypeInfo {
     return this.valueType
   }
 }
+
+export class TupleInfo extends TypeInfo {
+
+  /**
+   * @readonly
+   * @type {ReadonlyArray<TypeId>}
+   */
+  elementTypes
+
+  /**
+   * @param {TypeId[]} elementTypes
+   */
+  constructor(elementTypes) {
+    super()
+    this.elementTypes = elementTypes
+  }
+
+  /**
+   * @param {number} index
+   * @returns {TypeId | undefined}
+   */
+  getElement(index) {
+    return this.elementTypes[index]
+  }
+
+  /**
+   * @returns {ReadonlyArray<TypeId>}
+   */
+  getElements() {
+    return this.elementTypes
+  }
+}

--- a/src/reflect/core/info.js
+++ b/src/reflect/core/info.js
@@ -208,3 +208,27 @@ export class ArrayInfo extends TypeInfo {
     return this.elementType
   }
 }
+
+export class SetInfo extends TypeInfo {
+
+  /**
+   * @readonly
+   * @type {TypeId}
+   */
+  elementType
+
+  /**
+   * @param {TypeId} elementType
+   */
+  constructor(elementType) {
+    super()
+    this.elementType = elementType
+  }
+
+  /**
+   * @returns {TypeId}
+   */
+  getElementType() {
+    return this.elementType
+  }
+}

--- a/src/reflect/core/info.js
+++ b/src/reflect/core/info.js
@@ -232,3 +232,42 @@ export class SetInfo extends TypeInfo {
     return this.elementType
   }
 }
+
+export class MapInfo extends TypeInfo {
+
+  /**
+   * @readonly
+   * @type {TypeId}
+   */
+  keyType
+
+  /**
+   * @readonly
+   * @type {TypeId}
+   */
+  valueType
+
+  /**
+   * @param {TypeId} keyType
+   * @param {TypeId} valueType
+   */
+  constructor(keyType, valueType) {
+    super()
+    this.keyType = keyType
+    this.valueType = valueType
+  }
+
+  /**
+   * @returns {TypeId}
+   */
+  getKeyType() {
+    return this.keyType
+  }
+
+  /**
+   * @returns {TypeId}
+   */
+  getValueType() {
+    return this.valueType
+  }
+}

--- a/src/reflect/core/info.js
+++ b/src/reflect/core/info.js
@@ -184,3 +184,27 @@ export class FunctionInfo extends TypeInfo {
     return this.returnType
   }
 }
+
+export class ArrayInfo extends TypeInfo {
+
+  /**
+   * @readonly
+   * @type {TypeId}
+   */
+  elementType
+
+  /**
+   * @param {TypeId} elementType
+   */
+  constructor(elementType) {
+    super()
+    this.elementType = elementType
+  }
+
+  /**
+   * @returns {TypeId}
+   */
+  getElementType() {
+    return this.elementType
+  }
+}

--- a/src/reflect/tests/info/arrayinfo.test.js
+++ b/src/reflect/tests/info/arrayinfo.test.js
@@ -1,0 +1,12 @@
+import { test, describe } from "node:test";
+import { ArrayInfo } from "../../core/info.js";
+import { typeid } from "../../../type/core/typeid.js";
+import { strictEqual } from "assert";
+
+describe("Testing `ArrayInfo`", () => {
+  test("`ArrayInfo` stores element type", () => {
+    const info = new ArrayInfo(typeid(Number))
+
+    strictEqual(info.getElementType(), typeid(Number))
+  })
+})

--- a/src/reflect/tests/info/mapinfo.test.js
+++ b/src/reflect/tests/info/mapinfo.test.js
@@ -1,0 +1,13 @@
+import { test, describe } from "node:test";
+import { MapInfo } from "../../core/info.js";
+import { typeid } from "../../../type/core/typeid.js";
+import { strictEqual } from "assert";
+
+describe("Testing `MapInfo`", () => {
+  test("`MapInfo` stores key and value types", () => {
+    const info = new MapInfo(typeid(String), typeid(Number))
+
+    strictEqual(info.getKeyType(), typeid(String))
+    strictEqual(info.getValueType(), typeid(Number))
+  })
+})

--- a/src/reflect/tests/info/setinfo.test.js
+++ b/src/reflect/tests/info/setinfo.test.js
@@ -1,0 +1,12 @@
+import { test, describe } from "node:test";
+import { SetInfo } from "../../core/info.js";
+import { typeid } from "../../../type/core/typeid.js";
+import { strictEqual } from "assert";
+
+describe("Testing `SetInfo`", () => {
+  test("`SetInfo` stores element type", () => {
+    const info = new SetInfo(typeid(String))
+
+    strictEqual(info.getElementType(), typeid(String))
+  })
+})

--- a/src/reflect/tests/info/tupleinfo.test.js
+++ b/src/reflect/tests/info/tupleinfo.test.js
@@ -1,0 +1,19 @@
+import { test, describe } from "node:test";
+import { TupleInfo } from "../../core/info.js";
+import { typeid } from "../../../type/core/typeid.js";
+import { deepStrictEqual, strictEqual } from "assert";
+
+describe("Testing `TupleInfo`", () => {
+  test("`TupleInfo` stores element types", () => {
+    const info = new TupleInfo([typeid(Number), typeid(String)])
+
+    deepStrictEqual(info.getElements(), [typeid(Number), typeid(String)])
+  })
+
+  test("`TupleInfo` gets element by index", () => {
+    const info = new TupleInfo([typeid(Number), typeid(String)])
+
+    strictEqual(info.getElement(0), typeid(Number))
+    strictEqual(info.getElement(1), typeid(String))
+  })
+})


### PR DESCRIPTION
## Objective

Extends the reflection by introducing metadata types for common container structures.

## Solution

Introduces specialized `TypeInfo` subclasses that capture the type relationships inside common JavaScript data structures:
* `ArrayInfo`: For arrays.
* `SetInfo`: For sets.
* `MapInfo`: For maps.
* `TupleInfo`: Foe tuples.
Unit tests are also added to verify the behavior of the new reflection types.

## Showcase

Example usage within the reflection system:

```js
const info = new MapInfo(typeid(String), typeid(Number))

info.getKeyType()   // String
info.getValueType() // Number
```

Tuple example:

```js
const tuple = new TupleInfo([
  typeid(Number),
  typeid(String)
])

tuple.getElement(0) // Number
tuple.getElement(1) // String
```

## Migration guide

No breaking changes.

## Checklist

* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
