### PR TITLE
Add default system groups for schedules

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -100,7 +100,7 @@ export class App {
   }
 
   /**
-   * @param {{label: string, delay?: number, repeat?: boolean, errorHandler?: (error: Error, world: World) => void}} config
+   * @param {{label: string, delay?: number, repeat?: boolean, errorHandler?: (error: Error, world: World) => void, defaultSystemGroup?: import('../type/index.js').Constructor}} config
    */
   createSchedule(config) {
     return this.scheduler.set(new Executable(config))

--- a/src/schedule/core/executable.js
+++ b/src/schedule/core/executable.js
@@ -52,17 +52,24 @@ export class Executable {
 
   /**
    * @readonly
+   * @type {import('../../type/index.js').Constructor | undefined}
+   */
+  defaultSystemGroup
+
+  /**
+   * @readonly
    * @type {((error: Error, world: World) => void) | undefined}
    */
   errorHandler
 
   /**
-   * @param {{label: string, repeat?: boolean, delay?: number, errorHandler?: (error: Error, world: World) => void}} config
+   * @param {{label: string, repeat?: boolean, delay?: number, errorHandler?: (error: Error, world: World) => void, defaultSystemGroup?: import('../../type/index.js').Constructor}} config
    */
   constructor(config) {
     this.label = config.label
     this.repeat = config.repeat ?? true
     this.delay = config.delay ?? 0
     this.errorHandler = config.errorHandler
+    this.defaultSystemGroup = config.defaultSystemGroup
   }
 }

--- a/src/schedule/core/systembuilder.js
+++ b/src/schedule/core/systembuilder.js
@@ -37,6 +37,7 @@ export class SchedulerBuilder {
    * @param {Scheduler} scheduler
    */
   pushToScheduler(scheduler) {
+
     /** @type {Map<string, import('./executable.js').Executable['defaultSystemGroup']>} */
     const defaultGroupsBySchedule = new Map()
 

--- a/src/schedule/core/systembuilder.js
+++ b/src/schedule/core/systembuilder.js
@@ -37,7 +37,14 @@ export class SchedulerBuilder {
    * @param {Scheduler} scheduler
    */
   pushToScheduler(scheduler) {
-    const schedules = this.createScheduleContexts()
+    /** @type {Map<string, import('./executable.js').Executable['defaultSystemGroup']>} */
+    const defaultGroupsBySchedule = new Map()
+
+    for (const executable of scheduler.values()) {
+      defaultGroupsBySchedule.set(executable.label, executable.defaultSystemGroup)
+    }
+
+    const schedules = this.createScheduleContexts(defaultGroupsBySchedule)
 
     for (const [scheduleLabel, context] of schedules) {
       const schedule = scheduler.get(scheduleLabel)
@@ -52,9 +59,10 @@ export class SchedulerBuilder {
 
   /**
    * @private
+   * @param {Map<string, Constructor | undefined>} defaultGroupsBySchedule
    * @returns {Map<string, ScheduleContext>}
    */
-  createScheduleContexts() {
+  createScheduleContexts(defaultGroupsBySchedule) {
 
     /** @type {Map<string, ScheduleContext>} */
     const schedules = new Map()
@@ -115,11 +123,13 @@ export class SchedulerBuilder {
     }
 
     for (const [scheduleLabel, context] of schedules) {
+      context.defaultSystemGroup = defaultGroupsBySchedule.get(scheduleLabel)
+
       this.resolveGroupParents(context, scheduleLabel)
 
       for (let i = 0; i < context.systems.length; i++) {
         const system = context.systems[i]
-        const groupLabel = system.config.systemGroup
+        const groupLabel = system.config.systemGroup ?? context.defaultSystemGroup
 
         if (!groupLabel) continue
 
@@ -433,7 +443,8 @@ function getOrCreateScheduleContext(schedules, label) {
     systems: [],
     groups: [],
     nodesByLabel: new Map(),
-    groupIdsByTypeId: new Map()
+    groupIdsByTypeId: new Map(),
+    defaultSystemGroup: undefined
   })
 
   schedules.set(label, created)
@@ -463,6 +474,7 @@ const ScheduleNodeKind = Object.freeze({
  * @property {SystemGroupRegistration[]} groups
  * @property {Map<string, ScheduleNodeRef>} nodesByLabel
  * @property {Map<TypeId, number>} groupIdsByTypeId
+ * @property {Constructor | undefined} defaultSystemGroup
  */
 
 /**

--- a/src/schedule/tests/scheduleBuilder.test.js
+++ b/src/schedule/tests/scheduleBuilder.test.js
@@ -7,6 +7,9 @@ class Phase { }
 class ParentPhase { }
 class ChildPhase { }
 class MissingPhase { }
+class DefaultPhase { }
+class AlternatePhase { }
+class FencePhase { }
 
 describe('Testing `SchedulerBuilder`', () => {
   test('sorts systems topologically from their `before` and `after` labels', () => {
@@ -177,6 +180,103 @@ describe('Testing `SchedulerBuilder`', () => {
     scheduler.get('update')?.run(world)
 
     deepStrictEqual(order, ['prepare', 'first', 'second', 'finish'])
+  })
+
+  test('uses the schedule default system group when a system omits one', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+    const world = new World()
+    /** @type {string[]} */
+    const order = []
+
+    function explicit() { order.push('explicit') }
+    function implicit() { order.push('implicit') }
+    function other() { order.push('other') }
+
+    scheduler.set(new Executable({
+      label: 'update',
+      defaultSystemGroup: DefaultPhase
+    }))
+
+    builder.addGroup({
+      label: DefaultPhase,
+      schedule: 'update',
+      before: [AlternatePhase]
+    })
+    builder.addGroup({
+      label: AlternatePhase,
+      schedule: 'update'
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: DefaultPhase,
+      system: explicit
+    })
+    builder.add({
+      schedule: 'update',
+      system: implicit
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: AlternatePhase,
+      system: other
+    })
+
+    builder.pushToScheduler(scheduler)
+    scheduler.get('update')?.run(world)
+
+    deepStrictEqual(order, ['explicit', 'implicit', 'other'])
+  })
+
+  test('prefers an explicit system group over the schedule default', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+    const world = new World()
+    /** @type {string[]} */
+    const order = []
+
+    function explicit() { order.push('explicit') }
+    function implicit() { order.push('implicit') }
+    function fence() { order.push('fence') }
+
+    scheduler.set(new Executable({
+      label: 'update',
+      defaultSystemGroup: DefaultPhase
+    }))
+
+    builder.addGroup({
+      label: DefaultPhase,
+      schedule: 'update',
+      before: [FencePhase]
+    })
+    builder.addGroup({
+      label: AlternatePhase,
+      schedule: 'update',
+      after: [FencePhase]
+    })
+    builder.addGroup({
+      label: FencePhase,
+      schedule: 'update'
+    })
+    builder.add({
+      schedule: 'update',
+      system: implicit
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: AlternatePhase,
+      system: explicit
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: FencePhase,
+      system: fence
+    })
+
+    builder.pushToScheduler(scheduler)
+    scheduler.get('update')?.run(world)
+
+    deepStrictEqual(order, ['implicit', 'fence', 'explicit'])
   })
 
   test('orders groups relative to other groups', () => {


### PR DESCRIPTION
## Objective

Introduce schedule-level default system groups so systems can automatically inherit a group when one is not explicitly specified.

## Solution

Adds `defaultSystemGroup` support to `Executable` schedules and updates the scheduler builder to apply that group automatically during schedule construction.

Previously, every grouped system had to explicitly specify `systemGroup`, even when most systems belonged to the same phase. This created repetitive configuration and made schedule setup noisier.

The scheduler now resolves a system group using the following precedence:

1. Explicit `systemGroup` on the system
2. Schedule';s `defaultSystemGroup`
3. No group

The approach keeps grouping resolution centralized inside scheduler construction rather than mutating registrations during insertion, which avoids hidden side effects and keeps system registrations immutable.

## Showcase

### Before

```js
scheduler.set(new Executable({
  label: 'update'
}))

builder.add({
  schedule: 'update',
  systemGroup: DefaultPhase,
  system: movement
})

builder.add({
  schedule: 'update',
  systemGroup: DefaultPhase,
  system: animation
})
````

### After

```js
scheduler.set(new Executable({
  label: 'update',
  defaultSystemGroup: DefaultPhase
}))

builder.add({
  schedule: 'update',
  system: movement
})

builder.add({
  schedule: 'update',
  system: animation
})

// Explicit groups still override the schedule default:
builder.add({
  schedule: 'update',
  systemGroup: AlternatePhase,
  system: networking
})
```

## Migration guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
