### PR TITLE
Enable orthographic camera 2d

### DIFF
--- a/src/render-canvas2d/systems/index.js
+++ b/src/render-canvas2d/systems/index.js
@@ -5,7 +5,7 @@ import { Assets } from '../../asset/index.js'
 import { Entity, Query } from '../../ecs/index.js'
 import { warn } from '../../logger/index.js'
 import { typeidGeneric, typeid } from '../../type/index.js'
-import { Material, Mesh, TextureCache, RenderLists2D, Camera } from '../../render-core/index.js'
+import { Material, Mesh, TextureCache, RenderLists2D, Camera, OrthographicProjection } from '../../render-core/index.js'
 import { GlobalTransform2D } from '../../transform/index.js'
 import { MainWindow, Windows, Window } from '../../window/index.js'
 
@@ -42,19 +42,41 @@ export function genrender(type, renderMaterial) {
 
     const ctx = canvas.getContext('2d')
 
-    const offsetX = window[1].getWidth() / 2
-    const offsetY = window[1].getHeight() / 2
+    const width = window[1].getWidth()
+    const height = window[1].getHeight()
+    const offsetX = width / 2
+    const offsetY = height / 2
 
     if (!ctx) return warn('2d context could not be created on the canvas.')
 
     // TODO: Return when this becomes default rendering system
     // ctx.clearRect(0, 0, canvas.width, canvas.height)
-    cameras.each(([cameraTransform, renderList]) => {
+    cameras.each(([cameraTransform, renderList, camera]) => {
       const view = GlobalTransform2D.invert(cameraTransform)
 
       ctx.save()
-      ctx.translate(offsetX, offsetY)
-      ctx.scale(offsetX, -offsetY)
+
+      if (camera.projection instanceof OrthographicProjection) {
+        const { projection } = camera
+        const projectionWidth = projection.right - projection.left
+        const projectionHeight = projection.top - projection.bottom
+        const projectionOffsetX = -(projection.right + projection.left) / projectionWidth
+        const projectionOffsetY = -(projection.top + projection.bottom) / projectionHeight
+
+        ctx.translate(offsetX, offsetY)
+        ctx.scale(offsetX, -offsetY)
+        ctx.transform(
+          2 / projectionWidth,
+          0,
+          0,
+          2 / projectionHeight,
+          projectionOffsetX,
+          projectionOffsetY
+        )
+      } else {
+        throw new Error('Unsupported camera projection for 2d camera')
+      }
+
       ctx.transform(
         view.a,
         view.b,

--- a/src/render-core/prefabs/camera2d.js
+++ b/src/render-core/prefabs/camera2d.js
@@ -1,5 +1,6 @@
 import { createTransform2D, GlobalTransform2D, Orientation2D, Position2D, Scale2D } from '../../transform/index.js'
 import { Camera, RenderLists2D } from '../components/index.js'
+import { OrthographicProjection } from '../core/index.js'
 
 /**
  * @param {number} x
@@ -10,5 +11,9 @@ import { Camera, RenderLists2D } from '../components/index.js'
  * @returns {[Position2D,Orientation2D,Scale2D,GlobalTransform2D,Camera,RenderLists2D]}
  */
 export function createCamera2D(x = 0, y = 0, a = 0, sx = 1, sy = 1) {
-  return [...createTransform2D(x, y, a, sx, sy), new Camera(), new RenderLists2D()]
+  return [
+    ...createTransform2D(x, y, a, sx, sy),
+    new Camera(new OrthographicProjection()),
+    new RenderLists2D()
+  ]
 }


### PR DESCRIPTION
## Objective

Introduce orthographic projection support for the Canvas2D renderer.

* Added projection-aware camera rendering to canvas2d renderer
* Updated the default 2D camera prefab to use `OrthographicProjection`

## Solution

Previously, the Canvas2D renderer assumed a fixed normalized coordinate space based entirely on window dimensions and ignored the camera projection entirely;
This tightly coupled rendering behavior to the canvas size and prevented cameras from defining their own projection bounds.

### Why this approach

Instead of baking projection assumptions into renderer logic, the camera now fully owns projection behavior.
Benefits:

* Custom orthographic bounds now affect rendering correctly
* World-space scaling behaves consistently
* Camera projection is now explicit and extensible
* Aligns the render's behavior with other renderers

## Showcase

### Before

```js
const camera = new Camera()

// Projection settings had no effect
// Canvas coordinates were implicitly normalized to window size
```

### After

```js
const camera = new Camera(
  new OrthographicProjection(-10, 10, 10, -10)
)
// Projection settings now has an effect
```

## Migration guide

2D cameras now require a supported projection, unsupported projection types now throw.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
