### PR TITLE
Register component `clone` and `copy` into type registry

### DIFF
--- a/src/animation/systems/types.js
+++ b/src/animation/systems/types.js
@@ -40,12 +40,18 @@ export function registerAnimationTypes(world) {
     repeatMode: new Field(playbackRepeatId),
     paused: new Field(typeid(Boolean))
   }))
+  registry.get(Playback)?.setMethod(Playback.copy)
+  registry.get(Playback)?.setMethod(Playback.clone)
   registry.register(AnimationPlayer, new StructInfo({
     animations: new Field(playbackMapId),
     current: new Field(typeid(Number), true)
   }))
+  registry.get(AnimationPlayer)?.setMethod(AnimationPlayer.copy)
+  registry.get(AnimationPlayer)?.setMethod(AnimationPlayer.clone)
   registry.register(AnimationTarget, new StructInfo({
     player: new Field(typeid(Entity)),
     id: new Field(typeid(String))
   }))
+  registry.get(AnimationTarget)?.setMethod(AnimationTarget.copy)
+  registry.get(AnimationTarget)?.setMethod(AnimationTarget.clone)
 }

--- a/src/audio/systems/types.js
+++ b/src/audio/systems/types.js
@@ -29,6 +29,8 @@ export function registerAudioTypes(world) {
     attach: new Field(typeid(Number), true),
     audio: new Field(typeidGeneric(Handle, [Audio]), true)
   }))
+  registry.get(AudioPlayer)?.setMethod(AudioPlayer.copy)
+  registry.get(AudioPlayer)?.setMethod(AudioPlayer.clone)
   registry.register(AudioOscillator, new StructInfo({
     sourceNode: new Field(typeid(Number), true),
     type: new Field(oscillatorTypeId),
@@ -36,6 +38,8 @@ export function registerAudioTypes(world) {
     detune: new Field(typeid(Number)),
     frequency: new Field(typeid(Number))
   }))
+  registry.get(AudioOscillator)?.setMethod(AudioOscillator.copy)
+  registry.get(AudioOscillator)?.setMethod(AudioOscillator.clone)
   registry.register(AudioGraph, new StructInfo({
     graph: new Field(typeid(GraphList))
   }))

--- a/src/broadphase/systems/types.js
+++ b/src/broadphase/systems/types.js
@@ -22,6 +22,8 @@ export function registerBroadphaseTypes2D(world) {
     max: new Field(typeid(Vector2)),
     min: new Field(typeid(Vector2))
   }))
+  registry.get(PhysicsHitbox)?.setMethod(PhysicsHitbox.copy)
+  registry.get(PhysicsHitbox)?.setMethod(PhysicsHitbox.clone)
   registry.register(Broadphase2D, new StructInfo({}))
   registry.register(CollisionPairs, new ArrayInfo(typeid(CollisionPair)))
 }

--- a/src/color/systems/types.js
+++ b/src/color/systems/types.js
@@ -16,4 +16,5 @@ export function registerColorTypes(world) {
     b: new Field(typeid(Number)),
     a: new Field(typeid(Number))
   }))
+  registry.get(Color)?.setMethod(Color.copy)
 }

--- a/src/geometry/systems/types.js
+++ b/src/geometry/systems/types.js
@@ -21,9 +21,11 @@ export function registerGeometryTypes(world) {
     max: new Field(typeid(Vector2)),
     min: new Field(typeid(Vector2))
   }))
+  registry.get(BoundingBox2D)?.setMethod(BoundingBox2D.copy)
   registry.register(BoundingCircle, new StructInfo({
     type: new Field(boundTypeId),
     r: new Field(typeid(Number)),
     pos: new Field(typeid(Vector2))
   }))
+  registry.get(BoundingCircle)?.setMethod(BoundingCircle.copy)
 }

--- a/src/hierarchy/systems/types.js
+++ b/src/hierarchy/systems/types.js
@@ -17,7 +17,11 @@ export function registerHierarchyTypes(world) {
   registry.register(Children, new StructInfo({
     list: new Field(entityArrayId)
   }))
+  registry.get(Children)?.setMethod(Children.copy)
+  registry.get(Children)?.setMethod(Children.clone)
   registry.register(Parent, new StructInfo({
     entity: new Field(typeid(Entity))
   }))
+  registry.get(Parent)?.setMethod(Parent.copy)
+  registry.get(Parent)?.setMethod(Parent.clone)
 }

