### PR TITLE
Implement explicit system ordering

### DIFF
--- a/examples/samples/utils.js
+++ b/examples/samples/utils.js
@@ -1,21 +1,13 @@
 import {
   World,
-  AppSchedule,
   AssetServer,
   Assets,
   createCamera3D,
   EntityCommands,
   createCamera2D,
   Plugin,
-  App,
   typeidGeneric,
-  Audio,
-  Image,
-  Mesh,
-  BasicMaterial,
   Parser,
-  AudioParser,
-  ImageParser,
   Query,
   WindowCommands,
   Entity,
@@ -92,15 +84,8 @@ export function setupViewportWebgl(world) {
 
 // Sometimes features that are supposed to be there arent, this plugin
 // provides some hacks to "just enable" code to work until they land.
-export class HackPlugin extends Plugin {
-
-  /**
-   * @param {App} app
-   */
-  register(app) {
-
-  }
-}
+// TODO: Remove this
+export class HackPlugin extends Plugin {}
 
 /**
  * @template T

--- a/examples/samples/utils.js
+++ b/examples/samples/utils.js
@@ -99,16 +99,6 @@ export class HackPlugin extends Plugin {
    */
   register(app) {
 
-    // HACK: This is a hack until system sets and ordering is introduced.
-    {
-      app
-        .registerSystem({ schedule: AppSchedule.Startup, system: registerAssetOnAssetServer(Audio) })
-        .registerSystem({ schedule: AppSchedule.Startup, system: registerAssetOnAssetServer(Image) })
-        .registerSystem({ schedule: AppSchedule.Startup, system: registerAssetOnAssetServer(Mesh) })
-        .registerSystem({ schedule: AppSchedule.Startup, system: registerAssetOnAssetServer(BasicMaterial) })
-        .registerSystem({ schedule: AppSchedule.Startup, system: registerAssetParserOnAssetServer(Audio, new AudioParser()) })
-        .registerSystem({ schedule: AppSchedule.Startup, system: registerAssetParserOnAssetServer(Image, new ImageParser()) })
-    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "wima",
       "version": "0.3.0",
       "license": "SEE LICENSE in LICENSE.txt",
+      "dependencies": {
+        "vifaa": "^0.1.0"
+      },
       "devDependencies": {
         "@rollup/plugin-terser": "^1.0.0",
         "@stylistic/eslint-plugin": "^5.1.0",
@@ -4598,6 +4601,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/vifaa": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vifaa/-/vifaa-0.1.0.tgz",
+      "integrity": "sha512-Ojqrj/kk88E8jSDBFL/bueN2bPPB2Dnl+WMriSjc/X87/y3tCyVaxRU4SgjBXhAXiXfkrL8PgFhlXVBKS1ssjQ==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
   },
   "files": [
     "dist/*"
-  ]
+  ],
+  "dependencies": {
+    "vifaa": "^0.1.0"
+  }
 }

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,5 +1,5 @@
 /** @import { SystemFunc } from '../ecs/index.js' */
-/** @import { SystemConfig } from '../schedule/index.js' */
+/** @import { SystemConfig, SystemGroupConfig } from '../schedule/index.js' */
 /** @import { Constructor,TypeId } from '../type/index.js'*/
 
 import { World, ComponentHooks } from '../ecs/index.js'
@@ -85,15 +85,6 @@ export class App {
   initialized = false
 
   /**
-   * This will be removed in future revisions
-   * with no prior notice after system ordering is
-   * added.
-   *
-   * @type {SystemConfig[]}
-   */
-  systemsevents = []
-
-  /**
    * @private
    * @type {SchedulerBuilder}
    */
@@ -134,14 +125,6 @@ export class App {
   run() {
     this.plugins.register(this)
 
-    for (let i = 0; i < this.systemsevents.length; i++) {
-      const ev = this.systemsevents[i]
-
-      this.systemBuilder.add(ev)
-    }
-
-    this.systemsevents = []
-
     this.systemBuilder.pushToScheduler(this.scheduler)
     assert(this.runner, 'App runner is not set. Call `app.setRunner(...)` before `app.run()`.')
     this.runner(this.scheduler, this.world)
@@ -171,6 +154,15 @@ export class App {
    */
   registerSystem(config) {
     this.systemBuilder.add(config)
+
+    return this
+  }
+
+  /**
+   * @param {SystemGroupConfig} config
+   */
+  registerSystemGroup(config) {
+    this.systemBuilder.addGroup(config)
 
     return this
   }

--- a/src/asset/plugins/asset.js
+++ b/src/asset/plugins/asset.js
@@ -3,7 +3,7 @@
 import { App, Plugin } from '../../app/index.js'
 import { AppSchedule } from '../../core/index.js'
 import { EventPlugin } from '../../event/index.js'
-import { typeidGeneric } from '../../type/index.js'
+import { typeid, typeidGeneric } from '../../type/index.js'
 import { Assets } from '../core/index.js'
 import { AssetAdded, AssetDropped, AssetModified } from '../events/index.js'
 import { registerAssetTypes, registerAssetOnAssetServer, unloadDroppedAssets, updateAssetEvents } from '../systems/index.js'
@@ -55,12 +55,28 @@ export class AssetPlugin extends Plugin {
         .registerPlugin(new EventPlugin({
           event: events.dropped
         }))
-        .registerSystem({ schedule: AppSchedule.Update, system: updateAssetEvents(asset, events) })
-        .registerSystem({ schedule: AppSchedule.Update, system: unloadDroppedAssets(events.dropped) })
+        .registerSystem({
+          label: `updateAssetEvents<${typeid(asset)}>`,
+          schedule: AppSchedule.Update,
+          system: updateAssetEvents(asset, events)
+        })
+        .registerSystem({
+          label: `unloadDroppedAssets<${typeid(events.dropped)}>`,
+          schedule: AppSchedule.Update,
+          system: unloadDroppedAssets(events.dropped)
+        })
     }
 
-    app.registerSystem({ schedule: AppSchedule.Startup, system: registerAssetOnAssetServer(asset) })
-    app.registerSystem({ schedule: AppSchedule.Startup, system: registerAssetTypes(asset) })
+    app.registerSystem({
+      label: `registerAssetOnAssetServer<${typeid(asset)}>`,
+      schedule: AppSchedule.Startup,
+      system: registerAssetOnAssetServer(asset)
+    })
+    app.registerSystem({
+      label: `registerAssetTypes<${typeid(asset)}>`,
+      schedule: AppSchedule.Startup,
+      system: registerAssetTypes(asset)
+    })
     world.setResourceByTypeId(
       typeidGeneric(Assets, [asset]),
       new Assets(asset)

--- a/src/asset/plugins/parser.js
+++ b/src/asset/plugins/parser.js
@@ -1,7 +1,7 @@
 /** @import {Constructor} from '../../type/index.js' */
 import { App, Plugin } from '../../app/index.js'
 import { AppSchedule } from '../../core/index.js'
-import { typeidGeneric } from '../../type/index.js'
+import { typeid, typeidGeneric } from '../../type/index.js'
 import { Parser } from '../core/index.js'
 import { registerAssetParserOnAssetServer } from '../systems/index.js'
 
@@ -41,7 +41,11 @@ export class AssetParserPlugin extends Plugin {
     const { asset, parser } = this
 
     app
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerAssetParserOnAssetServer(asset, parser) })
+      .registerSystem({
+        label: `registerAssetParserOnAssetServer<${typeid(asset)}>`,
+        schedule: AppSchedule.Startup,
+        system: registerAssetParserOnAssetServer(asset, parser)
+      })
   }
 
   name() {

--- a/src/event/plugin.js
+++ b/src/event/plugin.js
@@ -3,7 +3,7 @@
 import { App, Plugin } from '../app/index.js'
 import { makeEventClear, registerEventTypes } from './systems/index.js'
 import { Events } from './core/index.js'
-import { typeidGeneric } from '../type/index.js'
+import { typeid, typeidGeneric } from '../type/index.js'
 import { AppSchedule } from '../core/index.js'
 
 /**
@@ -43,14 +43,23 @@ export class EventPlugin extends Plugin {
 
     app
       .registerType(event)
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerEventTypes(event) })
+      .registerSystem({
+        label: `registerEventTypes<${typeid(event)}>`,
+        schedule: AppSchedule.Startup,
+        system: registerEventTypes(event)
+      })
       .getWorld()
       .setResourceByTypeId(name, new Events())
 
-    // TODO - Once system ordering is implemented,remove this
-    // and `App.systemsevents`.
     if (this.autoClearEvent) {
-      app.systemsevents.push({ schedule: AppSchedule.Update, system: makeEventClear(name) })
+      app
+        .registerSystemGroup({ label: event, schedule: AppSchedule.Update })
+        .registerSystem({
+          label: `clearEvents<${typeid(event)}>`,
+          schedule: AppSchedule.Update,
+          systemGroup: event,
+          system: makeEventClear(name)
+        })
     }
   }
 

--- a/src/physics/plugins/plugin.js
+++ b/src/physics/plugins/plugin.js
@@ -5,10 +5,10 @@ import { NarrowPhase2DPlugin } from '../../narrowphase/index.js'
 import { EulerIntegrator2DPlugin } from '../../integrator/index.js'
 import { Collider2D, PhysicsProperties, SoftBody2D, SoftBody3D } from '../components/index.js'
 import { physicspropertiesAddHook } from '../hooks/index.js'
-import { Gravity2DPlugin } from '../../gravity/index.js'
 import { collisionResponse, registerPhysicsTypes, updateBodies, updateBounds } from '../systems/index.js'
 import { AppSchedule } from '../../core/index.js'
 
+// TODO: Convert to a plugin group
 export class Physics2DPlugin extends Plugin {
 
   /**
@@ -25,6 +25,8 @@ export class Physics2DPlugin extends Plugin {
     super()
     this.broadphase = broadphase
     this.narrowphase = narrowphase
+
+    // TODO: Remove this, legacy option
     this.integrator = integrator
     this.autoUpdateBounds = autoUpdateBounds
   }
@@ -52,11 +54,9 @@ export class Physics2DPlugin extends Plugin {
     if (this.autoUpdateBounds) app.registerSystem({ schedule: AppSchedule.Update, system: updateBounds })
 
     app
-      .registerPlugin(new Gravity2DPlugin())
       .registerPlugin(this.broadphase)
       .registerPlugin(this.narrowphase)
       .registerSystem({ schedule: AppSchedule.Update, system: collisionResponse })
-      .registerPlugin(this.integrator)
   }
 }
 

--- a/src/render-core/plugins/material.js
+++ b/src/render-core/plugins/material.js
@@ -2,7 +2,7 @@
 
 import { App, Plugin } from '../../app/index.js'
 import { AppSchedule } from '../../core/index.js'
-import { typeidGeneric } from '../../type/index.js'
+import { typeid, typeidGeneric } from '../../type/index.js'
 import { Material } from '../assets/index.js'
 import { Material2D, Material3D } from '../components/index.js'
 import { genBinRenderables2D, genBinRenderables3D, registerMaterialTypes } from '../systems/index.js'
@@ -41,8 +41,16 @@ export class Material2DPlugin extends Plugin {
 
     app
       .registerType(component)
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerMaterialTypes(component, asset) })
-      .registerSystem({ schedule: AppSchedule.Update, system: genBinRenderables2D(asset, component) })
+      .registerSystem({
+        schedule: AppSchedule.Startup,
+        label: `registerMaterialTypes<${typeid(asset)}>`,
+        system: registerMaterialTypes(component, asset)
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        label: `registerMaterialTypes<${typeid(asset)}>`,
+        system: genBinRenderables2D(asset, component)
+      })
   }
 
   /**

--- a/src/schedule/core/systembuilder.js
+++ b/src/schedule/core/systembuilder.js
@@ -102,6 +102,7 @@ export class SchedulerBuilder {
 
       context.systems.push(system)
       context.systemIdsByFunc.set(systemLabel, system.id)
+
       // context.systemIdsByFunc.set(systemLabel, system.id) // Removed as it's no longer used
 
       if (systemLabel !== '') {
@@ -216,9 +217,9 @@ export class SchedulerBuilder {
   addNodeOrdering(context, graph, graphIdsBySystemId, edges, source, before, after) {
     if (before) {
 
-
       for (let i = 0; i < before.length; i++) {
         const label = describeReference(before[i])
+
         this.addExpandedEdge(context, graph, graphIdsBySystemId, edges, source, this.resolveNode(context, label), before[i])
         this.addExpandedEdge(context, graph, graphIdsBySystemId, edges, source, this.resolveNode(context, label), label)
       }
@@ -227,6 +228,7 @@ export class SchedulerBuilder {
     if (after) {
       for (let i = 0; i < after.length; i++) {
         const label = describeReference(after[i])
+
         this.addExpandedEdge(context, graph, graphIdsBySystemId, edges, this.resolveNode(context, label), source, after[i])
         this.addExpandedEdge(context, graph, graphIdsBySystemId, edges, this.resolveNode(context, label), source, label)
       }
@@ -319,6 +321,7 @@ function getOrCreateScheduleContext(schedules, label) {
     nodesByLabel: new Map(),
     groupIdsByTypeId: new Map(),
     systemIdsByFunc: new Map()
+
     // systemIdsByFunc: new Map() // Removed as it's no longer used
   })
 

--- a/src/schedule/core/systembuilder.js
+++ b/src/schedule/core/systembuilder.js
@@ -1,5 +1,9 @@
-/** @import { Scheduler, SystemConfig } from '../index.js' */
-import { assert } from '../../logger/index.js'
+/** @import { Scheduler, SystemConfig, SystemGroupConfig } from '../index.js' */
+/** @import { SystemFunc } from '../../ecs/index.js' */
+/** @import { Constructor, TypeId } from '../../type/index.js' */
+import { Graph, kahnTopologySort } from 'vifaa'
+import { assert, throws } from '../../logger/index.js'
+import { typeid } from '../../type/index.js'
 
 export class SchedulerBuilder {
 
@@ -33,19 +37,336 @@ export class SchedulerBuilder {
    * @param {Scheduler} scheduler
    */
   pushToScheduler(scheduler) {
+    const schedules = this.createScheduleContexts()
+
+    for (const [scheduleLabel, context] of schedules) {
+      const schedule = scheduler.get(scheduleLabel)
+
+      assert(schedule, `The schedule label "${scheduleLabel}" is not set in the provided \`Scheduler\`.`)
+
+      for (const system of this.sortScheduleSystems(context)) {
+        schedule.add(system.config.system)
+      }
+    }
+  }
+
+  /**
+   * @private
+   * @returns {Map<string, ScheduleContext>}
+   */
+  createScheduleContexts() {
+
+    /** @type {Map<string, ScheduleContext>} */
+    const schedules = new Map()
+
+    for (let i = 0; i < this.systemGroups.length; i++) {
+      const config = this.systemGroups[i]
+      const context = getOrCreateScheduleContext(schedules, config.schedule)
+      const groupTypeId = typeid(config.label)
+
+      if (context.groupIdsByTypeId.has(groupTypeId)) {
+        throws(`Duplicate system group label "${config.label.name}" on schedule "${config.schedule}".`)
+      }
+
+      /** @type {SystemGroupRegistration} */
+      const group = {
+        id: context.groups.length,
+        config,
+        systems: []
+      }
+
+      context.groups.push(group)
+      context.groupIdsByTypeId.set(groupTypeId, group.id)
+
+      const groupLabel = config.label.name
+
+      if (groupLabel !== '') {
+        const existing = context.nodesByLabel.get(groupLabel)
+
+        if (existing) {
+          throws(`Duplicate system group label "${groupLabel}" on schedule "${config.schedule}". Use a unique label or direct function references in ordering.`)
+        }
+
+        context.nodesByLabel.set(groupLabel, { kind: ScheduleNodeKind.Group, id: group.id })
+      }
+    }
+
     for (let i = 0; i < this.systems.length; i++) {
       const config = this.systems[i]
+      const context = getOrCreateScheduleContext(schedules, config.schedule)
+      const systemLabel = config.label || config.system.name
+      const system = {
+        id: context.systems.length,
+        config
+      }
 
-      const schedule = scheduler.get(config.schedule)
+      context.systems.push(system)
+      context.systemIdsByFunc.set(systemLabel, system.id)
+      // context.systemIdsByFunc.set(systemLabel, system.id) // Removed as it's no longer used
 
-      assert(schedule, `The schedule label "${config.schedule}" is not set in the provided \`Scheduler\`.`)
+      if (systemLabel !== '') {
+        const existing = context.nodesByLabel.get(systemLabel)
 
-      schedule.add(config.system)
+        if (existing) {
+          throws(`Duplicate system label "${systemLabel}" on schedule "${config.schedule}". Use a unique label or direct function references in ordering.`)
+        }
+
+        context.nodesByLabel.set(systemLabel, { kind: ScheduleNodeKind.System, id: system.id })
+      }
     }
+
+    for (const [scheduleLabel, context] of schedules) {
+      for (let i = 0; i < context.systems.length; i++) {
+        const system = context.systems[i]
+        const groupLabel = system.config.systemGroup
+
+        if (!groupLabel) continue
+
+        const groupId = context.groupIdsByTypeId.get(typeid(groupLabel))
+
+        if (groupId === undefined) {
+          throws(`The system group "${groupLabel.name}" must be registered explicitly before it can be used on schedule "${scheduleLabel}".`)
+        }
+
+        context.groups[groupId].systems.push(system.id)
+      }
+    }
+
+    return schedules
+  }
+
+  /**
+   * @private
+   * @param {ScheduleContext} context
+   * @returns {SystemRegistration[]}
+   */
+  sortScheduleSystems(context) {
+    const graph = this.expandScheduleGraph(context)
+    const sorted = kahnTopologySort(graph)
+
+    if (!sorted) {
+      throws(`Schedule "${context.label}" contains cyclic system ordering constraints.`)
+    }
+
+    /** @type {SystemRegistration[]} */
+    const ordered = []
+
+    for (let i = 0; i < sorted.length; i++) {
+      const system = graph.getNodeWeight(sorted[i])
+
+      assert(system, `Internal error: Could not resolve system node ${sorted[i]} on schedule "${context.label}".`)
+      ordered.push(system)
+    }
+
+    return ordered
+  }
+
+  /**
+   * @private
+   * @param {ScheduleContext} context
+   * @returns {Graph<SystemRegistration, undefined>}
+   */
+  expandScheduleGraph(context) {
+    const graph = /** @type {Graph<SystemRegistration, undefined>} */ (new Graph(true))
+
+    /** @type {Map<number, number>} */
+    const graphIdsBySystemId = new Map()
+
+    /** @type {Set<string>} */
+    const edges = new Set()
+
+    for (let i = 0; i < context.systems.length; i++) {
+      const system = context.systems[i]
+      const graphId = graph.addNode(system)
+
+      graphIdsBySystemId.set(system.id, graphId)
+    }
+
+    for (let i = 0; i < context.systems.length; i++) {
+      const system = context.systems[i]
+
+      this.addNodeOrdering(context, graph, graphIdsBySystemId, edges, {
+        kind: ScheduleNodeKind.System,
+        id: system.id
+      }, system.config.before, system.config.after)
+    }
+
+    for (let i = 0; i < context.groups.length; i++) {
+      const group = context.groups[i]
+
+      this.addNodeOrdering(context, graph, graphIdsBySystemId, edges, {
+        kind: ScheduleNodeKind.Group,
+        id: group.id
+      }, group.config.before, group.config.after)
+    }
+
+    return graph
+  }
+
+  /**
+   * @private
+   * @param {ScheduleContext} context
+   * @param {Graph<SystemRegistration, undefined>} graph
+   * @param {Map<number, number>} graphIdsBySystemId
+   * @param {Set<string>} edges
+   * @param {ScheduleNodeRef} source
+   * @param {(SystemFunc | Constructor | string)[] | undefined} before
+   * @param {(SystemFunc | Constructor | string)[] | undefined} after
+   */
+  addNodeOrdering(context, graph, graphIdsBySystemId, edges, source, before, after) {
+    if (before) {
+
+
+      for (let i = 0; i < before.length; i++) {
+        const label = describeReference(before[i])
+        this.addExpandedEdge(context, graph, graphIdsBySystemId, edges, source, this.resolveNode(context, label), before[i])
+        this.addExpandedEdge(context, graph, graphIdsBySystemId, edges, source, this.resolveNode(context, label), label)
+      }
+    }
+
+    if (after) {
+      for (let i = 0; i < after.length; i++) {
+        const label = describeReference(after[i])
+        this.addExpandedEdge(context, graph, graphIdsBySystemId, edges, this.resolveNode(context, label), source, after[i])
+        this.addExpandedEdge(context, graph, graphIdsBySystemId, edges, this.resolveNode(context, label), source, label)
+      }
+    }
+  }
+
+  /**
+   * @private
+   * @param {ScheduleContext} context
+   * @param {string} label
+   * @returns {ScheduleNodeRef}
+   */
+  resolveNode(context, label) {
+    const stringLabel = /** @type {string} */ (label)
+    const node = context.nodesByLabel.get(stringLabel)
+
+    if (!node) {
+      throws(`Could not resolve the system or system group label "${stringLabel}" on schedule "${context.label}".`)
+    }
+
+    return node
+  }
+
+  /**
+   * @private
+   * @param {ScheduleContext} context
+   * @param {Graph<SystemRegistration, undefined>} graph
+   * @param {Map<number, number>} graphIdsBySystemId
+   * @param {Set<string>} edges
+   * @param {ScheduleNodeRef} from
+   * @param {ScheduleNodeRef} to
+   * @param {SystemFunc | Constructor | string} targetLabel
+   */
+  addExpandedEdge(context, graph, graphIdsBySystemId, edges, from, to, targetLabel) {
+    const fromSystems = this.expandNodeToSystems(context, from)
+    const toSystems = this.expandNodeToSystems(context, to)
+
+    for (let i = 0; i < fromSystems.length; i++) {
+      for (let j = 0; j < toSystems.length; j++) {
+        const fromSystemId = fromSystems[i]
+        const toSystemId = toSystems[j]
+
+        if (fromSystemId === toSystemId) {
+          throws(`The reference "${describeReference(targetLabel)}" creates a self-referential system ordering on schedule "${context.label}".`)
+        }
+
+        const graphFrom = graphIdsBySystemId.get(fromSystemId)
+        const graphTo = graphIdsBySystemId.get(toSystemId)
+
+        assert(graphFrom !== undefined, `Internal error: Could not resolve graph node for system ${fromSystemId} on schedule "${context.label}".`)
+        assert(graphTo !== undefined, `Internal error: Could not resolve graph node for system ${toSystemId} on schedule "${context.label}".`)
+
+        const key = `${graphFrom}:${graphTo}`
+
+        if (edges.has(key)) continue
+
+        edges.add(key)
+        graph.addEdge(graphFrom, graphTo, undefined)
+      }
+    }
+  }
+
+  /**
+   * @private
+   * @param {ScheduleContext} context
+   * @param {ScheduleNodeRef} node
+   * @returns {number[]}
+   */
+  expandNodeToSystems(context, node) {
+    if (node.kind === ScheduleNodeKind.System) return [node.id]
+
+    return context.groups[node.id].systems
   }
 }
 
 /**
- * @typedef SystemGroupConfig
- * @property {import('../../type/index.js').Constructor} label
+ * @param {Map<string, ScheduleContext>} schedules
+ * @param {string} label
+ * @returns {ScheduleContext}
+ */
+function getOrCreateScheduleContext(schedules, label) {
+  const existing = schedules.get(label)
+
+  if (existing) return existing
+
+  const created = /** @type {ScheduleContext} */ ({
+    label,
+    systems: [],
+    groups: [],
+    nodesByLabel: new Map(),
+    groupIdsByTypeId: new Map(),
+    systemIdsByFunc: new Map()
+    // systemIdsByFunc: new Map() // Removed as it's no longer used
+  })
+
+  schedules.set(label, created)
+
+  return created
+}
+
+/**
+ * @param {SystemFunc | Constructor | string} reference
+ */
+function describeReference(reference) {
+  if (typeof reference === 'string') return reference
+
+  return reference.name || '<anonymous>'
+}
+
+/** @enum {number} */
+const ScheduleNodeKind = Object.freeze({
+  System: 0,
+  Group: 1
+})
+
+/**
+ * @typedef ScheduleContext
+ * @property {string} label
+ * @property {SystemRegistration[]} systems
+ * @property {SystemGroupRegistration[]} groups
+ * @property {Map<string, ScheduleNodeRef>} nodesByLabel
+ * @property {Map<TypeId, number>} groupIdsByTypeId
+ * @property {Map<string, number>} systemIdsByFunc
+ */
+
+/**
+ * @typedef SystemRegistration
+ * @property {number} id
+ * @property {SystemConfig} config
+ */
+
+/**
+ * @typedef SystemGroupRegistration
+ * @property {number} id
+ * @property {SystemGroupConfig} config
+ * @property {number[]} systems
+ */
+
+/**
+ * @typedef ScheduleNodeRef
+ * @property {ScheduleNodeKind} kind
+ * @property {number} id
  */

--- a/src/schedule/core/systemconfig.js
+++ b/src/schedule/core/systemconfig.js
@@ -2,10 +2,25 @@
 /** @import { Constructor } from "../../type/index.js" */
 
 /**
+ * @typedef {SystemFunc | Constructor | string} SystemOrderReference
+ */
+
+/**
  * @typedef SystemConfig
  * @property {SystemFunc} system
  * @property {string} schedule
+ * @property {string | undefined} [label]
  * @property {Constructor | undefined} [systemGroup]
+ * @property {SystemOrderReference[] | undefined} [before]
+ * @property {SystemOrderReference[] | undefined} [after]
+ */
+
+/**
+ * @typedef SystemGroupConfig
+ * @property {Constructor} label
+ * @property {string} schedule
+ * @property {SystemOrderReference[] | undefined} [before]
+ * @property {SystemOrderReference[] | undefined} [after]
  */
 
 export default {}

--- a/src/schedule/tests/scheduleBuilder.test.js
+++ b/src/schedule/tests/scheduleBuilder.test.js
@@ -1,0 +1,351 @@
+import { describe, test } from 'node:test'
+import { deepStrictEqual, throws } from 'node:assert'
+import { World } from '../../ecs/index.js'
+import { Executable, Scheduler, SchedulerBuilder } from '../index.js'
+
+class Phase { }
+class MissingPhase { }
+
+describe('Testing `SchedulerBuilder`', () => {
+  test('sorts systems topologically from their `before` and `after` labels', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+    const world = new World()
+    /** @type {string[]} */
+    const order = []
+    function late() { order.push('late') }
+    function early() { order.push('early') }
+    function middle() { order.push('middle') }
+
+    scheduler.set(new Executable({ label: 'update' }))
+
+    builder.add({
+      schedule: 'update',
+      after: [middle],
+      system: late
+    })
+    builder.add({
+      schedule: 'update',
+      before: ['middle'],
+      system: early
+    })
+    builder.add({
+      schedule: 'update',
+      system: middle
+    })
+
+    builder.pushToScheduler(scheduler)
+    scheduler.get('update')?.run(world)
+
+    deepStrictEqual(order, ['early', 'middle', 'late'])
+  })
+
+  test('prefers explicit system labels over function names', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+    const world = new World()
+    /** @type {string[]} */
+    const order = []
+    function systemA() { order.push('a') }
+    function systemB() { order.push('b') }
+
+    scheduler.set(new Executable({ label: 'update' }))
+
+    builder.add({
+      label: 'first',
+      schedule: 'update',
+      system: systemA
+    })
+    builder.add({
+      schedule: 'update',
+      after: ['first'],
+      system: systemB
+    })
+
+    builder.pushToScheduler(scheduler)
+    scheduler.get('update')?.run(world)
+
+    deepStrictEqual(order, ['a', 'b'])
+  })
+
+  test('expands groups per schedule without label overlap', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+    const world = new World()
+    /** @type {string[]} */
+    const startupOrder = []
+    /** @type {string[]} */
+    const updateOrder = []
+    function boot() { startupOrder.push('boot') }
+    function register() { startupOrder.push('register') }
+    function simulate() { updateOrder.push('simulate') }
+    function input() { updateOrder.push('input') }
+    function render() { updateOrder.push('render') }
+
+    scheduler.set(new Executable({ label: 'startup' }))
+    scheduler.set(new Executable({ label: 'update' }))
+
+    builder.addGroup({
+      label: Phase,
+      schedule: 'startup'
+    })
+    builder.add({
+      schedule: 'startup',
+      before: [Phase],
+      system: boot
+    })
+    builder.add({
+      schedule: 'startup',
+      systemGroup: Phase,
+      system: register
+    })
+
+    builder.addGroup({
+      label: Phase,
+      schedule: 'update',
+      after: ['input']
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: Phase,
+      before: [render],
+      system: simulate
+    })
+    builder.add({
+      schedule: 'update',
+      system: input
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: Phase,
+      system: render
+    })
+
+    builder.pushToScheduler(scheduler)
+    scheduler.get('startup')?.run(world)
+    scheduler.get('update')?.run(world)
+
+    deepStrictEqual(startupOrder, ['boot', 'register'])
+    deepStrictEqual(updateOrder, ['input', 'simulate', 'render'])
+  })
+
+  test('orders systems around a group label', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+    const world = new World()
+    /** @type {string[]} */
+    const order = []
+
+    class Phase { }
+
+    function prepare() { order.push('prepare') }
+    function first() { order.push('first') }
+    function second() { order.push('second') }
+    function finish() { order.push('finish') }
+
+    scheduler.set(new Executable({ label: 'update' }))
+
+    builder.addGroup({
+      label: Phase,
+      schedule: 'update',
+      after: ['prepare'],
+      before: ['finish']
+    })
+    builder.add({
+      schedule: 'update',
+      system: prepare
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: Phase,
+      system: first
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: Phase,
+      after: [first],
+      system: second
+    })
+    builder.add({
+      schedule: 'update',
+      system: finish
+    })
+
+    builder.pushToScheduler(scheduler)
+    scheduler.get('update')?.run(world)
+
+    deepStrictEqual(order, ['prepare', 'first', 'second', 'finish'])
+  })
+
+  test('orders groups relative to other groups', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+    const world = new World()
+    /** @type {string[]} */
+    const order = []
+
+    class EarlyPhase { }
+    class LatePhase { }
+
+    function earlyOne() { order.push('earlyOne') }
+    function earlyTwo() { order.push('earlyTwo') }
+    function lateOne() { order.push('lateOne') }
+    function lateTwo() { order.push('lateTwo') }
+
+    scheduler.set(new Executable({ label: 'update' }))
+
+    builder.addGroup({
+      label: EarlyPhase,
+      schedule: 'update',
+      before: [LatePhase]
+    })
+    builder.addGroup({
+      label: LatePhase,
+      schedule: 'update'
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: EarlyPhase,
+      system: earlyOne
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: EarlyPhase,
+      after: [earlyOne],
+      system: earlyTwo
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: LatePhase,
+      system: lateOne
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: LatePhase,
+      after: [lateOne],
+      system: lateTwo
+    })
+
+    builder.pushToScheduler(scheduler)
+    scheduler.get('update')?.run(world)
+
+    deepStrictEqual(order, ['earlyOne', 'earlyTwo', 'lateOne', 'lateTwo'])
+  })
+
+  test('keeps schedules isolated from each other', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+    const world = new World()
+    /** @type {string[]} */
+    const startupOrder = []
+    /** @type {string[]} */
+    const updateOrder = []
+
+    function sharedStartup() { startupOrder.push('sharedStartup') }
+    function sharedUpdate() { updateOrder.push('sharedUpdate') }
+
+    scheduler.set(new Executable({ label: 'startup' }))
+    scheduler.set(new Executable({ label: 'update' }))
+
+    builder.add({
+      schedule: 'startup',
+      label: 'shared',
+      system: sharedStartup
+    })
+    builder.add({
+      schedule: 'update',
+      label: 'shared',
+      system: sharedUpdate
+    })
+
+    builder.pushToScheduler(scheduler)
+    scheduler.get('startup')?.run(world)
+    scheduler.get('update')?.run(world)
+
+    deepStrictEqual(startupOrder, ['sharedStartup'])
+    deepStrictEqual(updateOrder, ['sharedUpdate'])
+  })
+
+  test('rejects duplicate system labels on the same schedule', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+
+    scheduler.set(new Executable({ label: 'update' }))
+    builder.add({
+      schedule: 'update',
+      label: 'duplicate',
+      system: () => { }
+    })
+    builder.add({
+      schedule: 'update',
+      label: 'duplicate',
+      system: () => { }
+    })
+
+    throws(() => builder.pushToScheduler(scheduler), /Duplicate system label/)
+  })
+
+  test('rejects duplicate group labels on the same schedule', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+
+    scheduler.set(new Executable({ label: 'update' }))
+    builder.addGroup({
+      label: Phase,
+      schedule: 'update'
+    })
+    builder.addGroup({
+      label: Phase,
+      schedule: 'update'
+    })
+
+    throws(() => builder.pushToScheduler(scheduler), /Duplicate system group label/)
+  })
+
+  test('rejects schedules that are missing from the scheduler', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+
+    builder.add({
+      schedule: 'update',
+      system: () => { }
+    })
+
+    throws(() => builder.pushToScheduler(scheduler), /The schedule label "update" is not set/)
+  })
+
+  test('requires system groups to be registered explicitly', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+
+    scheduler.set(new Executable({ label: 'update' }))
+    builder.add({
+      schedule: 'update',
+      systemGroup: MissingPhase,
+      system: () => { }
+    })
+
+    throws(() => builder.pushToScheduler(scheduler), /must be registered explicitly/)
+  })
+
+  test('detects cyclic ordering constraints', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+    function first() { }
+    function second() { }
+
+    scheduler.set(new Executable({ label: 'update' }))
+    builder.add({
+      schedule: 'update',
+      after: [second],
+      system: first
+    })
+    builder.add({
+      schedule: 'update',
+      after: [first],
+      system: second
+    })
+
+    throws(() => builder.pushToScheduler(scheduler), /cyclic system ordering/)
+  })
+})

