### PR TITLE
Implement systems error handling in running `Schedule`s

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -105,9 +105,10 @@ export class App {
    * @template {Executor} T
    * @param {string} label
    * @param {T} executor
+   * @param {(error: Error, world: World) => void} [errorHandler]
    */
-  createSchedule(label, executor) {
-    return this.scheduler.set(label, executor)
+  createSchedule(label, executor, errorHandler) {
+    return this.scheduler.set(label, executor, errorHandler)
   }
 
   /**

--- a/src/schedule/core/executable.js
+++ b/src/schedule/core/executable.js
@@ -41,6 +41,7 @@ export class Executable {
    * @type {Schedule}
    */
   schedule
+
   /**
    * @private
    * @type {((error: Error, world: World) => void) | undefined}

--- a/src/schedule/core/executable.js
+++ b/src/schedule/core/executable.js
@@ -9,8 +9,8 @@ import { Schedule } from './schedule.js'
  * @example
  * ```ts
  * class SomeExecutor extends Executor {
- *   start(world:World, schedule:Schedule){
- *     schedule.run(world,schedule)
+ *   start(world:World, schedule:Schedule, errorHandler){
+ *     schedule.run(world, errorHandler)
  *   }
  * }
  *
@@ -41,21 +41,28 @@ export class Executable {
    * @type {Schedule}
    */
   schedule
+  /**
+   * @private
+   * @type {((error: Error, world: World) => void) | undefined}
+   */
+  errorHandler
 
   /**
    * @param {Schedule} schedule
    * @param {Executor} executor
+   * @param {(error: Error, world: World) => void} [errorHandler]
    */
-  constructor(schedule, executor) {
+  constructor(schedule, executor, errorHandler) {
     this.schedule = schedule
     this.executor = executor
+    this.errorHandler = errorHandler
   }
 
   /**
    * @param {World} world
    */
   start(world) {
-    this.executor.start(world, this.schedule)
+    this.executor.start(world, this.schedule, this.errorHandler)
   }
   stop() {
     this.executor.stop()

--- a/src/schedule/core/executors/Immediate.js
+++ b/src/schedule/core/executors/Immediate.js
@@ -11,9 +11,10 @@ export class ImmediateExecutor extends Executor {
   /**
    * @param {World} world
    * @param {Schedule} schedule
+   * @param {(error: Error, world: World) => void} [errorHandler]
    */
-  start(world, schedule) {
-    schedule.run(world)
+  start(world, schedule, errorHandler) {
+    schedule.run(world, errorHandler)
   }
   stop() {}
 }

--- a/src/schedule/core/executors/RAF.js
+++ b/src/schedule/core/executors/RAF.js
@@ -17,15 +17,16 @@ export class RAFExecutor extends Executor {
   /**
    * @param {World} world
    * @param {Schedule} schedule
+   * @param {(error: Error, world: World) => void} [errorHandler]
    */
-  start(world, schedule) {
+  start(world, schedule, errorHandler) {
     this.tick = requestAnimationFrame(execute.bind(this))
 
     /**
      * @this {RAFExecutor}
      */
     function execute() {
-      schedule.run(world)
+      schedule.run(world, errorHandler)
       this.tick = requestAnimationFrame(execute.bind(this))
     }
   }

--- a/src/schedule/core/executors/executor.js
+++ b/src/schedule/core/executors/executor.js
@@ -44,7 +44,8 @@ export class Executor {
   /**
    * @param {World} _world
    * @param {Schedule} _schedule
+   * @param {(error: Error, world: World) => void} [_errorHandler]
    */
-  start(_world, _schedule) { }
+  start(_world, _schedule, _errorHandler) { }
   stop() { }
 }

--- a/src/schedule/core/executors/interval.js
+++ b/src/schedule/core/executors/interval.js
@@ -20,9 +20,10 @@ export class IntervalExecutor extends Executor {
   /**
    * @param {World} world
    * @param {Schedule} schedule
+   * @param {(error: Error, world: World) => void} [errorHandler]
    */
-  start(world, schedule) {
-    this.tick = window.setInterval(() => { schedule.run(world) }, this.time)
+  start(world, schedule, errorHandler) {
+    this.tick = window.setInterval(() => { schedule.run(world, errorHandler) }, this.time)
   }
   stop() {
     clearInterval(this.tick)

--- a/src/schedule/core/executors/timeout.js
+++ b/src/schedule/core/executors/timeout.js
@@ -16,9 +16,10 @@ export class TimeoutExecutor extends Executor {
   /**
    * @param {World} world
    * @param {Schedule} schedule
+   * @param {(error: Error, world: World) => void} [errorHandler]
    */
-  start(world, schedule) {
-    this.tick = window.setTimeout(() => { schedule.run(world) }, this.time)
+  start(world, schedule, errorHandler) {
+    this.tick = window.setTimeout(() => { schedule.run(world, errorHandler) }, this.time)
   }
   stop() {
     clearTimeout(this.tick)

--- a/src/schedule/core/schedule.js
+++ b/src/schedule/core/schedule.js
@@ -49,11 +49,32 @@ export class Schedule {
   }
 
   /**
-   * @param {World} registry
+   * @param {World} world
+   * @param {(error: Error, world: World) => void} [errorHandler]
    */
-  run(registry) {
+  run(world, errorHandler) {
+    const handler =  errorHandler ?? defaultErrorHandler
+  
     for (let i = 0; i < this.systems.length; i++) {
-      if (this.condition.get(i)) this.systems[i](registry)
+      try {
+        if (this.condition.get(i)) this.systems[i](world)
+      } catch (error) {
+        if (error instanceof Error) {
+          handler(error, world)
+        } else if (typeof error === 'string') {
+          handler(new Error(error), world)
+        } else {
+          handler(new Error(String(error)), world)
+        }
+      }
     }
   }
+}
+
+/**
+ * @param {Error} error
+ * @throws {Error}
+ */
+function defaultErrorHandler(error) {
+    throw error
 }

--- a/src/schedule/core/schedule.js
+++ b/src/schedule/core/schedule.js
@@ -53,12 +53,12 @@ export class Schedule {
    * @param {(error: Error, world: World) => void} [errorHandler]
    */
   run(world, errorHandler) {
-    const handler =  errorHandler ?? defaultErrorHandler
-  
+    const handler = errorHandler ?? defaultErrorHandler
+
     for (let i = 0; i < this.systems.length; i++) {
       try {
         if (this.condition.get(i)) this.systems[i](world)
-      } catch (error) {
+      } catch(error) {
         if (error instanceof Error) {
           handler(error, world)
         } else if (typeof error === 'string') {
@@ -76,5 +76,5 @@ export class Schedule {
  * @throws {Error}
  */
 function defaultErrorHandler(error) {
-    throw error
+  throw error
 }

--- a/src/schedule/core/scheduler.js
+++ b/src/schedule/core/scheduler.js
@@ -27,11 +27,12 @@ export class Scheduler {
   /**
    * @param {string} label
    * @param {Executor} executor
+   * @param {(error: Error, world: World) => void} [errorHandler]
    */
-  set(label, executor) {
+  set(label, executor, errorHandler) {
     const schedule = new Schedule()
 
-    this.executables.set(label, new Executable(schedule, executor))
+    this.executables.set(label, new Executable(schedule, executor, errorHandler))
   }
 
   /**


### PR DESCRIPTION
## Objective

Introduce structured error handling into the scheduling when running systems.

### Behavior changes

* Systems no longer crash the entire schedule by default if a handler is provided
* Errors are caught per-system rather than per-app

## Solution

* Allow schedules to define an error handler
* Prevent a single system failure from crashing the entire application
* Provide a consistent error propagation mechanism across all executors

## Showcase

Users can now add error handlers

```js
app.createSchedule('update', executor, (error, world) => {
  // custom handling (log, recover, etc.)
})
```

## Migration guide

* `Executor.start` signature changed:

  ```js
  start(world, schedule, errorHandler)
  ```

* Custom executors must be updated to forward `errorHandler` to `schedule.run`

## Checklist

* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
