### PR TITLE
Add `Typeinfo` method registration

### DIFF
--- a/src/reflect/resources/typeregistry.js
+++ b/src/reflect/resources/typeregistry.js
@@ -1,6 +1,6 @@
 /** @import { TypeId, Constructor } from '../../type/index.js' */
 import { TypeInfo } from '../core/info.js'
-import { typeid } from '../../type/index.js'
+import { typeid, typeidFunction } from '../../type/index.js'
 
 export class TypeRegistry {
 
@@ -74,9 +74,68 @@ export class TypeEntry {
   info
 
   /**
+   * @private
+   * @type {Map<string, MethodEntry>}
+   */
+  methods = new Map()
+
+  /**
    * @param {TypeInfo} info
    */
   constructor(info) {
     this.info = info
+  }
+
+  /**
+   * 
+   * @template {unknown[]} T
+   * @param {string} name 
+   * @param {[...T]} args 
+   * @returns {unknown}
+   */
+  call(name, args) {
+    const method = this.getMethod(name)
+
+    if(method){
+      return method.call(args)
+    } else {
+      return undefined
+    }
+  }
+  
+  /**
+   * @param {string} name
+   */
+  getMethod(name){
+    return this.methods.get(name)
+  }
+  /**
+   * @param {Function} method
+   */
+  setMethod(method) {
+    this.methods.set(method.name,new MethodEntry(method))
+  }
+}
+
+export class MethodEntry {
+  
+  /**
+   * @type {Function}
+   */
+  method
+
+  /**
+   * @param {Function} method
+   */
+  constructor(method){
+    this.method = method
+  }
+  /**
+   * @template {unknown[]} T
+   * @param {[...T]} [args]
+   * @returns {unknown}
+   */
+  call(args){
+    return this.method(...(args || []))
   }
 }

--- a/src/reflect/resources/typeregistry.js
+++ b/src/reflect/resources/typeregistry.js
@@ -115,6 +115,13 @@ export class TypeEntry {
   setMethod(method) {
     this.methods.set(method.name,new MethodEntry(method))
   }
+
+  /**
+   * @returns {ReadonlyMap<string, readonly MethodEntry>}
+   */
+  getMethods(){
+    return this.methods
+  }
 }
 
 export class MethodEntry {

--- a/src/reflect/resources/typeregistry.js
+++ b/src/reflect/resources/typeregistry.js
@@ -1,6 +1,6 @@
 /** @import { TypeId, Constructor } from '../../type/index.js' */
 import { TypeInfo } from '../core/info.js'
-import { typeid, typeidFunction } from '../../type/index.js'
+import { typeid } from '../../type/index.js'
 
 export class TypeRegistry {
 
@@ -87,45 +87,46 @@ export class TypeEntry {
   }
 
   /**
-   * 
    * @template {unknown[]} T
-   * @param {string} name 
-   * @param {[...T]} args 
+   * @param {string} name
+   * @param {[...T]} args
    * @returns {unknown}
    */
   call(name, args) {
     const method = this.getMethod(name)
 
-    if(method){
+    if (method) {
       return method.call(args)
-    } else {
-      return undefined
     }
+
+    return undefined
+
   }
-  
+
   /**
    * @param {string} name
    */
-  getMethod(name){
+  getMethod(name) {
     return this.methods.get(name)
   }
+
   /**
    * @param {Function} method
    */
   setMethod(method) {
-    this.methods.set(method.name,new MethodEntry(method))
+    this.methods.set(method.name, new MethodEntry(method))
   }
 
   /**
    * @returns {ReadonlyMap<string, readonly MethodEntry>}
    */
-  getMethods(){
+  getMethods() {
     return this.methods
   }
 }
 
 export class MethodEntry {
-  
+
   /**
    * @type {Function}
    */
@@ -134,15 +135,16 @@ export class MethodEntry {
   /**
    * @param {Function} method
    */
-  constructor(method){
+  constructor(method) {
     this.method = method
   }
+
   /**
    * @template {unknown[]} T
    * @param {[...T]} [args]
    * @returns {unknown}
    */
-  call(args){
+  call(args) {
     return this.method(...(args || []))
   }
 }

--- a/src/reflect/systems/types.js
+++ b/src/reflect/systems/types.js
@@ -12,7 +12,7 @@ import {
   TupleInfo,
   TypeInfo
 } from '../core/index.js'
-import { TypeEntry, TypeRegistry } from '../resources/index.js'
+import { MethodEntry, TypeEntry, TypeRegistry } from '../resources/index.js'
 
 /**
  * @param {World} world
@@ -47,11 +47,13 @@ export function registerReflectTypes(world) {
   const typeIdArrayId = setTypeId('Array<TypeId>')
   const fieldArrayId = typeidGeneric(Array, [Field])
   const typeEntryMapId = setTypeId('Map<TypeId,TypeEntry>')
+  const methodEntryMapId = setTypeId(`Map<TypeId,${MethodEntry.name}>`)
 
   registry.registerTypeId(mapStringNumberId, new MapInfo(typeid(String), typeid(Number)))
   registry.registerTypeId(typeIdArrayId, new ArrayInfo(typeIdId))
   registry.registerTypeId(fieldArrayId, new ArrayInfo(typeid(Field)))
   registry.registerTypeId(typeEntryMapId, new MapInfo(typeIdId, typeid(TypeEntry)))
+  registry.registerTypeId(methodEntryMapId, new MapInfo(typeIdId, typeid(MethodEntry)))
 
   registry.register(TypeInfo, new OpaqueInfo())
   registry.register(Field, new StructInfo({
@@ -83,8 +85,11 @@ export function registerReflectTypes(world) {
   registry.register(TupleInfo, new StructInfo({
     elementTypes: new Field(typeIdArrayId)
   }))
+  registry.register(MethodEntry, new StructInfo({
+    method: new Field(typeid(Function))
+  }))
   registry.register(TypeEntry, new StructInfo({
-    info: new Field(typeid(TypeInfo))
+    info: new Field(typeid(TypeInfo)),
   }))
   registry.register(TypeRegistry, new StructInfo({
     inner: new Field(typeEntryMapId)

--- a/src/reflect/systems/types.js
+++ b/src/reflect/systems/types.js
@@ -89,7 +89,7 @@ export function registerReflectTypes(world) {
     method: new Field(typeid(Function))
   }))
   registry.register(TypeEntry, new StructInfo({
-    info: new Field(typeid(TypeInfo)),
+    info: new Field(typeid(TypeInfo))
   }))
   registry.register(TypeRegistry, new StructInfo({
     inner: new Field(typeEntryMapId)

--- a/src/reflect/tests/typeentry.test.js
+++ b/src/reflect/tests/typeentry.test.js
@@ -1,0 +1,45 @@
+import { test, describe } from "node:test";
+import { strictEqual } from "node:assert";
+import { StructInfo } from "../core/index.js";
+import { MethodEntry, TypeEntry } from "../resources/index.js";
+
+describe("Testing `TypeEntry` method registry", () => {
+  test("`TypeEntry` can set and get methods", () => {
+    /**
+     * @param {number} a
+     * @param {number} b
+     */
+    function add(a, b) {
+      return a + b;
+    }
+
+    const entry = new TypeEntry(StructInfo.default());
+    entry.setMethod(add);
+
+    const method = entry.getMethod("add");
+    strictEqual(method instanceof MethodEntry, true);
+    strictEqual(method?.call([2, 3]), 5);
+  });
+
+  test("`TypeEntry` can call methods by name", () => {
+    /**
+     * @param {number} a
+     * @param {number} b
+     */
+    function multiply(a, b) {
+      return a * b;
+    }
+
+    const entry = new TypeEntry(StructInfo.default());
+    entry.setMethod(multiply);
+
+    strictEqual(entry.call("multiply", [4, 5]), 20);
+  });
+
+  test("`TypeEntry` returns undefined for missing methods", () => {
+    const entry = new TypeEntry(StructInfo.default());
+
+    strictEqual(entry.call("missing", [1]), undefined);
+    strictEqual(entry.getMethod("missing"), undefined);
+  });
+});

--- a/src/reflect/tests/typeentry.test.js
+++ b/src/reflect/tests/typeentry.test.js
@@ -36,6 +36,33 @@ describe("Testing `TypeEntry` method registry", () => {
     strictEqual(entry.call("multiply", [4, 5]), 20);
   });
 
+  test("`TypeEntry` can return all methods", () => {
+    /**
+     * @param {number} a
+     * @param {number} b
+     */
+    function add(a, b) {
+      return a + b;
+    }
+
+    /**
+     * @param {number} a
+     * @param {number} b
+     */
+    function multiply(a, b) {
+      return a + b;
+    }
+
+    const entry = new TypeEntry(StructInfo.default());
+    entry.setMethod(add);
+    entry.setMethod(multiply);
+
+    const methods = entry.getMethods();
+    strictEqual(methods.size, 2);
+    strictEqual(methods.get("add") instanceof MethodEntry, true);
+    strictEqual(methods.get("multiply") instanceof MethodEntry, true);
+  });
+
   test("`TypeEntry` returns undefined for missing methods", () => {
     const entry = new TypeEntry(StructInfo.default());
 


### PR DESCRIPTION
## Objective

Extend the reflection system to support runtime method registration and invocation on types.

## Solution

The existing reflection system (`TypeRegistry` / `TypeEntry`) only stored **type metadata** (`TypeInfo`) but lacked support for:

- Associating **callable behavior** with types
- Dynamically invoking methods by name
- Extending types at runtime with additional functionality

This limited reflection to **static inspection** without **behavioral interaction**.

### Changes made

- Added method registry to `TypeEntry`
  - Maps method.name to `MethodEntry`
  - Co-locates behavior alongside type metadata
- Introduced `MethodEntry, a lightweight wrapper around a callable function.

### Why this approach

#### 1. Enables behavioral reflection

Moves reflection from **introspection-only** to **introspection + execution**

This is critical for:

- scripting layers
- editor tooling
- serialization systems with hooks
- behavior injection

#### 2. Minimal abstraction overhead

- `MethodEntry` is intentionally thin
- Avoids premature complexity (no binding, context, metadata yet)

#### 3. Extensible foundation

This design allows future additions:
- Method metadata (signatures, annotations)
- Context binding (`this`)
- Static vs instance methods
- Type-safe invocation layers

### Notes

- Anonymous functions will not register meaningfully
- Invocation uses positional arguments (`Array`)

## Showcase

```js
function add(a, b) {
  return a + b
}

const entry = new TypeEntry(info)

entry.setMethod(add)

entry.call("add", [2, 3]) // 5
```

### Direct method access

```js
const method = entry.getMethod("add")

method.call([10, 20]) // 30
```

## Migration guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