--- a/src/tween/plugin.js
+++ b/src/tween/plugin.js
@@ -14,9 +14,10 @@ import {
 import { Vector2, Quaternion, Vector3, Rotary } from '../math/index.js'
 import { generateTweenFlipSystem, generateTweenRepeatTween, generateTweenTimerSystem, generateTweenUpdateSystem } from './systems/index.js'
 import { Orientation2D, Orientation3D, Position2D, Position3D, Scale2D, Scale3D } from '../transform/index.js'
-import { typeidGeneric } from '../type/index.js'
+import { typeid, typeidGeneric } from '../type/index.js'
 import { AppSchedule } from '../core/index.js'
 
+// TODO: Convert this into a plugin group
 export class DefaultTweenPlugin extends Plugin {
 
   /**
@@ -24,6 +25,7 @@ export class DefaultTweenPlugin extends Plugin {
    */
   register(app) {
     app
+      .registerPlugin(new CoreTweenPlugin())
       .registerPlugin(new TweenPlugin({
         component: Position2D,
         tween: Position2DTween,
@@ -55,6 +57,19 @@ export class DefaultTweenPlugin extends Plugin {
         interpolation: Vector3.lerp
       }))
   }
+}
+
+export class CoreTweenPlugin extends Plugin {
+
+  /**
+   * @param {App} app
+   */
+  register(app) {
+    app
+      .registerType(TweenFlip)
+      .registerType(TweenRepeat)
+  }
+
 }
 
 // TweenPlugin<T> where `T: Lerp`
@@ -99,12 +114,26 @@ export class TweenPlugin extends Plugin {
   register(app) {
     app
       .registerType(this.tween)
-      .registerType(TweenFlip)
-      .registerType(TweenRepeat)
-      .registerSystem({ schedule: AppSchedule.Update, system: generateTweenFlipSystem(this.tween) })
-      .registerSystem({ schedule: AppSchedule.Update, system: generateTweenRepeatTween(this.tween) })
-      .registerSystem({ schedule: AppSchedule.Update, system: generateTweenTimerSystem(this.tween) })
-      .registerSystem({ schedule: AppSchedule.Update, system: generateTweenUpdateSystem(this.component, this.tween, this.interpolation) })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        label: `flipTween<${typeid(this.component)}>`,
+        system: generateTweenFlipSystem(this.tween)
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        label: `repeatTween<${typeid(this.component)}>`,
+        system: generateTweenRepeatTween(this.tween)
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        label: `updateTimerTween<${typeid(this.component)}>`,
+        system: generateTweenTimerSystem(this.tween)
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        label: `updateTween<${typeid(this.component)}>`,
+        system: generateTweenUpdateSystem(this.component, this.tween, this.interpolation)
+      })
   }
 
   name() {


### PR DESCRIPTION
## Objective

Introduce deterministic system ordering and system groups to the scheduler and removes several temporary scheduling hacks and adds explicit execution ordering through `before` and `after` constraints.

## Solution

The scheduler previously relied entirely on insertion order of the plugins, making execution order implicit and difficult to maintain as the engine grew. This caused several issues:

- Plugins depended on fragile registration order
- Event clearing relied on deferred manual insertion
- Asset registration required startup hacks
- There was no way to express execution dependencies explicitly

This introduces:

- Explicit `before` / `after` ordering constraints
- System groups
- Deterministic topological sorting
- Added validation for:
  - duplicate system labels
  - duplicate group labels
  - cyclic ordering constraints
  - missing schedules
  - missing system groups
- Removed legacy scheduling hacks:
  - `App.systemsevents`
  - startup registration hacks in `HackPlugin`
- Updated plugins to use explicit labeled systems:
  - `AssetPlugin`
  - `AssetParserPlugin`
  - `EventPlugin`
  - `TweenPlugin`
  - `Material2DPlugin`
- Added comprehensive scheduler ordering tests

This approach was chosen because graph-based scheduling scales better than insertion-order execution and allows deterministic execution while enabling future scheduler improvements.

## Showcase

### Before

```js
// ordering depended entirely on registration order

app
  .registerSystem({ schedule: 'update', system: a })
  .registerSystem({ schedule: 'update', system: b })

// legacy deferred ordering hack
app.systemsevents.push(...)
```

### After

```js
class PhysicsPhase {}

app.registerSystemGroup({
  label: PhysicsPhase,
  schedule: 'update'
})

app.registerSystem({
  schedule: 'update',
  before: [PhysicsPhase],
  system: inputSystem
})

app.registerSystem({
  schedule: 'update',
  systemGroup: PhysicsPhase,
  system: physicsSystem
})

app.registerSystem({
  schedule: 'update',
  after: [PhysicsPhase],
  system: renderSystem
})
```

## Migration guide

New optional system configuration fields:

```js
{
  label,
  before,
  after,
  systemGroup
}
```

New system group configuration:

```js
{
  label,
  schedule,
  before,
  after
}
```

Replace implicit registration ordering:

```js
app.registerSystem(a)
app.registerSystem(b)
```

with explicit constraints:

```js
app.registerSystem({
  system: a,
  before: [b]
})
```

Notes:

- Ordering is now deterministic
- Duplicate labels are rejected
- System groups must be explicitly registered
- Cyclic ordering constraints throw during scheduler construction

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.