### PR TITLE
Fix invalid selector handling for DOM canvas windows

### DIFF
--- a/src/window-dom/hooks/window.js
+++ b/src/window-dom/hooks/window.js
@@ -11,25 +11,35 @@ export function openWindow(entity, world) {
 
   // SAFETY: Component is guaranteed as this is its component hook
   const window = /** @type {Window}*/(world.get(entity, Window))
+
+  if (window.selector) {
+    const canvas = document.querySelector(window.selector)
+    if (canvas instanceof HTMLCanvasElement) {
+      registerWindow(world,entity, canvas, window)
+      return
+    } else {
+      warn(`The provided selector '${window.selector}' does not yield a canvas element.`)
+    }
+  }
+
+  const canvas = document.createElement('canvas')
+
+  document.body.append(canvas)
+  registerWindow(world,entity, canvas, window)
+}
+
+/**
+ * @param {import("../../ecs/registry.js").World} world
+ * @param {import("../../ecs/index.js").Entity} entity
+ * @param {HTMLCanvasElement} canvas
+ * @param {Window} window
+ */
+function registerWindow(world, entity, canvas, window){
   const windows = world.getResource(Windows)
-  let element
-
-  if (window.selector) element = /** @type {HTMLElement | undefined}*/(document.querySelector(window.selector))
-  if (!element) {
-    element = document.createElement('canvas')
-  }
-  if (element.nodeName !== 'CANVAS') {
-    element = document.createElement('canvas')
-    warn(`The provided selector '${window.selector}' does not yield a canvas element.`)
-  }
-
-  const canvas = /** @type {HTMLCanvasElement}*/(element)
-
-  windows.setWindow(entity, canvas)
+  
   canvas.width = window.getWidth()
   canvas.height = window.getHeight()
-  document.body.append(canvas)
-
+  windows.setWindow(entity, canvas)
   // setting tabindex and focus to enable keyboard events
   // on the canvas element.
   canvas.tabIndex = -1
@@ -40,7 +50,6 @@ export function openWindow(entity, world) {
   setUpWindowEvents(world, canvas)
   setUpFileEvents(world, canvas)
 }
-
 /**
  * @type {ComponentHook}
  */

--- a/src/window-dom/hooks/window.js
+++ b/src/window-dom/hooks/window.js
@@ -14,18 +14,21 @@ export function openWindow(entity, world) {
 
   if (window.selector) {
     const canvas = document.querySelector(window.selector)
+
     if (canvas instanceof HTMLCanvasElement) {
-      registerWindow(world,entity, canvas, window)
+      registerWindow(world, entity, canvas, window)
+
       return
-    } else {
-      warn(`The provided selector '${window.selector}' does not yield a canvas element.`)
     }
+
+    warn(`The provided selector '${window.selector}' does not yield a canvas element.`)
+
   }
 
   const canvas = document.createElement('canvas')
 
   document.body.append(canvas)
-  registerWindow(world,entity, canvas, window)
+  registerWindow(world, entity, canvas, window)
 }
 
 /**
@@ -34,12 +37,13 @@ export function openWindow(entity, world) {
  * @param {HTMLCanvasElement} canvas
  * @param {Window} window
  */
-function registerWindow(world, entity, canvas, window){
+function registerWindow(world, entity, canvas, window) {
   const windows = world.getResource(Windows)
-  
+
   canvas.width = window.getWidth()
   canvas.height = window.getHeight()
   windows.setWindow(entity, canvas)
+
   // setting tabindex and focus to enable keyboard events
   // on the canvas element.
   canvas.tabIndex = -1
@@ -50,6 +54,7 @@ function registerWindow(world, entity, canvas, window){
   setUpWindowEvents(world, canvas)
   setUpFileEvents(world, canvas)
 }
+
 /**
  * @type {ComponentHook}
  */


### PR DESCRIPTION
## Objective

Fix invalid CSS selector handling in the DOM window hook.

## Solution

The previous implementation allowed invalid selector matches to continue through initialization before replacing them with a new canvas. This changes that by ensuring the selected canvas is used instead of replaced by a new canvas on DOM windowing

This also validates selector results immediately.

## Showcase

N/A

## Migration guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
