### PR TITLE
Add system group support to scheduler configuration

### DIFF
--- a/src/schedule/core/systembuilder.js
+++ b/src/schedule/core/systembuilder.js
@@ -11,12 +11,24 @@ export class SchedulerBuilder {
   systems = []
 
   /**
+   * @private
+   * @type {SystemGroupConfig[]}
+   */
+  systemGroups = []
+
+  /**
    * @param {SystemConfig} config
    */
   add(config) {
     this.systems.push(config)
   }
 
+  /**
+   * @param {SystemGroupConfig} config
+   */
+  addGroup(config) {
+    this.systemGroups.push(config)
+  }
   /**
    * @param {Scheduler} scheduler
    */
@@ -32,3 +44,8 @@ export class SchedulerBuilder {
     }
   }
 }
+
+/**
+ * @typedef SystemGroupConfig
+ * @property {import('../../type/index.js').Constructor} label
+ */

--- a/src/schedule/core/systembuilder.js
+++ b/src/schedule/core/systembuilder.js
@@ -29,6 +29,7 @@ export class SchedulerBuilder {
   addGroup(config) {
     this.systemGroups.push(config)
   }
+
   /**
    * @param {Scheduler} scheduler
    */

--- a/src/schedule/core/systemconfig.js
+++ b/src/schedule/core/systemconfig.js
@@ -2,6 +2,10 @@
 export class SystemConfig {
 
   /**
+   * @type {import("../../type/index.js").Constructor | undefined}
+   */
+  systemGroup
+  /**
    * @type {SystemFunc}
    */
   system
@@ -14,9 +18,11 @@ export class SystemConfig {
   /**
    * @param {SystemFunc} system
    * @param {string} schedule
+   * @param {import("../../type/index.js").Constructor | undefined} [systemGroup]
    */
-  constructor(system, schedule) {
+  constructor(system, schedule, systemGroup) {
     this.system = system
     this.schedule = schedule
+    this.systemGroup = systemGroup
   }
 }

--- a/src/schedule/core/systemconfig.js
+++ b/src/schedule/core/systemconfig.js
@@ -5,6 +5,7 @@ export class SystemConfig {
    * @type {import("../../type/index.js").Constructor | undefined}
    */
   systemGroup
+
   /**
    * @type {SystemFunc}
    */


### PR DESCRIPTION
## Objective

Introduce system group support to the scheduling configuration layer.

* Add system group registration to `SchedulerBuilder`
* Extend `SystemConfig` with optional group metadata
* Prepare the scheduler architecture for grouped system organization and execution

## Solution

Previously, systems could only be registered as a flat list within the scheduler builder.

This limited the ability to:

* Organize systems into logical execution groups
* Attach metadata to groups
* Build future grouped execution or ordering behavior

### Why this approach

Adding grouping metadata at the configuration layer:

* Keeps the scheduler extensible
* Avoids coupling group semantics directly into system execution
* Enables future features such as:

  * grouped ordering
  * conditional execution
  * hierarchical scheduling
  * debugging/visualization tooling

Using constructor labels also aligns with the engine's existing type-based identification patterns.

## Showcase

### Before

Systems were registered independently,No grouping metadata existed.:

```js 
new SystemConfig(system, 'update')
```



### After

Systems can now declare a group:

```js
new SystemConfig(system, 'update', RenderSystems)
```

Groups can also be registered explicitly:

```js
builder.addGroup({
  label: RenderSystems
})
```

Benefits:

* Systems can now be categorized structurally and semantically
* Scheduler configuration becomes more extensible
* Future grouped execution logic can build on existing metadata

Notes:

* System grouping currently introduces configuration metadata only
* Existing scheduling behavior remains unchanged
* System groups is optional and fully backwards compatible

## Migration guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
