### PR TITLE
Add base system groups

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -103,7 +103,9 @@ export class App {
    * @param {{label: string, delay?: number, repeat?: boolean, errorHandler?: (error: Error, world: World) => void, defaultSystemGroup?: import('../type/index.js').Constructor}} config
    */
   createSchedule(config) {
-    return this.scheduler.set(new Executable(config))
+    this.scheduler.set(new Executable(config))
+
+    return this
   }
 
   /**

--- a/src/core/core/index.js
+++ b/src/core/core/index.js
@@ -1,3 +1,4 @@
 export * from './schedules.js'
 export * from './runner.js'
 export * from './entity.js'
+export * from './systemgroups.js'

--- a/src/core/core/systemgroups.js
+++ b/src/core/core/systemgroups.js
@@ -1,0 +1,35 @@
+/**
+ * Core scheduling phases used by startup and update schedules.
+ */
+class Start {}
+
+/**
+ * Systems that should run before the main phase.
+ */
+class PreMain {}
+
+/**
+ * The default core phase for startup and update schedules.
+ */
+class Main {}
+
+/**
+ * Systems that should run after the main phase.
+ */
+class PostMain {}
+
+/**
+ * Final core scheduling phase.
+ */
+class End {}
+
+/**
+ *  @enum {import('../../type/index.js').Constructor}
+ */
+export const CoreSystems = Object.freeze({
+  Start,
+  PreMain,
+  Main,
+  PostMain,
+  End
+})

--- a/src/core/plugin.js
+++ b/src/core/plugin.js
@@ -1,5 +1,5 @@
 import { App, Plugin } from '../app/index.js'
-import { AppSchedule, defaultRunner } from './core/index.js'
+import { AppSchedule, CoreSystems, defaultRunner } from './core/index.js'
 import { registerCoreTypes } from './systems/index.js'
 
 export class CorePlugin extends Plugin {
@@ -8,13 +8,70 @@ export class CorePlugin extends Plugin {
    * @param {App} app
    */
   register(app) {
-    app.setRunner(defaultRunner)
-    app.createSchedule(
-      { label: AppSchedule.Startup, repeat: false }
-    )
-    app.createSchedule(
-      { label: AppSchedule.Update, repeat: true }
-    )
-    app.registerSystem({ schedule: AppSchedule.Startup, system: registerCoreTypes })
+    app
+      .setRunner(defaultRunner)
+      .createSchedule({
+        label: AppSchedule.Startup,
+        repeat: false,
+        defaultSystemGroup: CoreSystems.Main
+      })
+      .createSchedule({
+        label: AppSchedule.Update,
+        repeat: true,
+        defaultSystemGroup: CoreSystems.Main
+      })
+      .registerSystemGroup({
+        label: CoreSystems.Start,
+        schedule: AppSchedule.Startup,
+        before: [CoreSystems.PreMain]
+      })
+      .registerSystemGroup({
+        label: CoreSystems.PreMain,
+        schedule: AppSchedule.Startup,
+        before: [CoreSystems.Main]
+      })
+      .registerSystemGroup({
+        label: CoreSystems.Main,
+        schedule: AppSchedule.Startup,
+        before: [CoreSystems.PostMain]
+      })
+      .registerSystemGroup({
+        label: CoreSystems.PostMain,
+        schedule: AppSchedule.Startup,
+        before: [CoreSystems.End]
+      })
+      .registerSystemGroup({
+        label: CoreSystems.End,
+        schedule: AppSchedule.Startup
+      })
+
+      .registerSystemGroup({
+        label: CoreSystems.Start,
+        schedule: AppSchedule.Update,
+        before: [CoreSystems.PreMain]
+      })
+      .registerSystemGroup({
+        label: CoreSystems.PreMain,
+        schedule: AppSchedule.Update,
+        before: [CoreSystems.Main]
+      })
+      .registerSystemGroup({
+        label: CoreSystems.Main,
+        schedule: AppSchedule.Update,
+        before: [CoreSystems.PostMain]
+      })
+      .registerSystemGroup({
+        label: CoreSystems.PostMain,
+        schedule: AppSchedule.Update,
+        before: [CoreSystems.End]
+      })
+      .registerSystemGroup({
+        label: CoreSystems.End,
+        schedule: AppSchedule.Update
+      })
+      .registerSystem({
+        schedule: AppSchedule.Startup,
+        system: registerCoreTypes
+      })
   }
 }


### PR DESCRIPTION
## Objective

Introduce built-in core scheduling phases by adding reusable core system groups for startup and update schedules while making `App#createSchedule()` chainable.

## Solution

Previously, startup and update schedules were created independently without predefined execution phases. This privides systems with a way to be ordered in larger base groups that are defined by the engine.

Changes include:

* Added built-in core system groups:
  * `Start`
  * `PreMain`
  * `Main`
  * `PostMain`
  * `End`

Core execution flow:

```mermaid
flowchart LR
    Start --> PreMain --> Main --> PostMain --> End
```

The scheduling phases provide a consistent execution structure across applications while still allowing custom ordering and extension through existing group APIs.

Returning the app instance from `createSchedule()` aligns it with the rest of the fluent application configuration API and simplifies plugin setup code.Systems can now automatically participate in the default `Main` phase if registered without a system group in the core schedules.

## Showcase

N/A

## Migration guide

No migrations required

### Notes

* Systems without an explicit group now default to `CoreSystems.Main` inside core schedules
* Existing explicit system groups continue to work unchanged

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.