### PR TITLE
Make canvas material rendering in NDC space

### DIFF
--- a/examples/samples/animation/2d/basic.js
+++ b/examples/samples/animation/2d/basic.js
@@ -75,7 +75,7 @@ function init(world) {
 
   const rawClip = createClip()
   const clip = clips.add(rawClip)
-  const mesh = meshes.add(Mesh.quad2D(50, 50))
+  const mesh = meshes.add(Mesh.quad2D(0.15, 0.15))
   const material = materials.add(new BasicMaterial())
   const targetname = '/bone'
   const animationplayer = new AnimationPlayer()
@@ -92,7 +92,7 @@ function init(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(100, 100),
+      ...createTransform2D(0.3, 0.3),
       new Meshed(mesh),
       new BasicMaterial2D(material),
       new AnimationTarget(player, targetname),
@@ -116,16 +116,16 @@ function createClip() {
   scale.times = [0, 2, 4, 6, 8]
 
   translate.keyframes = [
-    -100,
-    100,
-    -100,
-    -100,
-    100,
-    -100,
-    100,
-    100,
-    -100,
-    100
+    -0.5,
+    0.5,
+    -0.5,
+    -0.5,
+    0.5,
+    -0.5,
+    0.5,
+    0.5,
+    -0.5,
+    0.5
   ]
   rotate.keyframes = [
     0,

--- a/examples/samples/ecs/despawn.js
+++ b/examples/samples/ecs/despawn.js
@@ -22,10 +22,10 @@ import { addDefaultCamera2D, HackPlugin, setupViewport } from '../utils.js'
 
 class Marker { }
 
-const itemWidth = 50
-const itemHeight = 50
-const paddingWidth = 10
-const paddingHeight = 10
+const itemWidth = 0.12
+const itemHeight = 0.12
+const paddingWidth = 0.03
+const paddingHeight = 0.03
 const app = new App()
 
 app
@@ -48,8 +48,8 @@ function init(world) {
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
 
-  const width = 1000
-  const height = 600
+  const width = 1.8
+  const height = 1.2
   const halfWidth = width / 2
   const halfHeight = height / 2
   const mesh = meshes.add(Mesh.quad2D(
@@ -58,8 +58,8 @@ function init(world) {
   ))
   const material = materials.add(new BasicMaterial())
 
-  for (let y = -halfHeight; y <= halfHeight; y += itemHeight) {
-    for (let x = -halfWidth; x < halfWidth; x += itemWidth) {
+  for (let y = -halfHeight + itemHeight / 2; y <= halfHeight - itemHeight / 2; y += itemHeight + paddingHeight) {
+    for (let x = -halfWidth + itemWidth / 2; x <= halfWidth - itemWidth / 2; x += itemWidth + paddingWidth) {
       commands
         .spawn()
         .insertPrefab([

--- a/examples/samples/ecs/spawn.js
+++ b/examples/samples/ecs/spawn.js
@@ -22,10 +22,10 @@ import { addDefaultCamera2D, HackPlugin, setupViewport } from '../utils.js'
 
 class Marker { }
 
-const itemWidth = 50
-const itemHeight = 50
-const paddingWidth = 10
-const paddingHeight = 10
+const itemWidth = 0.12
+const itemHeight = 0.12
+const paddingWidth = 0.03
+const paddingHeight = 0.03
 const app = new App()
 
 app
@@ -51,11 +51,11 @@ function update(world) {
   const mesh = meshes.add(Mesh.quad2D(itemHeight - paddingWidth, itemWidth - paddingHeight))
   const material = materials.add(new BasicMaterial())
 
-  const width = 1000
-  const height = 600
-  const nx = Math.floor(width / itemWidth)
-  const x = ((entities.count() % nx) * itemWidth) - width / 2
-  const y = Math.floor(entities.count() / nx) * itemHeight - height / 2
+  const width = 1.8
+  const height = 1.2
+  const nx = Math.floor(width / (itemWidth + paddingWidth))
+  const x = ((entities.count() % nx) * (itemWidth + paddingWidth)) - width / 2 + itemWidth / 2
+  const y = Math.floor(entities.count() / nx) * (itemHeight + paddingHeight) - height / 2 + itemHeight / 2
 
   if (y > height / 2) return
 

--- a/examples/samples/input/keyboard.js
+++ b/examples/samples/input/keyboard.js
@@ -26,12 +26,12 @@ import { addDefaultCamera2D, HackPlugin, setupViewport } from '../utils.js'
 /** @type {Map<KeyCode,Entity>} */
 class KeytoEntityMap extends Map { }
 
-const offsetX = -400
-const offsetY = -100
-const itemWidth = 50
-const itemHeight = 50
-const paddingWidth = 10
-const paddingHeight = 10
+const offsetX = -0.9
+const offsetY = 0.7
+const itemWidth = 0.12
+const itemHeight = 0.12
+const paddingWidth = 0.03
+const paddingHeight = 0.03
 const app = new App()
 
 app
@@ -108,8 +108,8 @@ function spawnDigits(world) {
 
   for (let i = 0; i < digits.length; i++) {
     const digit = /** @type {KeyCode}*/(digits[i])
-    const x = offsetX + (i % digits.length) * (itemWidth + paddingWidth) + paddingWidth
-    const y = offsetY + Math.floor(i / digits.length) * (itemHeight + paddingHeight)
+    const x = offsetX + (i * (itemWidth + paddingWidth)) + (itemWidth / 2)
+    const y = offsetY
     const entity = commands
       .spawn()
       .insertPrefab([
@@ -132,7 +132,7 @@ function spawnAlphabet(world) {
   const commands = world.getResource(EntityCommands)
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
-  const mesh = meshes.add(Mesh.quad2D(50, 50))
+  const mesh = meshes.add(Mesh.quad2D(itemWidth, itemHeight))
   const alphabet = [
     KeyCode.KeyQ,
     KeyCode.KeyW,
@@ -171,8 +171,10 @@ function spawnAlphabet(world) {
     // eslint-disable-next-line no-nested-ternary
     const ny = i < 10 ? 0 : i < 19 ? 1 : 2
 
-    const x = offsetX + nx * (itemWidth + paddingWidth) + paddingWidth + itemWidth / 2 + ((itemWidth + paddingWidth) / 2 * ny)
-    const y = offsetY + ny * (itemHeight + paddingHeight) + itemHeight / 2 + itemHeight + paddingHeight
+    const rowSpacing = itemHeight + paddingHeight
+    const baseY = offsetY - rowSpacing * 1.5
+    const x = offsetX + nx * (itemWidth + paddingWidth) + (itemWidth / 2) + ((itemWidth + paddingWidth) / 2 * ny)
+    const y = baseY - (rowSpacing * ny)
 
     const entity = commands
       .spawn()

--- a/examples/samples/input/mouse.js
+++ b/examples/samples/input/mouse.js
@@ -23,7 +23,7 @@ import {
   DefaultPlugin,
   FPSDebugger
 } from 'wima'
-import { addDefaultCamera2D, HackPlugin, setupViewport } from '../utils.js'
+import { addDefaultCamera2D, HackPlugin, setupViewport, pxToNdc } from '../utils.js'
 
 /** @type {Map<KeyCode,Entity>} */
 class KeytoEntityMap extends Map { }
@@ -37,11 +37,11 @@ class MouseEntity {
   }
 }
 
-const offsetX = 100
-const offsetY = 100
-const itemWidth = 50
-const itemHeight = 50
-const paddingWidth = 10
+const offsetX = -0.9
+const offsetY = 0.8
+const itemWidth = 0.15
+const itemHeight = 0.15
+const paddingWidth = 0.05
 const app = new App()
 
 app
@@ -64,7 +64,7 @@ app
 function spawnMouseFollower(world) {
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
-  const mesh = meshes.add(Mesh.quad2D(50, 50))
+  const mesh = meshes.add(Mesh.quad2D(0.1, 0.1))
   const commands = world.getResource(EntityCommands)
 
   const entity = commands
@@ -90,7 +90,7 @@ function spawnButtons(world) {
   const materials = world.getResource(BasicMaterialAssets)
   const map = new KeytoEntityMap()
   const commands = world.getResource(EntityCommands)
-  const mesh = meshes.add(Mesh.quad2D(50, 50))
+  const mesh = meshes.add(Mesh.quad2D(itemWidth, itemHeight))
   const digits = [
     MouseButton.Left,
     MouseButton.Wheel,
@@ -102,8 +102,8 @@ function spawnButtons(world) {
 
   for (let i = 0; i < digits.length; i++) {
     const digit = digits[i]
-    const x = offsetX + ((i % digits.length) * (itemWidth + paddingWidth)) + ((itemWidth + paddingWidth) / 2)
-    const y = offsetY + Math.floor(i / digits.length) * itemHeight + itemHeight / 2
+    const x = offsetX + (i * (itemWidth + paddingWidth)) + (itemWidth / 2)
+    const y = offsetY
 
     const entity = commands
       .spawn()
@@ -136,7 +136,7 @@ function updateFollower(world) {
 
   const [position] = components
 
-  position.copy(mouse.position)
+  position.copy(pxToNdc(mouse.position.x, mouse.position.y))
 }
 
 /**

--- a/examples/samples/input/touch.js
+++ b/examples/samples/input/touch.js
@@ -22,7 +22,7 @@ import {
   DOMWindowPlugin,
   FPSDebugger
 } from 'wima'
-import { addDefaultCamera2D, HackPlugin, setupViewport } from '../utils.js'
+import { addDefaultCamera2D, HackPlugin, setupViewport, pxToNdc } from '../utils.js'
 
 /** @type {Map<number,Entity>} */
 class TouchtoEntityMap extends Map { }
@@ -52,7 +52,7 @@ function init(world) {
 
   if (!window) return warn('No window set up')
 
-  const mesh = meshes.add(Mesh.quad2D(50, 50))
+  const mesh = meshes.add(Mesh.quad2D(0.1, 0.1))
 
   for (let i = 0; i < 10; i++) {
     const entity = commands
@@ -94,7 +94,7 @@ function update(world) {
     if (!material) return
 
     if (touch) {
-      components[0].copy(touch.position)
+      components[0].copy(pxToNdc(touch.position.x, touch.position.y))
       material.color.copy(Color.RED)
     } else {
       material.color.copy(Color.WHITE)

--- a/examples/samples/render/canvas-2d/material.js
+++ b/examples/samples/render/canvas-2d/material.js
@@ -39,13 +39,13 @@ function init(world) {
   const meshes = world.getResource(MeshAssets)
   const basicMaterials = world.getResource(BasicMaterialAssets)
 
-  const mesh = meshes.add(Mesh.quad2D(50, 50))
+  const mesh = meshes.add(Mesh.quad2D(0.2, 0.2))
   const material = basicMaterials.add(new BasicMaterial())
 
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(-120, 0),
+      ...createTransform2D(-0.5, 0),
       new Meshed(mesh),
       new BasicMaterial2D(material),
       new Cleanup()

--- a/examples/samples/transform/2d/lookat.js
+++ b/examples/samples/transform/2d/lookat.js
@@ -55,11 +55,11 @@ function spawnLookers(world) {
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
 
-  const mesh = meshes.add(Mesh.triangle2D(10, 50))
+  const mesh = meshes.add(Mesh.triangle2D(0.05, 0.15))
   const material = materials.add(new BasicMaterial())
 
-  for (let x = -innerWidth / 2; x < innerWidth / 2; x += 100) {
-    for (let y = -innerHeight / 2; y < innerHeight / 2; y += 100) {
+  for (let x = -0.8; x <= 0.8; x += 0.4) {
+    for (let y = -0.6; y <= 0.6; y += 0.4) {
       commands
         .spawn()
         .insertPrefab([
@@ -83,7 +83,7 @@ function spawnTarget(world) {
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
 
-  const mesh = meshes.add(Mesh.circle2D(10))
+  const mesh = meshes.add(Mesh.circle2D(0.05))
   const material = materials.add(new BasicMaterial({
     color:new Color(0, 1, 1)
   }))
@@ -139,8 +139,8 @@ function updateTarget(world) {
   const speed = 0.3
   const frequencyX = 3
   const frequencyY = 1
-  const amplitudeX = innerWidth / 2 - 100
-  const amplitudeY = innerHeight / 2 - 100
+  const amplitudeX = 0.7
+  const amplitudeY = 0.7
 
   if (!target) return
 

--- a/examples/samples/transform/2d/propagate.js
+++ b/examples/samples/transform/2d/propagate.js
@@ -50,7 +50,7 @@ function addMeshes(world) {
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
 
-  const mesh = meshes.add(Mesh.circle2D(50))
+  const mesh = meshes.add(Mesh.circle2D(0.1))
   const material = materials.add(new BasicMaterial())
 
   const parent = commands
@@ -66,7 +66,7 @@ function addMeshes(world) {
   const child = commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(200, 0, 0, 0.5, 0.5),
+      ...createTransform2D(0.4, 0, 0, 0.5, 0.5),
       new Meshed(mesh),
       new BasicMaterial2D(material),
       new Parent(parent),
@@ -77,7 +77,7 @@ function addMeshes(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(200, 0, 0, 0.5, 0.5),
+      ...createTransform2D(0.4, 0, 0, 0.5, 0.5),
       new Meshed(mesh),
       new BasicMaterial2D(material),
       new Cleanup(),
@@ -87,7 +87,6 @@ function addMeshes(world) {
 
 }
 
-// TODO: Revisit when transform propagation lands.
 /**
  * @param {World} world
  */

--- a/examples/samples/transform/2d/rotate.js
+++ b/examples/samples/transform/2d/rotate.js
@@ -43,7 +43,7 @@ function addmesh(world) {
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
 
-  const mesh = meshes.add(Mesh.quad2D(50, 50))
+  const mesh = meshes.add(Mesh.quad2D(0.25, 0.25))
   const material = materials.add(new BasicMaterial())
 
   commands

--- a/examples/samples/transform/2d/scale.js
+++ b/examples/samples/transform/2d/scale.js
@@ -44,7 +44,7 @@ function addmesh(world) {
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
 
-  const mesh = meshes.add(Mesh.quad2D(50, 50))
+  const mesh = meshes.add(Mesh.quad2D(0.25, 0.25))
   const material = materials.add(new BasicMaterial())
 
   commands

--- a/examples/samples/transform/2d/translate.js
+++ b/examples/samples/transform/2d/translate.js
@@ -43,7 +43,7 @@ function addmesh(world) {
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
 
-  const mesh = meshes.add(Mesh.quad2D(50, 50))
+  const mesh = meshes.add(Mesh.quad2D(0.2, 0.2))
   const material = materials.add(new BasicMaterial())
 
   commands
@@ -66,7 +66,8 @@ function updateMesh(world) {
   const dt = clock.getElapsed()
 
   query.each(([position]) => {
-    position.x = Math.sin(dt) * 100
-    position.y = Math.cos(dt) * 100
+    const amplitude = 0.7
+    position.x = Math.sin(dt) * amplitude
+    position.y = Math.cos(dt) * amplitude
   })
 }

--- a/examples/samples/transform/2d/translate.js
+++ b/examples/samples/transform/2d/translate.js
@@ -67,6 +67,7 @@ function updateMesh(world) {
 
   query.each(([position]) => {
     const amplitude = 0.7
+
     position.x = Math.sin(dt) * amplitude
     position.y = Math.cos(dt) * amplitude
   })

--- a/examples/samples/transform/3d/propagate.js
+++ b/examples/samples/transform/3d/propagate.js
@@ -86,7 +86,6 @@ function spawnMeshes(world) {
 
 }
 
-// TODO: Revisit when transform propagation lands.
 /**
  * @param {World} world
  */

--- a/examples/samples/tween/easing.js
+++ b/examples/samples/tween/easing.js
@@ -49,28 +49,29 @@ function init(world) {
   const basicMaterials = world.getResourceByTypeId(typeidGeneric(Assets, [BasicMaterial]))
 
   const material = basicMaterials.add(new BasicMaterial())
-  const mesh = meshes.add(Mesh.quad2D(50, 50))
+  const mesh = meshes.add(Mesh.quad2D(0.08, 0.08))
 
-  const width = 1000
-  const height = 600
-  const offset = -width
-  const stride = 100
+  const width = 1.8
+  const startY = -0.7
+  const endY = 0.7
   const easings = Object.keys(Easing)
+  const stride = easings.length > 1 ? width / (easings.length - 1) : width
+  const offset = -width / 2
 
   for (let i = 0; i < easings.length; i++) {
     const easeName = easings[i]
     const x = offset + i * stride
-    const y = -height / 2
+    const y = startY
 
     commands
       .spawn()
       .insertPrefab([
-        ...createTransform2D(x, y + 50),
+        ...createTransform2D(x, y),
         new Meshed(mesh),
         new BasicMaterial2D(material),
         new Position2DTween(
-          new Vector2(x, y + 50),
-          new Vector2(x, 0 - 100),
+          new Vector2(x, y),
+          new Vector2(x, endY),
           4,
           true,
           true,

--- a/examples/samples/utils.js
+++ b/examples/samples/utils.js
@@ -21,6 +21,7 @@ import {
   WindowCommands,
   Entity,
   MainWindow,
+  Vector2,
   warn,
   Windows
 } from 'wima'
@@ -138,4 +139,36 @@ export function registerAssetParserOnAssetServer(type, parser) {
 
     server.registerParser(type, parser)
   }
+}
+
+/**
+ * Convert a pixel-space coordinate (origin top-left) to NDC (-1..1, Y up).
+ *
+ * @param {number} x
+ * @param {number} y
+ * @param {number} [width]
+ * @param {number} [height]
+ * @returns {Vector2}
+ */
+export function pxToNdc(x, y, width = innerWidth, height = innerHeight) {
+  return new Vector2(
+    (x / (width / 2)) - 1,
+    1 - (y / (height / 2))
+  )
+}
+
+/**
+ * Convert an NDC coordinate (-1..1, Y up) to pixel-space (origin top-left).
+ *
+ * @param {number} x
+ * @param {number} y
+ * @param {number} [width]
+ * @param {number} [height]
+ * @returns {Vector2}
+ */
+export function ndcToPx(x, y, width = innerWidth, height = innerHeight) {
+  return new Vector2(
+    (x + 1) * (width / 2),
+    (1 - y) * (height / 2)
+  )
 }

--- a/src/render-canvas2d/systems/index.js
+++ b/src/render-canvas2d/systems/index.js
@@ -54,6 +54,7 @@ export function genrender(type, renderMaterial) {
 
       ctx.save()
       ctx.translate(offsetX, offsetY)
+      ctx.scale(offsetX, -offsetY)
       ctx.transform(
         view.a,
         view.b,


### PR DESCRIPTION
## Objective

Standardize the canvas renderer around Normalized Device Coordinates (NDC) instead of pixel-space coordinates.This was done to allow interop between renderers as NDC space is the preferred space on all systems.

## Solution

* Migrate all example scenes from pixel units to NDC space
* Introduce utilities for converting between pixel-space and NDC
* Ensure input (mouse/touch) integrates correctly with NDC-based transforms
* Align rendering pipeline with NDC conventions

## Showcase
See migration guide.

## Migration guide

Scenes needs to be scaled down as materials are rendered in NDC space

### Breaking changes

* Engine now assumes NDC rendering space
* Pixel-based positioning will no longer produce expected results

### Required updates

#### 1. Scale down pixel values
```js
// Before
createTransform2D(100, 100)

// After
createTransform2D(0.2, 0.2)
```

#### 2. Normalize input

```js
// Before
position.copy(mouse.position)

// After
position.copy(pixelToNDC(mouse.position.x, mouse.position.y))
```

#### 3. Adjust layouts

* Recompute spacing using normalized units
* Avoid mixing pixel constants with NDC transforms

#### 4. Rendering assumptions

* Engine now assumes:

  * Origin at center
  * X ∈ [-1, 1], Y ∈ [-1, 1]
  * Y axis points upward

## Checklist

* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
