### PR TITLE
Make `PluginGroup.add` and `PluginGroup.remove` chainable

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -239,10 +239,13 @@ export class PluginGroup extends Plugin {
   /**
    * @template {Plugin} T
    * @param {T} plugin
-   * @returns {void}
+   * @returns {this}
    */
   add(plugin) {
     this.plugins.set(plugin.name(), plugin)
+
+    return this
+
   }
 
   /**
@@ -250,6 +253,8 @@ export class PluginGroup extends Plugin {
    */
   remove(id) {
     this.plugins.delete(id)
+
+    return this
   }
 
   /**


### PR DESCRIPTION
## Objective

Improve the `PluginGroup` API by enabling method chaining.

## Solution

Previously, `PluginGroup#add()` and `PluginGroup#remove()` mutated internal state but returned `void`.

This prevented fluent configuration patterns such as:

```js
group.add(pluginA).add(pluginB)
````

### Why this approach

Improves ergonomics for plugin composition

## Showcase

### Before

```js
const group = new PluginGroup()

group.add(pluginA)
group.add(pluginB)
group.remove(typeid(MyPlugin))
```

### After

```js
const group = new PluginGroup()
  .add(pluginA)
  .add(pluginB)
  .remove(typeid(MyPlugin))
```

## Migration guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
