### PR TITLE
Fix empty group ordering

### DIFF
--- a/src/schedule/core/systembuilder.js
+++ b/src/schedule/core/systembuilder.js
@@ -219,7 +219,7 @@ export class SchedulerBuilder {
    * @returns {SystemRegistration[]}
    */
   sortScheduleSystems(context) {
-    const graph = this.expandScheduleGraph(context)
+    const { graph, systemsByGraphId } = this.expandScheduleGraph(context)
     const sorted = kahnTopologySort(graph)
 
     if (!sorted) {
@@ -230,9 +230,10 @@ export class SchedulerBuilder {
     const ordered = []
 
     for (let i = 0; i < sorted.length; i++) {
-      const system = graph.getNodeWeight(sorted[i])
+      const system = systemsByGraphId.get(sorted[i])
 
-      assert(system, `Internal error: Could not resolve system node ${sorted[i]} on schedule "${context.label}".`)
+      if (!system) continue
+
       ordered.push(system)
     }
 
@@ -242,13 +243,21 @@ export class SchedulerBuilder {
   /**
    * @private
    * @param {ScheduleContext} context
-   * @returns {Graph<SystemRegistration, undefined>}
+   * @returns {{ graph: Graph<SystemRegistration | SystemGroupRegistration, undefined>, systemsByGraphId: Map<number, SystemRegistration> }}
    */
   expandScheduleGraph(context) {
-    const graph = /** @type {Graph<SystemRegistration, undefined>} */ (new Graph(true))
+    const graph = /** @type {Graph<SystemRegistration | SystemGroupRegistration, undefined>} */ (new Graph(true))
 
     /** @type {Map<number, number>} */
     const graphIdsBySystemId = new Map()
+
+    /** @type {Map<number, number>} */
+    const graphIdsByGroupId = new Map()
+
+    context.graphIdsByGroupId = graphIdsByGroupId
+
+    /** @type {Map<number, SystemRegistration>} */
+    const systemsByGraphId = new Map()
 
     /** @type {Map<number, number[]>} */
     const groupSystemsCache = new Map()
@@ -256,11 +265,19 @@ export class SchedulerBuilder {
     /** @type {Set<string>} */
     const edges = new Set()
 
+    for (let i = 0; i < context.groups.length; i++) {
+      const group = context.groups[i]
+      const graphId = graph.addNode(group)
+
+      graphIdsByGroupId.set(group.id, graphId)
+    }
+
     for (let i = 0; i < context.systems.length; i++) {
       const system = context.systems[i]
       const graphId = graph.addNode(system)
 
       graphIdsBySystemId.set(system.id, graphId)
+      systemsByGraphId.set(graphId, system)
     }
 
     for (let i = 0; i < context.systems.length; i++) {
@@ -281,13 +298,16 @@ export class SchedulerBuilder {
       }, group.config.before, group.config.after, groupSystemsCache)
     }
 
-    return graph
+    return {
+      graph,
+      systemsByGraphId
+    }
   }
 
   /**
    * @private
    * @param {ScheduleContext} context
-   * @param {Graph<SystemRegistration, undefined>} graph
+   * @param {Graph<SystemRegistration | SystemGroupRegistration, undefined>} graph
    * @param {Map<number, number>} graphIdsBySystemId
    * @param {Set<string>} edges
    * @param {ScheduleNodeRef} source
@@ -336,7 +356,7 @@ export class SchedulerBuilder {
   /**
    * @private
    * @param {ScheduleContext} context
-   * @param {Graph<SystemRegistration, undefined>} graph
+   * @param {Graph<SystemRegistration | SystemGroupRegistration, undefined>} graph
    * @param {Map<number, number>} graphIdsBySystemId
    * @param {Set<string>} edges
    * @param {ScheduleNodeRef} from
@@ -345,32 +365,78 @@ export class SchedulerBuilder {
    * @param {Map<number, number[]>} groupSystemsCache
    */
   addExpandedEdge(context, graph, graphIdsBySystemId, edges, from, to, targetLabel, groupSystemsCache) {
-    const fromSystems = this.expandNodeToSystems(context, from, groupSystemsCache)
-    const toSystems = this.expandNodeToSystems(context, to, groupSystemsCache)
+    const fromNodes = this.expandNodeToOrderingNodes(context, from, graphIdsBySystemId, groupSystemsCache)
+    const toNodes = this.expandNodeToOrderingNodes(context, to, graphIdsBySystemId, groupSystemsCache)
 
-    for (let i = 0; i < fromSystems.length; i++) {
-      for (let j = 0; j < toSystems.length; j++) {
-        const fromSystemId = fromSystems[i]
-        const toSystemId = toSystems[j]
+    for (let i = 0; i < fromNodes.length; i++) {
+      for (let j = 0; j < toNodes.length; j++) {
+        const fromNodeId = fromNodes[i]
+        const toNodeId = toNodes[j]
 
-        if (fromSystemId === toSystemId) {
+        if (fromNodeId === toNodeId) {
           throws(`The reference "${describeReference(targetLabel)}" creates a self-referential system ordering on schedule "${context.label}".`)
         }
 
-        const graphFrom = graphIdsBySystemId.get(fromSystemId)
-        const graphTo = graphIdsBySystemId.get(toSystemId)
-
-        assert(graphFrom !== undefined, `Internal error: Could not resolve graph node for system ${fromSystemId} on schedule "${context.label}".`)
-        assert(graphTo !== undefined, `Internal error: Could not resolve graph node for system ${toSystemId} on schedule "${context.label}".`)
-
-        const key = `${graphFrom}:${graphTo}`
+        const key = `${fromNodeId}:${toNodeId}`
 
         if (edges.has(key)) continue
 
         edges.add(key)
-        graph.addEdge(graphFrom, graphTo, undefined)
+        graph.addEdge(fromNodeId, toNodeId, undefined)
       }
     }
+  }
+
+  /**
+   * @private
+   * @param {ScheduleContext} context
+   * @param {ScheduleNodeRef} node
+   * @param {Map<number, number>} graphIdsBySystemId
+   * @param {Map<number, number[]>} groupSystemsCache
+   * @returns {number[]}
+   */
+  expandNodeToOrderingNodes(context, node, graphIdsBySystemId, groupSystemsCache) {
+    if (node.kind === ScheduleNodeKind.System) {
+      const graphId = graphIdsBySystemId.get(node.id)
+
+      assert(graphId !== undefined, `Internal error: Could not resolve graph node for system ${node.id} on schedule "${context.label}".`)
+
+      return [graphId]
+    }
+
+    const systems = this.expandGroupToSystems(context, node.id, groupSystemsCache, new Set())
+
+    if (systems.length > 0) {
+      /** @type {number[]} */
+      const graphIds = []
+
+      for (let i = 0; i < systems.length; i++) {
+        const graphId = graphIdsBySystemId.get(systems[i])
+
+        assert(graphId !== undefined, `Internal error: Could not resolve graph node for system ${systems[i]} on schedule "${context.label}".`)
+        graphIds.push(graphId)
+      }
+
+      return graphIds
+    }
+
+    const graphId = this.expandGroupToGraphNode(context, node.id)
+
+    return [graphId]
+  }
+
+  /**
+   * @private
+   * @param {ScheduleContext} context
+   * @param {number} groupId
+   * @returns {number}
+   */
+  expandGroupToGraphNode(context, groupId) {
+    const graphId = context.graphIdsByGroupId?.get(groupId)
+
+    assert(graphId !== undefined, `Internal error: Could not resolve graph node for system group ${groupId} on schedule "${context.label}".`)
+
+    return graphId
   }
 
   /**
@@ -445,6 +511,7 @@ function getOrCreateScheduleContext(schedules, label) {
     groups: [],
     nodesByLabel: new Map(),
     groupIdsByTypeId: new Map(),
+    graphIdsByGroupId: undefined,
     defaultSystemGroup: undefined
   })
 
@@ -475,6 +542,7 @@ const ScheduleNodeKind = Object.freeze({
  * @property {SystemGroupRegistration[]} groups
  * @property {Map<string, ScheduleNodeRef>} nodesByLabel
  * @property {Map<TypeId, number>} groupIdsByTypeId
+ * @property {Map<number, number> | undefined} graphIdsByGroupId
  * @property {Constructor | undefined} defaultSystemGroup
  */
 

--- a/src/schedule/core/systembuilder.js
+++ b/src/schedule/core/systembuilder.js
@@ -407,6 +407,7 @@ export class SchedulerBuilder {
     const systems = this.expandGroupToSystems(context, node.id, groupSystemsCache, new Set())
 
     if (systems.length > 0) {
+
       /** @type {number[]} */
       const graphIds = []
 

--- a/src/schedule/tests/scheduleBuilder.test.js
+++ b/src/schedule/tests/scheduleBuilder.test.js
@@ -334,6 +334,53 @@ describe('Testing `SchedulerBuilder`', () => {
     deepStrictEqual(order, ['earlyOne', 'earlyTwo', 'lateOne', 'lateTwo'])
   })
 
+  test('treats empty groups as ordering barriers', () => {
+    const builder = new SchedulerBuilder()
+    const scheduler = new Scheduler()
+    const world = new World()
+    /** @type {string[]} */
+    const order = []
+
+    class StartPhase { }
+    class MiddlePhase { }
+    class EndPhase { }
+
+    function startSystem() { order.push('start') }
+    function endSystem() { order.push('end') }
+
+    scheduler.set(new Executable({ label: 'update' }))
+
+    builder.addGroup({
+      label: StartPhase,
+      schedule: 'update',
+      before: [MiddlePhase]
+    })
+    builder.addGroup({
+      label: MiddlePhase,
+      schedule: 'update',
+      before: [EndPhase]
+    })
+    builder.addGroup({
+      label: EndPhase,
+      schedule: 'update'
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: EndPhase,
+      system: endSystem
+    })
+    builder.add({
+      schedule: 'update',
+      systemGroup: StartPhase,
+      system: startSystem
+    })
+
+    builder.pushToScheduler(scheduler)
+    scheduler.get('update')?.run(world)
+
+    deepStrictEqual(order, ['start', 'end'])
+  })
+
   test('inherits parent ordering constraints across descendants', () => {
     const builder = new SchedulerBuilder()
     const scheduler = new Scheduler()


### PR DESCRIPTION
## Objective

Fix scheduling behavior for empty system groups by treating them as explicit ordering barriers during graph expansion. This ensures ordering constraints remain valid even when intermediary groups contain no systems.

## Solution

Previously, group ordering constraints were expanded directly into system-to-system edges. This worked when groups contained systems, but failed for empty groups because they produced no graph nodes during expansion.

As a result, ordering relationships that depended on empty intermediary phases could silently disappear. This introduces explicit graph nodes for system groups and uses them as ordering barriers when a group has no systems.The new approach preserves ordering semantics regardless of whether a group currently contains systems.Instead of collapsing groups prematurely into systems, the scheduler now treats groups as first-class ordering nodes. This allows:

* empty groups to participate in ordering
* future extensibility for other barriers
* consistent graph semantics across systems and groups

## Showcase

### Before

```js
builder.addGroup({
  label: StartPhase,
  schedule: 'update',
  before: [MiddlePhase]
})

builder.addGroup({
  label: MiddlePhase,
  schedule: 'update',
  before: [EndPhase]
})

builder.addGroup({
  label: EndPhase,
  schedule: 'update'
})
````

If `MiddlePhase` contained no systems, the ordering relationship could collapse during graph expansion.

### After

```js
builder.addGroup({
  label: StartPhase,
  schedule: 'update',
  before: [MiddlePhase]
})

builder.addGroup({
  label: MiddlePhase,
  schedule: 'update',
  before: [EndPhase]
})

builder.addGroup({
  label: EndPhase,
  schedule: 'update'
})
```

`MiddlePhase` now acts as a stable ordering barrier even without systems.

## Migration guide

No migration required.

### Notes

* Empty system groups now participate in scheduling order resolution
* Existing schedules continue to work unchanged
* Topological sorting still outputs executable systems only

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
