### PR TITLE
Add `copy` and `clone` static methods to all components

### DIFF
--- a/src/animation/components/player.js
+++ b/src/animation/components/player.js
@@ -17,6 +17,30 @@ export class AnimationPlayer {
   current = null
 
   /**
+   * @param {AnimationPlayer} source
+   * @param {AnimationPlayer} target
+   */
+  static copy(source, target = new AnimationPlayer()) {
+    const animations = new Map()
+
+    source.animations.forEach((playback, id) => {
+      animations.set(id, Playback.copy(playback))
+    })
+
+    target.animations = animations
+    target.current = source.current
+
+    return target
+  }
+
+  /**
+   * @param {AnimationPlayer} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+
+  /**
    * @param {Handle<AnimationClip>} handle
    * @param {PlaybackSettings} settings
    */

--- a/src/animation/components/target.js
+++ b/src/animation/components/target.js
@@ -20,4 +20,22 @@ export class AnimationTarget {
     this.player = player
     this.id = id
   }
+
+  /**
+   * @param {AnimationTarget} source
+   * @param {AnimationTarget} target
+   */
+  static copy(source, target = new AnimationTarget(source.player, source.id)) {
+    target.player = source.player
+    target.id = source.id
+
+    return target
+  }
+
+  /**
+   * @param {AnimationTarget} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }

--- a/src/animation/core/playback.js
+++ b/src/animation/core/playback.js
@@ -31,13 +31,34 @@ export class Playback {
    * @param {PlaybackSettings} options
    */
   constructor({
-    duration,
+    duration = 1,
     speed = 1,
     repeatMode = PlaybackRepeat.None
-  }) {
+  } = {}) {
     this.duration = duration
     this.speed = speed
     this.repeatMode = repeatMode
+  }
+
+  /**
+   * @param {Playback} source
+   * @param {Playback} target
+   */
+  static copy(source, target = new Playback()) {
+    target.duration = source.duration
+    target.speed = source.speed
+    target.repeatMode = source.repeatMode
+    target.elapsed = source.elapsed
+    target.paused = source.paused
+
+    return target
+  }
+
+  /**
+   * @param {Playback} target
+   */
+  static clone(target) {
+    return this.copy(target)
   }
 
   start() {
@@ -81,7 +102,7 @@ export class Playback {
 
 /**
  * @typedef PlaybackSettings
- * @property {number} duration
+ * @property {number} [duration]
  * @property {number} [speed]
  * @property {PlaybackRepeat} [repeatMode]
  */

--- a/src/audio/components/audiooscillator.js
+++ b/src/audio/components/audiooscillator.js
@@ -43,6 +43,27 @@ export class AudioOscillator {
     this.detune = detune
     this.frequency = frequency
   }
+
+  /**
+   * @param {AudioOscillator} source
+   * @param {AudioOscillator} target
+   */
+  static copy(source, target = new AudioOscillator()){
+    target.sourceNode = source.sourceNode
+    target.attach = source.attach
+    target.type = source.type
+    target.detune = source.detune
+    target.frequency = source.frequency
+
+    return target
+  }
+
+  /**
+   * @param {AudioOscillator} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }
 
 /**

--- a/src/audio/components/audiooscillator.js
+++ b/src/audio/components/audiooscillator.js
@@ -48,7 +48,7 @@ export class AudioOscillator {
    * @param {AudioOscillator} source
    * @param {AudioOscillator} target
    */
-  static copy(source, target = new AudioOscillator()){
+  static copy(source, target = new AudioOscillator()) {
     target.sourceNode = source.sourceNode
     target.attach = source.attach
     target.type = source.type

--- a/src/audio/components/audioplayer.js
+++ b/src/audio/components/audioplayer.js
@@ -28,6 +28,25 @@ export class AudioPlayer {
     this.attach = attach
     this.audio = audio
   }
+
+  /**
+   * @param {AudioPlayer} source
+   * @param {AudioPlayer} target
+   */
+  static copy(source, target = new AudioPlayer()) {
+    target.sourceNode = source.sourceNode
+    target.attach = source.attach
+    target.audio = source.audio
+
+    return target
+  }
+
+  /**
+   * @param {AudioPlayer} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }
 
 /**

--- a/src/broadphase/components/hitbox.js
+++ b/src/broadphase/components/hitbox.js
@@ -1,3 +1,19 @@
 import { BoundingBox2D } from '../../geometry/index.js'
 
-export class PhysicsHitbox extends BoundingBox2D {}
+export class PhysicsHitbox extends BoundingBox2D {
+
+  /**
+   * @param {PhysicsHitbox} source
+   * @param {PhysicsHitbox} target
+   */
+  static copy(source, target = new PhysicsHitbox()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {PhysicsHitbox} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/emitter/components/emitter.js
+++ b/src/emitter/components/emitter.js
@@ -46,6 +46,27 @@ export class Emitter {
     this.burstCount = burstCount
     this.enabled = enabled
   }
+
+  /**
+   * @param {Emitter} source
+   * @param {Emitter} target
+   */
+  static copy(source, target = new Emitter()) {
+    target.prefab = source.prefab
+    target.patch = source.patch
+    target.lifetime = new Range(source.lifetime.start, source.lifetime.end)
+    target.burstCount = new Range(source.burstCount.start, source.burstCount.end)
+    target.enabled = source.enabled
+
+    return target
+  }
+
+  /**
+   * @param {Emitter} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }
 
 /**

--- a/src/emitter/components/particle.js
+++ b/src/emitter/components/particle.js
@@ -1,1 +1,17 @@
-export class Particle {}
+export class Particle {
+
+  /**
+   * @param {Particle} source
+   * @param {Particle} target
+   */
+  static copy(source, target = new Particle()) {
+    return target
+  }
+
+  /**
+   * @param {Particle} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/hierarchy/components/children.js
+++ b/src/hierarchy/components/children.js
@@ -21,6 +21,23 @@ export class Children {
   }
 
   /**
+   * @param {Children} source
+   * @param {Children} target
+   */
+  static copy(source, target = new Children()) {
+    target.list = source.list.slice()
+
+    return target
+  }
+
+  /**
+   * @param {Children} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+
+  /**
    * @param {Entity} entity
    */
   add(entity) {

--- a/src/hierarchy/components/parent.js
+++ b/src/hierarchy/components/parent.js
@@ -19,6 +19,23 @@ export class Parent {
   constructor(entity) {
     this.entity = entity
   }
+
+  /**
+   * @param {Parent} source
+   * @param {Parent} target
+   */
+  static copy(source, target = new Parent(source.entity)) {
+    target.entity = source.entity
+
+    return target
+  }
+
+  /**
+   * @param {Parent} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
   visit() {
     return [this.entity]
   }

--- a/src/movable/components/2d/acceleration.js
+++ b/src/movable/components/2d/acceleration.js
@@ -1,3 +1,19 @@
 import { Vector2 } from '../../../math/index.js'
 
-export class Acceleration2D extends Vector2 {}
+export class Acceleration2D extends Vector2 {
+
+  /**
+   * @param {Acceleration2D} source
+   * @param {Acceleration2D} target
+   */
+  static copy(source, target = new Acceleration2D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Acceleration2D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/movable/components/2d/rotation.js
+++ b/src/movable/components/2d/rotation.js
@@ -1,3 +1,21 @@
 import { Angle } from '../../../math/index.js'
 
-export class Rotation2D extends Angle {}
+export class Rotation2D extends Angle {
+
+  /**
+   * @param {Rotation2D} source
+   * @param {Rotation2D} target
+   */
+  static copy(source, target = new Rotation2D()) {
+    target.value = source.value
+
+    return target
+  }
+
+  /**
+   * @param {Rotation2D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/movable/components/2d/torque.js
+++ b/src/movable/components/2d/torque.js
@@ -1,3 +1,21 @@
 import { Angle } from '../../../math/index.js'
 
-export class Torque2D extends Angle {}
+export class Torque2D extends Angle {
+
+  /**
+   * @param {Torque2D} source
+   * @param {Torque2D} target
+   */
+  static copy(source, target = new Torque2D()) {
+    target.value = source.value
+
+    return target
+  }
+
+  /**
+   * @param {Torque2D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/movable/components/2d/velocity.js
+++ b/src/movable/components/2d/velocity.js
@@ -1,3 +1,19 @@
 import { Vector2 } from '../../../math/index.js'
 
-export class Velocity2D extends Vector2 {}
+export class Velocity2D extends Vector2 {
+
+  /**
+   * @param {Velocity2D} source
+   * @param {Velocity2D} target
+   */
+  static copy(source, target = new Velocity2D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Velocity2D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/movable/components/3d/acceleration.js
+++ b/src/movable/components/3d/acceleration.js
@@ -1,3 +1,19 @@
 import { Vector3 } from '../../../math/index.js'
 
-export class Acceleration3D extends Vector3 {}
+export class Acceleration3D extends Vector3 {
+
+  /**
+   * @param {Acceleration3D} source
+   * @param {Acceleration3D} target
+   */
+  static copy(source, target = new Acceleration3D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Acceleration3D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/movable/components/3d/rotation.js
+++ b/src/movable/components/3d/rotation.js
@@ -1,3 +1,19 @@
 import { Vector3 } from '../../../math/index.js'
 
-export class Rotation3D extends Vector3 {}
+export class Rotation3D extends Vector3 {
+
+  /**
+   * @param {Rotation3D} source
+   * @param {Rotation3D} target
+   */
+  static copy(source, target = new Rotation3D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Rotation3D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/movable/components/3d/torque.js
+++ b/src/movable/components/3d/torque.js
@@ -1,3 +1,19 @@
 import { Vector3 } from '../../../math/index.js'
 
-export class Torque3D extends Vector3 {}
+export class Torque3D extends Vector3 {
+
+  /**
+   * @param {Torque3D} source
+   * @param {Torque3D} target
+   */
+  static copy(source, target = new Torque3D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Torque3D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/movable/components/3d/velocity.js
+++ b/src/movable/components/3d/velocity.js
@@ -1,3 +1,19 @@
 import { Vector3 } from '../../../math/index.js'
 
-export class Velocity3D extends Vector3 {}
+export class Velocity3D extends Vector3 {
+
+  /**
+   * @param {Velocity3D} source
+   * @param {Velocity3D} target
+   */
+  static copy(source, target = new Velocity3D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Velocity3D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/name/components/name.js
+++ b/src/name/components/name.js
@@ -11,4 +11,21 @@ export class Name {
   constructor(name = '') {
     this.value = name
   }
+
+  /**
+   * @param {Name} source
+   * @param {Name} target
+   */
+  static copy(source, target = new Name('')) {
+    target.value = source.value
+
+    return target
+  }
+
+  /**
+   * @param {Name} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }

--- a/src/physics/components/collider.js
+++ b/src/physics/components/collider.js
@@ -54,6 +54,7 @@ export class Collider2D {
 
     target.vertices = vertices
     target.geometry = new Geometry(vertices)
+
     // @ts-ignore
     target.type = source.type
     target.angle = source.angle

--- a/src/physics/components/collider.js
+++ b/src/physics/components/collider.js
@@ -46,6 +46,29 @@ export class Collider2D {
   }
 
   /**
+   * @param {Collider2D} source
+   * @param {Collider2D} target
+   */
+  static copy(source, target = new Collider2D(source.vertices.map((v) => Vector2.copy(v)))) {
+    const vertices = source.vertices.map((v) => Vector2.copy(v))
+
+    target.vertices = vertices
+    target.geometry = new Geometry(vertices)
+    // @ts-ignore
+    target.type = source.type
+    target.angle = source.angle
+
+    return target
+  }
+
+  /**
+   * @param {Collider2D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+
+  /**
    * @param {number} width
    * @param {number} height
    */

--- a/src/physics/components/physicsproperties.js
+++ b/src/physics/components/physicsproperties.js
@@ -6,4 +6,27 @@ export class PhysicsProperties {
   sleep = false
   restitution = 0.7
   kineticFriction = 0.6
+
+  /**
+   * @param {PhysicsProperties} source
+   * @param {PhysicsProperties} target
+   */
+  static copy(source, target = new PhysicsProperties()) {
+    target.invinertia = source.invinertia
+    target.invmass = source.invmass
+    target.mask = source.mask
+    target.group = source.group
+    target.sleep = source.sleep
+    target.restitution = source.restitution
+    target.kineticFriction = source.kineticFriction
+
+    return target
+  }
+
+  /**
+   * @param {PhysicsProperties} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }

--- a/src/physics/components/softbody.js
+++ b/src/physics/components/softbody.js
@@ -1,2 +1,35 @@
-export class SoftBody2D {}
-export class SoftBody3D {}
+export class SoftBody2D {
+
+  /**
+   * @param {SoftBody2D} source
+   * @param {SoftBody2D} target
+   */
+  static copy(source, target = new SoftBody2D()) {
+    return target
+  }
+
+  /**
+   * @param {SoftBody2D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}
+
+export class SoftBody3D {
+
+  /**
+   * @param {SoftBody3D} source
+   * @param {SoftBody3D} target
+   */
+  static copy(source, target = new SoftBody3D()) {
+    return target
+  }
+
+  /**
+   * @param {SoftBody3D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/render-core/components/camera.js
+++ b/src/render-core/components/camera.js
@@ -1,4 +1,4 @@
-import { Projection, PerspectiveProjection } from '../core/index.js'
+import { OrthographicProjection, Projection, PerspectiveProjection } from '../core/index.js'
 
 export class Camera {
 
@@ -16,6 +16,31 @@ export class Camera {
     this.projection = projection
     this.near = near
     this.far = far
+  }
+
+  /**
+   * @param {Camera} source
+   * @param {Camera} target
+   */
+  static copy(source, target = new Camera(source.projection, source.near, source.far)) {
+    const {projection} = source
+    if (projection instanceof PerspectiveProjection) {
+      target.projection = new PerspectiveProjection(projection.fov, projection.aspect)
+    } else if (projection instanceof OrthographicProjection) {
+      target.projection = new OrthographicProjection(projection.left, projection.right, projection.top, projection.bottom)
+    }
+
+    target.near = source.near
+    target.far = source.far
+
+    return target
+  }
+
+  /**
+   * @param {Camera} target
+   */
+  static clone(target) {
+    return this.copy(target)
   }
   projectionMatrix() {
     return this.projection.asProjectionMatrix(this.near, this.far)

--- a/src/render-core/components/camera.js
+++ b/src/render-core/components/camera.js
@@ -23,7 +23,8 @@ export class Camera {
    * @param {Camera} target
    */
   static copy(source, target = new Camera(source.projection, source.near, source.far)) {
-    const {projection} = source
+    const { projection } = source
+
     if (projection instanceof PerspectiveProjection) {
       target.projection = new PerspectiveProjection(projection.fov, projection.aspect)
     } else if (projection instanceof OrthographicProjection) {

--- a/src/render-core/components/material.js
+++ b/src/render-core/components/material.js
@@ -17,6 +17,25 @@ export class Material2D {
   constructor(handle) {
     this.handle = handle
   }
+
+  /**
+   * @template {Material} U
+   * @param {Material2D<U>} source
+   * @param {Material2D<U>} target
+   */
+  static copy(source, target = new this(source.handle)) {
+    target.handle = source.handle.clone()
+
+    return target
+  }
+
+  /**
+   * @template {Material} U
+   * @param {Material2D<U>} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }
 
 /**
@@ -34,5 +53,24 @@ export class Material3D {
    */
   constructor(handle) {
     this.handle = handle
+  }
+
+  /**
+   * @template {Material} U
+   * @param {Material3D<U>} source
+   * @param {Material3D<U>} target
+   */
+  static copy(source, target = new this(source.handle)) {
+    target.handle = source.handle.clone()
+
+    return target
+  }
+
+  /**
+   * @template {Material} U
+   * @param {Material3D<U>} target
+   */
+  static clone(target) {
+    return this.copy(target)
   }
 }

--- a/src/render-core/components/mesh.js
+++ b/src/render-core/components/mesh.js
@@ -14,4 +14,21 @@ export class Meshed {
   constructor(handle) {
     this.handle = handle
   }
+
+  /**
+   * @param {Meshed} source
+   * @param {Meshed} target
+   */
+  static copy(source, target = new Meshed(source.handle)) {
+    target.handle = source.handle.clone()
+
+    return target
+  }
+
+  /**
+   * @param {Meshed} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }

--- a/src/render-core/components/renderlists.js
+++ b/src/render-core/components/renderlists.js
@@ -46,6 +46,23 @@ export class RenderLists {
   opaquePass = new Map()
 
   /**
+   * @template U
+   * @param {RenderLists<U>} _source
+   * @param {RenderLists<U>} target
+   */
+  static copy(_source, target = new this()) {
+    return target
+  }
+
+  /**
+   * @template U
+   * @param {RenderLists<U>} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+
+  /**
    * @param {TypeId} id
    * @returns {RenderType<T>[] | undefined}
    */

--- a/src/scene/components/instance.js
+++ b/src/scene/components/instance.js
@@ -20,4 +20,21 @@ export class SceneInstance {
   constructor(handle) {
     this.handle = handle
   }
+
+  /**
+   * @param {SceneInstance} source
+   * @param {SceneInstance} target
+   */
+  static copy(source, target = new SceneInstance(source.handle)) {
+    target.handle = source.handle.clone()
+
+    return target
+  }
+
+  /**
+   * @param {SceneInstance} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }

--- a/src/time/components/timer.js
+++ b/src/time/components/timer.js
@@ -81,6 +81,33 @@ export class Timer {
     this.paused = paused
   }
 
+  /**
+   * @param {Timer} source
+   * @param {Timer} target
+   */
+  static copy(source, target = new Timer()) {
+    target.mode = source.mode
+    target.duration = source.duration
+    target.speed = source.speed
+    target.paused = source.paused
+    target.elapsedCount = source.elapsedCount
+    target.elapsedTime = source.elapsedTime
+    target.finished = source.finished
+    target.startTicks = source.startTicks
+    target.endTicks = source.endTicks
+    target.playbackRequested = source.playbackRequested
+    target.playbackResolved = source.playbackResolved
+
+    return target
+  }
+
+  /**
+   * @param {Timer} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+
   elapsed() {
     return this.elapsedTime
   }

--- a/src/transform/components/2d/globaltransform.js
+++ b/src/transform/components/2d/globaltransform.js
@@ -1,3 +1,19 @@
 import { Affine2 } from '../../../math/index.js'
 
-export class GlobalTransform2D extends Affine2 {}
+export class GlobalTransform2D extends Affine2 {
+
+  /**
+   * @param {GlobalTransform2D} source
+   * @param {GlobalTransform2D} target
+   */
+  static copy(source, target = new GlobalTransform2D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {GlobalTransform2D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/transform/components/2d/orientation.js
+++ b/src/transform/components/2d/orientation.js
@@ -1,3 +1,19 @@
 import { Rotary } from '../../../math/index.js'
 
-export class Orientation2D extends Rotary {}
+export class Orientation2D extends Rotary {
+
+  /**
+   * @param {Orientation2D} source
+   * @param {Orientation2D} target
+   */
+  static copy(source, target = new Orientation2D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Orientation2D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/transform/components/2d/position.js
+++ b/src/transform/components/2d/position.js
@@ -1,3 +1,19 @@
 import { Vector2 } from '../../../math/index.js'
 
-export class Position2D extends Vector2 {}
+export class Position2D extends Vector2 {
+
+  /**
+   * @param {Position2D} source
+   * @param {Position2D} target
+   */
+  static copy(source, target = new Position2D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Position2D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/transform/components/2d/remote.js
+++ b/src/transform/components/2d/remote.js
@@ -34,4 +34,25 @@ export class RemoteTransform2D {
   constructor(entity) {
     this.entity = entity
   }
+
+  /**
+   * @param {RemoteTransform2D} source
+   * @param {RemoteTransform2D} target
+   */
+  static copy(source, target = new RemoteTransform2D(source.entity)) {
+    target.copyTranslation = source.copyTranslation
+    target.copyOrientation = source.copyOrientation
+    target.copyScale = source.copyScale
+    target.entity = source.entity
+    target.offsetTransform = Affine2.copy(source.offsetTransform, new Affine2())
+
+    return target
+  }
+
+  /**
+   * @param {RemoteTransform2D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }

--- a/src/transform/components/2d/scale.js
+++ b/src/transform/components/2d/scale.js
@@ -4,4 +4,19 @@ export class Scale2D extends Vector2 {
   constructor(x = 1, y = 1) {
     super(x, y)
   }
+
+  /**
+   * @param {Scale2D} source
+   * @param {Scale2D} target
+   */
+  static copy(source, target = new Scale2D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Scale2D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }

--- a/src/transform/components/3d/globaltransform.js
+++ b/src/transform/components/3d/globaltransform.js
@@ -1,3 +1,19 @@
 import { Affine3 } from '../../../math/index.js'
 
-export class GlobalTransform3D extends Affine3 { }
+export class GlobalTransform3D extends Affine3 {
+
+  /**
+   * @param {GlobalTransform3D} source
+   * @param {GlobalTransform3D} target
+   */
+  static copy(source, target = new GlobalTransform3D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {GlobalTransform3D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/transform/components/3d/orientation.js
+++ b/src/transform/components/3d/orientation.js
@@ -1,3 +1,19 @@
 import { Quaternion } from '../../../math/index.js'
 
-export class Orientation3D extends Quaternion {}
+export class Orientation3D extends Quaternion {
+
+  /**
+   * @param {Orientation3D} source
+   * @param {Orientation3D} target
+   */
+  static copy(source, target = new Orientation3D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Orientation3D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/transform/components/3d/position.js
+++ b/src/transform/components/3d/position.js
@@ -1,3 +1,19 @@
 import { Vector3 } from '../../../math/index.js'
 
-export class Position3D extends Vector3 {}
+export class Position3D extends Vector3 {
+
+  /**
+   * @param {Position3D} source
+   * @param {Position3D} target
+   */
+  static copy(source, target = new Position3D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Position3D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/transform/components/3d/remote.js
+++ b/src/transform/components/3d/remote.js
@@ -34,4 +34,25 @@ export class RemoteTransform3D {
   constructor(entity) {
     this.entity = entity
   }
+
+  /**
+   * @param {RemoteTransform3D} source
+   * @param {RemoteTransform3D} target
+   */
+  static copy(source, target = new RemoteTransform3D(source.entity)) {
+    target.copyTranslation = source.copyTranslation
+    target.copyOrientation = source.copyOrientation
+    target.copyScale = source.copyScale
+    target.entity = source.entity
+    target.offsetTransform = Affine3.copy(source.offsetTransform, new Affine3())
+
+    return target
+  }
+
+  /**
+   * @param {RemoteTransform3D} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }

--- a/src/transform/components/3d/scale.js
+++ b/src/transform/components/3d/scale.js
@@ -1,7 +1,23 @@
 import { Vector3 } from '../../../math/index.js'
 
 export class Scale3D extends Vector3 {
+
   constructor(x = 1, y = 1, z = 1) {
     super(x, y, z)
+  }
+
+  /**
+   * @param {Scale3D} source
+   * @param {Scale3D} target
+   */
+  static copy(source, target = new Scale3D()) {
+    return super.copy(source, target)
+  }
+
+  /**
+   * @param {Scale3D} target
+   */
+  static clone(target) {
+    return this.copy(target)
   }
 }

--- a/src/tween/components/markers.js
+++ b/src/tween/components/markers.js
@@ -16,4 +16,20 @@ export class TweenRepeat {
   }
 }
 
-export class TweenFlip { }
+export class TweenFlip {
+
+  /**
+   * @param {TweenFlip} source
+   * @param {TweenFlip} target
+   */
+  static copy(source, target = new TweenFlip()) {
+    return target
+  }
+
+  /**
+   * @param {TweenFlip} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/tween/components/markers.js
+++ b/src/tween/components/markers.js
@@ -1,2 +1,19 @@
-export class TweenRepeat { }
+export class TweenRepeat {
+
+  /**
+   * @param {TweenRepeat} source
+   * @param {TweenRepeat} target
+   */
+  static copy(source, target = new TweenRepeat()) {
+    return target
+  }
+
+  /**
+   * @param {TweenRepeat} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}
+
 export class TweenFlip { }

--- a/src/tween/components/tween.js
+++ b/src/tween/components/tween.js
@@ -70,6 +70,7 @@ export class Tween {
 
       // @ts-ignore
       if (ctor && typeof ctor.copy === 'function') {
+
         // @ts-ignore
         return ctor.copy(value)
       }

--- a/src/tween/components/tween.js
+++ b/src/tween/components/tween.js
@@ -68,10 +68,8 @@ export class Tween {
 
       const ctor = value.constructor
 
-      // @ts-ignore
-      if (ctor && typeof ctor.copy === 'function') {
+      if ('copy' in ctor && typeof ctor.copy === 'function') {
 
-        // @ts-ignore
         return ctor.copy(value)
       }
 

--- a/src/tween/components/tween.js
+++ b/src/tween/components/tween.js
@@ -54,4 +54,46 @@ export class Tween {
     this.duration = duration
     this.easing = easing
   }
+
+  /**
+   * @template U
+   * @param {Tween<U>} source
+   * @param {Tween<U>} target
+   */
+  static copy(source, target = new this(source.to, source.from, source.duration, source.repeat, source.flip, source.easing)) {
+    const cloneValue = (/** @type {U} */ value) => {
+      if (!value || typeof value !== 'object') {
+        return value
+      }
+
+      const ctor = value.constructor
+
+      // @ts-ignore
+      if (ctor && typeof ctor.copy === 'function') {
+        // @ts-ignore
+        return ctor.copy(value)
+      }
+
+      throw `The source cannot be copied with value type \`${ctor.name}\``
+    }
+
+    target.duration = source.duration
+    target.finish = source.finish
+    target.to = cloneValue(source.to)
+    target.from = cloneValue(source.from)
+    target.easing = source.easing
+    target.timeTaken = source.timeTaken
+    target.repeat = source.repeat
+    target.flip = source.flip
+
+    return target
+  }
+
+  /**
+   * @template U
+   * @param {Tween<U>} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
 }

--- a/src/type/core/typedef/index.js
+++ b/src/type/core/typedef/index.js
@@ -11,4 +11,14 @@
  * @template {unknown[]} T
  * @typedef {{[K in keyof T]:Constructor<T[K]>}} TupleConstructor
  */
+
+/**
+ * @template T
+ * @typedef {{ copy(value: T, out?: T): T }} Copy
+ */
+
+/**
+ * @template T
+ * @typedef {{ clone(value: T): T }} Clone 
+ */
 export default {}

--- a/src/type/core/typedef/index.js
+++ b/src/type/core/typedef/index.js
@@ -19,6 +19,6 @@
 
 /**
  * @template T
- * @typedef {{ clone(value: T): T }} Clone 
+ * @typedef {{ clone(value: T): T }} Clone
  */
 export default {}

--- a/src/window/components/main.js
+++ b/src/window/components/main.js
@@ -1,1 +1,17 @@
-export class MainWindow {}
+export class MainWindow {
+
+  /**
+   * @param {MainWindow} source
+   * @param {MainWindow} target
+   */
+  static copy(source, target = new MainWindow()) {
+    return target
+  }
+
+  /**
+   * @param {MainWindow} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+}

--- a/src/window/components/window.js
+++ b/src/window/components/window.js
@@ -28,6 +28,24 @@ export class Window {
   }
 
   /**
+   * @param {Window} source
+   * @param {Window} target
+   */
+  static copy(source, target = new Window()) {
+    target.width = source.width
+    target.height = source.height
+
+    return target
+  }
+
+  /**
+   * @param {Window} target
+   */
+  static clone(target) {
+    return this.copy(target)
+  }
+
+  /**
    * Returns width of the window.
    *
    * @returns {number}


### PR DESCRIPTION
## Objective

Introduce a standardized `copy` / `clone` API across ECS components and some core types.

## Solution

There was no unified or explicit mechanism for duplicating component state leading to:

- Inconsistent cloning behavior across systems
- Risk of shallow copies where deep copies are required
- Difficulty implementing higher-level features (entity cloning, undo/redo, prefab instancing)

### Changes made

- Introduced static `copy(source, target?)` and `clone(target)` methods across all components
- Added `Copy<T>` and `Clone<T>` typedefs to formalize the contract
- Implemented per-component copy logic:
- Delegation to base classes where applicable
- Normalized constructor defaults where required

### Why this approach

- **Static methods over instance methods**

  - Avoids mutation ambiguity (`a.copy(b)` vs `copy(a, b)`)
  - Aligns with data-oriented patterns (pure transformations)
- **`copy(source, target)` pattern**

  * Supports allocation-free reuse
  * Enables pooling
* **Explicit per-type implementations**

  * Avoids generic deep-clone overhead/reflection
  * Keeps control over semantics (critical for engine correctness)

## Showcase

### Before

```js
// No standard way to duplicate components

const a = new Position2D(1, 2)

// Shallow copy (incorrect for many types)
const b = { ...a }

// Manual reconstruction (inconsistent)
const c = new Position2D(a.x, a.y)
```

### After

```js
// Explicit cloning
const a = new Position2D(1, 2)

const b = Position2D.clone(a)

// Allocation-free reuse
const out = new Position2D()
Position2D.copy(a, out)
```

Expected:

```txt
b !== a
b.x === a.x
b.y === a.y
```

## Migration guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