--- a/src/movable/systems/types.js
+++ b/src/movable/systems/types.js
@@ -14,16 +14,24 @@ export function registerMovable2DTypes(world) {
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number))
   }))
+  registry.get(Velocity2D)?.setMethod(Velocity2D.copy)
+  registry.get(Velocity2D)?.setMethod(Velocity2D.clone)
   registry.register(Rotation2D, new StructInfo({
     value: new Field(typeid(Number))
   }))
+  registry.get(Rotation2D)?.setMethod(Rotation2D.copy)
+  registry.get(Rotation2D)?.setMethod(Rotation2D.clone)
   registry.register(Acceleration2D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number))
   }))
+  registry.get(Acceleration2D)?.setMethod(Acceleration2D.copy)
+  registry.get(Acceleration2D)?.setMethod(Acceleration2D.clone)
   registry.register(Torque2D, new StructInfo({
     value: new Field(typeid(Number))
   }))
+  registry.get(Torque2D)?.setMethod(Torque2D.copy)
+  registry.get(Torque2D)?.setMethod(Torque2D.clone)
 }
 
 /**
@@ -37,19 +45,27 @@ export function registerMovable3DTypes(world) {
     y: new Field(typeid(Number)),
     z: new Field(typeid(Number))
   }))
+  registry.get(Velocity3D)?.setMethod(Velocity3D.copy)
+  registry.get(Velocity3D)?.setMethod(Velocity3D.clone)
   registry.register(Rotation3D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number)),
     z: new Field(typeid(Number))
   }))
+  registry.get(Rotation3D)?.setMethod(Rotation3D.copy)
+  registry.get(Rotation3D)?.setMethod(Rotation3D.clone)
   registry.register(Acceleration3D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number)),
     z: new Field(typeid(Number))
   }))
+  registry.get(Acceleration3D)?.setMethod(Acceleration3D.copy)
+  registry.get(Acceleration3D)?.setMethod(Acceleration3D.clone)
   registry.register(Torque3D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number)),
     z: new Field(typeid(Number))
   }))
+  registry.get(Torque3D)?.setMethod(Torque3D.copy)
+  registry.get(Torque3D)?.setMethod(Torque3D.clone)
 }

--- a/src/name/systems/types.js
+++ b/src/name/systems/types.js
@@ -13,4 +13,6 @@ export function registerNameTypes(world) {
   registry.register(Name, new StructInfo({
     value: new Field(typeid(String))
   }))
+  registry.get(Name)?.setMethod(Name.copy)
+  registry.get(Name)?.setMethod(Name.clone)
 }

--- a/src/physics/systems/types.js
+++ b/src/physics/systems/types.js
@@ -26,6 +26,8 @@ export function registerPhysicsTypes(world) {
     vertices: new Field(vector2ArrayId),
     geometry: new Field(typeid(Geometry))
   }))
+  registry.get(Collider2D)?.setMethod(Collider2D.copy)
+  registry.get(Collider2D)?.setMethod(Collider2D.clone)
   registry.register(PhysicsProperties, new StructInfo({
     invinertia: new Field(typeid(Number)),
     invmass: new Field(typeid(Number)),
@@ -35,6 +37,12 @@ export function registerPhysicsTypes(world) {
     restitution: new Field(typeid(Number)),
     kineticFriction: new Field(typeid(Number))
   }))
+  registry.get(PhysicsProperties)?.setMethod(PhysicsProperties.copy)
+  registry.get(PhysicsProperties)?.setMethod(PhysicsProperties.clone)
   registry.register(SoftBody2D, new StructInfo({}))
+  registry.get(SoftBody2D)?.setMethod(SoftBody2D.copy)
+  registry.get(SoftBody2D)?.setMethod(SoftBody2D.clone)
   registry.register(SoftBody3D, new StructInfo({}))
+  registry.get(SoftBody3D)?.setMethod(SoftBody3D.copy)
+  registry.get(SoftBody3D)?.setMethod(SoftBody3D.clone)
 }

--- a/src/render-core/systems/types.js
+++ b/src/render-core/systems/types.js
@@ -89,11 +89,12 @@ export function registerMaterialTypes(component, material) {
     registry.register(component, new StructInfo({
       handle: new Field(handleTypeId)
     }))
-    if ("copy" in component && typeof component["copy"] === 'function') {
-      registry.get(component)?.setMethod(component["copy"])
+
+    if ('copy' in component && typeof component.copy === 'function') {
+      registry.get(component)?.setMethod(component.copy)
     }
-    if ("clone" in component && typeof component["clone"] === 'function') {
-      registry.get(component)?.setMethod(component["clone"])
+    if ('clone' in component && typeof component.clone === 'function') {
+      registry.get(component)?.setMethod(component.clone)
     }
   }
 }

--- a/src/render-core/systems/types.js
+++ b/src/render-core/systems/types.js
@@ -47,17 +47,25 @@ export function registerRenderCoreTypes(world) {
   registry.register(Meshed, new StructInfo({
     handle: new Field(typeidGeneric(Handle, [Mesh]))
   }))
+  registry.get(Meshed)?.setMethod(Meshed.copy)
+  registry.get(Meshed)?.setMethod(Meshed.clone)
   registry.register(BasicMaterial2D, new StructInfo({
     handle: new Field(basicMaterialHandleId)
   }))
+  registry.get(BasicMaterial2D)?.setMethod(BasicMaterial2D.copy)
+  registry.get(BasicMaterial2D)?.setMethod(BasicMaterial2D.clone)
   registry.register(BasicMaterial3D, new StructInfo({
     handle: new Field(basicMaterialHandleId)
   }))
+  registry.get(BasicMaterial3D)?.setMethod(BasicMaterial3D.copy)
+  registry.get(BasicMaterial3D)?.setMethod(BasicMaterial3D.clone)
   registry.register(Camera, new StructInfo({
     projection: new Field(typeid(Projection)),
     near: new Field(typeid(Number)),
     far: new Field(typeid(Number))
   }))
+  registry.get(Camera)?.setMethod(Camera.copy)
+  registry.get(Camera)?.setMethod(Camera.clone)
 }
 
 /**
@@ -81,5 +89,11 @@ export function registerMaterialTypes(component, material) {
     registry.register(component, new StructInfo({
       handle: new Field(handleTypeId)
     }))
+    if ("copy" in component && typeof component["copy"] === 'function') {
+      registry.get(component)?.setMethod(component["copy"])
+    }
+    if ("clone" in component && typeof component["clone"] === 'function') {
+      registry.get(component)?.setMethod(component["clone"])
+    }
   }
 }

--- a/src/time/systems/types.js
+++ b/src/time/systems/types.js
@@ -23,6 +23,8 @@ export function registerTimeTypes(world) {
     speed: new Field(typeid(Number)),
     paused: new Field(typeid(Boolean))
   }))
+  registry.get(Timer)?.setMethod(Timer.copy)
+  registry.get(Timer)?.setMethod(Timer.clone)
   registry.register(Clock, new StructInfo({
     elapsed: new Field(typeid(Number)),
     lastTick: new Field(typeid(Number)),

--- a/src/transform/systems/types.js
+++ b/src/transform/systems/types.js
@@ -26,14 +26,20 @@ export function registerTransform2DTypes(world) {
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number))
   }))
+  registry.get(Position2D)?.setMethod(Position2D.copy)
+  registry.get(Position2D)?.setMethod(Position2D.clone)
   registry.register(Orientation2D, new StructInfo({
     cos: new Field(typeid(Number)),
     sin: new Field(typeid(Number))
   }))
+  registry.get(Orientation2D)?.setMethod(Orientation2D.copy)
+  registry.get(Orientation2D)?.setMethod(Orientation2D.clone)
   registry.register(Scale2D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number))
   }))
+  registry.get(Scale2D)?.setMethod(Scale2D.copy)
+  registry.get(Scale2D)?.setMethod(Scale2D.clone)
   registry.register(GlobalTransform2D, new StructInfo({
     a: new Field(typeid(Number)),
     b: new Field(typeid(Number)),
@@ -42,6 +48,8 @@ export function registerTransform2DTypes(world) {
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number))
   }))
+  registry.get(GlobalTransform2D)?.setMethod(GlobalTransform2D.copy)
+  registry.get(GlobalTransform2D)?.setMethod(GlobalTransform2D.clone)
 }
 
 /**
@@ -55,17 +63,23 @@ export function registerTransform3DTypes(world) {
     y: new Field(typeid(Number)),
     z: new Field(typeid(Number))
   }))
+  registry.get(Position3D)?.setMethod(Position3D.copy)
+  registry.get(Position3D)?.setMethod(Position3D.clone)
   registry.register(Orientation3D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number)),
     z: new Field(typeid(Number)),
     w: new Field(typeid(Number))
   }))
+  registry.get(Orientation3D)?.setMethod(Orientation3D.copy)
+  registry.get(Orientation3D)?.setMethod(Orientation3D.clone)
   registry.register(Scale3D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number)),
     z: new Field(typeid(Number))
   }))
+  registry.get(Scale3D)?.setMethod(Scale3D.copy)
+  registry.get(Scale3D)?.setMethod(Scale3D.clone)
   registry.register(GlobalTransform3D, new StructInfo({
     a: new Field(typeid(Number)),
     b: new Field(typeid(Number)),
@@ -80,6 +94,8 @@ export function registerTransform3DTypes(world) {
     y: new Field(typeid(Number)),
     z: new Field(typeid(Number))
   }))
+  registry.get(GlobalTransform3D)?.setMethod(GlobalTransform3D.copy)
+  registry.get(GlobalTransform3D)?.setMethod(GlobalTransform3D.clone)
 }
 
 /**
@@ -95,6 +111,8 @@ export function registerRemoteTransform2DTypes(world) {
     entity: new Field(typeid(Entity)),
     offsetTransform: new Field(typeid(Affine2))
   }))
+  registry.get(RemoteTransform2D)?.setMethod(RemoteTransform2D.copy)
+  registry.get(RemoteTransform2D)?.setMethod(RemoteTransform2D.clone)
 }
 
 /**
@@ -110,4 +128,6 @@ export function registerRemoteTransform3DTypes(world) {
     entity: new Field(typeid(Entity)),
     offsetTransform: new Field(typeid(Affine3))
   }))
+  registry.get(RemoteTransform3D)?.setMethod(RemoteTransform3D.copy)
+  registry.get(RemoteTransform3D)?.setMethod(RemoteTransform3D.clone)
 }

--- a/src/tween/systems/types.js
+++ b/src/tween/systems/types.js
@@ -24,6 +24,8 @@ export function registerTweenTypes(tween, valueType) {
       repeat: new Field(typeid(Boolean)),
       flip: new Field(typeid(Boolean))
     }))
+    registry.get(tween)?.setMethod(tween.copy)
+    registry.get(tween)?.setMethod(tween.clone)
   }
 }
 
@@ -36,5 +38,9 @@ export function registerTweenMarkerTypes() {
 
     registry.register(TweenFlip, new StructInfo({}))
     registry.register(TweenRepeat, new StructInfo({}))
+    registry.get(TweenFlip)?.setMethod(TweenFlip.copy)
+    registry.get(TweenFlip)?.setMethod(TweenFlip.clone)
+    registry.get(TweenRepeat)?.setMethod(TweenRepeat.copy)
+    registry.get(TweenRepeat)?.setMethod(TweenRepeat.clone)
   }
 }

--- a/src/window/systems/types.js
+++ b/src/window/systems/types.js
@@ -25,7 +25,11 @@ export function registerWindowTypes(world) {
     height: new Field(typeid(Number)),
     selector: new Field(typeid(String), true)
   }))
+  registry.get(Window)?.setMethod(Window.copy)
+  registry.get(Window)?.setMethod(Window.clone)
   registry.register(MainWindow, new StructInfo({}))
+  registry.get(MainWindow)?.setMethod(MainWindow.copy)
+  registry.get(MainWindow)?.setMethod(MainWindow.clone)
   registry.register(Windows, new StructInfo({
     entities: new Field(entityWindowMapId)
   }))


### PR DESCRIPTION
## Objective

Integrate `copy` / `clone` semantics into the type registry system.

- Registers duplication methods for all ECS components in their respective modules
- Enables reflection-based systems to invoke component-specific duplication logic
- This is building upon #307
## Solution

Although `copy` / `clone` methods were introduced on components, they were not discoverable through the type registry. This adds a way to use the type registry to clone/copy components in reflection based systems without needing to know the underlying type.

### Changes made

Added method registrations for ` ``copy` and `clone` across all registered component types.

### Why this approach

- Enables generic systems to invoke `copy`/`clone` without hardcoding types
- Aligns duplication with existing metadata-driven workflows

## Showcase

### Before

```js
// Registry cannot perform cloning generically

const info = registry.get(Position2D)

// No way to invoke type-specific copy logic
// Requires manual handling per type
```

### After

```js
const info = registry.get(Position2D)

// Invoke registered method (pseudo-API)
const copy = info.call('copy', source)
```

## Migration guide

No migration required.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
