### PR TITLE
Fix spawning of entities in transform examples

### DIFF
--- a/examples/samples/transform/2d/propagate.js
+++ b/examples/samples/transform/2d/propagate.js
@@ -74,7 +74,7 @@ function addMeshes(world) {
     .insertPrefab([
       ...createTransform2D(0.4, 0, 0, 0.5, 0.5),
       new Meshed(mesh),
-      new BasicMaterial2D(material), ,
+      new BasicMaterial2D(material),
       new Parent(child)
     ])
     .build()

--- a/examples/samples/transform/3d/propagate.js
+++ b/examples/samples/transform/3d/propagate.js
@@ -73,7 +73,7 @@ function spawnMeshes(world) {
     .insertPrefab([
       ...createTransform3D(0.5, 0, 0, 0, 0, 0, 0.5, 0.5, 0.5),
       new Meshed(mesh),
-      new BasicMaterial3D(material), ,
+      new BasicMaterial3D(material),
       new Parent(child)
     ])
     .build()


### PR DESCRIPTION
## Objective

Fix a syntax error in transform examples.

## Solution

The root cause was an extra trailing comma in component instantiation inside the `insertPrefab` array, resulting in a crash as undefined is added as a component to the entity.

## Showcase

N/A

## Migration guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
