### PR TITLE
Update plugins and examples

### DIFF
--- a/src/asset/plugins/asset.js
+++ b/src/asset/plugins/asset.js
@@ -1,7 +1,7 @@
 /** @import { Constructor } from '../../type/index.js' */
 
 import { App, Plugin } from '../../app/index.js'
-import { AppSchedule } from '../../core/index.js'
+import { AppSchedule, CoreSystems } from '../../core/index.js'
 import { EventPlugin } from '../../event/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
 import { Assets } from '../core/index.js'
@@ -58,11 +58,13 @@ export class AssetPlugin extends Plugin {
         .registerSystem({
           label: `updateAssetEvents<${typeid(asset)}>`,
           schedule: AppSchedule.Update,
+          systemGroup: CoreSystems.End,
           system: updateAssetEvents(asset, events)
         })
         .registerSystem({
           label: `unloadDroppedAssets<${typeid(events.dropped)}>`,
           schedule: AppSchedule.Update,
+          systemGroup: CoreSystems.End,
           system: unloadDroppedAssets(events.dropped)
         })
     }
@@ -70,11 +72,13 @@ export class AssetPlugin extends Plugin {
     app.registerSystem({
       label: `registerAssetOnAssetServer<${typeid(asset)}>`,
       schedule: AppSchedule.Startup,
+      systemGroup: CoreSystems.Start,
       system: registerAssetOnAssetServer(asset)
     })
     app.registerSystem({
       label: `registerAssetTypes<${typeid(asset)}>`,
       schedule: AppSchedule.Startup,
+      systemGroup: CoreSystems.Start,
       system: registerAssetTypes(asset)
     })
     world.setResourceByTypeId(

--- a/src/asset/plugins/assetServer.js
+++ b/src/asset/plugins/assetServer.js
@@ -3,7 +3,7 @@ import { EventPlugin } from '../../event/index.js'
 import { AssetServer } from '../resources/index.js'
 import { AssetLoadFail, AssetLoadSuccess } from '../events/index.js'
 import { updateAssets, updateAssetLoadEvents, logFailedLoads, registerAssetServerTypes } from '../systems/index.js'
-import { AppSchedule } from '../../core/index.js'
+import { AppSchedule, CoreSystems } from '../../core/index.js'
 
 export class AssetServerPlugin extends Plugin {
 
@@ -19,9 +19,9 @@ export class AssetServerPlugin extends Plugin {
       .registerPlugin(new EventPlugin({
         event: AssetLoadFail
       }))
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerAssetServerTypes })
-      .registerSystem({ schedule: AppSchedule.Update, system: updateAssets })
-      .registerSystem({ schedule: AppSchedule.Update, system: updateAssetLoadEvents })
-      .registerSystem({ schedule: AppSchedule.Update, system: logFailedLoads })
+      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerAssetServerTypes })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: updateAssets })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: updateAssetLoadEvents })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: logFailedLoads })
   }
 }

--- a/src/asset/plugins/parser.js
+++ b/src/asset/plugins/parser.js
@@ -1,6 +1,6 @@
 /** @import {Constructor} from '../../type/index.js' */
 import { App, Plugin } from '../../app/index.js'
-import { AppSchedule } from '../../core/index.js'
+import { AppSchedule, CoreSystems } from '../../core/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
 import { Parser } from '../core/index.js'
 import { registerAssetParserOnAssetServer } from '../systems/index.js'
@@ -44,6 +44,7 @@ export class AssetParserPlugin extends Plugin {
       .registerSystem({
         label: `registerAssetParserOnAssetServer<${typeid(asset)}>`,
         schedule: AppSchedule.Startup,
+        systemGroup: CoreSystems.Start,
         system: registerAssetParserOnAssetServer(asset, parser)
       })
   }

--- a/src/command/plugin.js
+++ b/src/command/plugin.js
@@ -1,5 +1,5 @@
 import { App, Plugin } from '../app/index.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 import { World } from '../ecs/index.js'
 import { CommandQueue } from './resources/index.js'
 
@@ -11,7 +11,16 @@ export class CommandsPlugin extends Plugin {
   register(app) {
     app
       .setResource(new CommandQueue())
-      .registerSystem({ schedule: AppSchedule.Update, system: executeCommands })
+      .registerSystem({
+        schedule: AppSchedule.Startup,
+        systemGroup: CoreSystems.End,
+        system: executeCommands
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        systemGroup: CoreSystems.End,
+        system: executeCommands
+      })
   }
 }
 

--- a/src/diagnostic/entitycount.js
+++ b/src/diagnostic/entitycount.js
@@ -1,5 +1,5 @@
 import { App } from '../app/index.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 import { World, Entity, Query } from '../ecs/index.js'
 
 export class EntityCountDiagnosticPlugin {
@@ -9,8 +9,8 @@ export class EntityCountDiagnosticPlugin {
    */
   register(app) {
     app
-      .registerSystem({ schedule: AppSchedule.Startup, system: setUpUI })
-      .registerSystem({ schedule: AppSchedule.Update, system: updateEntityCount })
+      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: setUpUI })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: updateEntityCount })
   }
 }
 

--- a/src/diagnostic/fpsdebugger.js
+++ b/src/diagnostic/fpsdebugger.js
@@ -1,5 +1,5 @@
 import { App, Plugin } from '../app/index.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 import { World } from '../ecs/index.js'
 import { TimerMode, VirtualClock } from '../time/index.js'
 import { RAFTimer } from './resources/index.js'
@@ -13,10 +13,10 @@ export class FPSDebugger extends Plugin {
   register(app) {
     app
       .setResource(new RAFTimer({ duration: 1, mode: TimerMode.Repeat }))
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerFpsDebuggerTypes })
-      .registerSystem({ schedule: AppSchedule.Startup, system: setUpUI })
-      .registerSystem({ schedule: AppSchedule.Update, system: updateFPSCounter })
-      .registerSystem({ schedule: AppSchedule.Update, system: updateRAFTimer })
+      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerFpsDebuggerTypes })
+      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: setUpUI })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: updateFPSCounter })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: updateRAFTimer })
   }
 }
 

--- a/src/event/plugin.js
+++ b/src/event/plugin.js
@@ -1,10 +1,10 @@
 /** @import { Constructor } from '../type/index.js'*/
 
 import { App, Plugin } from '../app/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 import { makeEventClear, registerEventTypes } from './systems/index.js'
 import { Events } from './core/index.js'
 import { typeid, typeidGeneric } from '../type/index.js'
-import { AppSchedule } from '../core/index.js'
 
 /**
  * @template T
@@ -46,6 +46,7 @@ export class EventPlugin extends Plugin {
       .registerSystem({
         label: `registerEventTypes<${typeid(event)}>`,
         schedule: AppSchedule.Startup,
+        systemGroup: CoreSystems.Start,
         system: registerEventTypes(event)
       })
       .getWorld()
@@ -53,11 +54,10 @@ export class EventPlugin extends Plugin {
 
     if (this.autoClearEvent) {
       app
-        .registerSystemGroup({ label: event, schedule: AppSchedule.Update })
         .registerSystem({
           label: `clearEvents<${typeid(event)}>`,
           schedule: AppSchedule.Update,
-          systemGroup: event,
+          systemGroup: CoreSystems.End,
           system: makeEventClear(name)
         })
     }

--- a/src/keyboard/plugin.js
+++ b/src/keyboard/plugin.js
@@ -5,7 +5,7 @@ import { Events } from '../event/index.js'
 import { World } from '../ecs/index.js'
 import { KeyCode } from './core/key.js'
 import { typeidGeneric } from '../type/index.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 import { registerKeyboardTypes } from './systems/index.js'
 
 export class KeyboardPlugin extends Plugin {
@@ -16,8 +16,8 @@ export class KeyboardPlugin extends Plugin {
   register(app) {
     app
       .setResource(new Keyboard())
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerKeyboardTypes })
-      .registerSystem({ schedule: AppSchedule.Update, system: updateKeyBoard })
+      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerKeyboardTypes })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.Start, system: updateKeyBoard })
   }
 }
 

--- a/src/mouse/plugin.js
+++ b/src/mouse/plugin.js
@@ -6,7 +6,7 @@ import { Events } from '../event/index.js'
 import { PointerDown, PointerMove, PointerUp } from '../window/index.js'
 import { Vector2 } from '../math/index.js'
 import { typeidGeneric } from '../type/index.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 import { registerMouseTypes } from './systems/index.js'
 
 export class MousePlugin extends Plugin {
@@ -19,9 +19,9 @@ export class MousePlugin extends Plugin {
     app
       .setResource(new Mouse())
       .setResource(new MouseButtons())
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerMouseTypes })
-      .registerSystem({ schedule: AppSchedule.Update, system: updateMouse })
-      .registerSystem({ schedule: AppSchedule.Update, system: updateMouseButtons })
+      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerMouseTypes })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.Start, system: updateMouse })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.Start, system: updateMouseButtons })
   }
 }
 

--- a/src/profiler/plugin.js
+++ b/src/profiler/plugin.js
@@ -3,7 +3,7 @@ import { TimerMode, VirtualClock } from '../time/index.js'
 import { App, Plugin } from '../app/index.js'
 import { World } from '../ecs/index.js'
 import { warn } from '../logger/index.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 import { registerProfilerTypes } from './systems/index.js'
 
 export class ProfilerPlugin extends Plugin {
@@ -14,10 +14,10 @@ export class ProfilerPlugin extends Plugin {
   register(app) {
     app.setResource(new Profiler())
     app.setResource(new ProfilerTimer({ duration: 1, mode: TimerMode.Repeat }))
-    app.registerSystem({ schedule: AppSchedule.Startup, system: registerProfilerTypes })
+    app.registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerProfilerTypes })
     setupProfileViewer(document.body)
-    app.registerSystem({ schedule: AppSchedule.Update, system: updateProfileViewer })
-    app.registerSystem({ schedule: AppSchedule.Update, system: updateProfileTimer })
+    app.registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: updateProfileViewer })
+    app.registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: updateProfileTimer })
   }
 }
 

--- a/src/render-canvas2d/plugins/index.js
+++ b/src/render-canvas2d/plugins/index.js
@@ -2,10 +2,10 @@
 /** @import { Canvas2DFunction } from '../types/index.js' */
 
 import { App, Plugin } from '../../app/index.js'
-import { typeidGeneric } from '../../type/index.js'
+import { typeid, typeidGeneric } from '../../type/index.js'
 import { genrender } from '../systems/index.js'
 import { Material } from '../../render-core/index.js'
-import { AppSchedule } from '../../core/index.js'
+import { AppSchedule, CoreSystems } from '../../core/index.js'
 
 /**
  * @template {Material} T
@@ -39,7 +39,12 @@ export class Canvas2DMaterialPlugin extends Plugin {
   register(app) {
     const { material, update } = this
 
-    app.registerSystem({ schedule: AppSchedule.Update, system: genrender(material, update) })
+    app.registerSystem({
+      schedule: AppSchedule.Update,
+      label: `renderToCanvas2d<${typeid(material)}>`,
+      systemGroup: CoreSystems.PostMain,
+      system: genrender(material, update)
+    })
   }
 
   name() {

--- a/src/render-core/plugin.js
+++ b/src/render-core/plugin.js
@@ -1,5 +1,5 @@
 import { App, Plugin } from '../app/index.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 import { AssetParserPlugin, AssetPlugin, Assets } from '../asset/index.js'
 import { BasicMaterial2D, BasicMaterial3D, Camera, Meshed } from './components/index.js'
 import { Mesh, Shader, Image, BasicMaterial } from './assets/index.js'
@@ -33,7 +33,7 @@ export class RenderCorePlugin extends Plugin {
     app
       .registerType(Meshed)
       .registerType(Camera)
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerRenderCoreTypes })
+      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerRenderCoreTypes })
       .registerPlugin(new AssetPlugin({
         asset: Image,
         events: {

--- a/src/render-core/plugins/material.js
+++ b/src/render-core/plugins/material.js
@@ -1,7 +1,7 @@
 /** @import { Constructor, TypeId } from '../../type/index.js' */
 
 import { App, Plugin } from '../../app/index.js'
-import { AppSchedule } from '../../core/index.js'
+import { AppSchedule, CoreSystems } from '../../core/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
 import { Material } from '../assets/index.js'
 import { Material2D, Material3D } from '../components/index.js'
@@ -43,11 +43,13 @@ export class Material2DPlugin extends Plugin {
       .registerType(component)
       .registerSystem({
         schedule: AppSchedule.Startup,
+        systemGroup: CoreSystems.Start,
         label: `registerMaterialTypes<${typeid(asset)}>`,
         system: registerMaterialTypes(component, asset)
       })
       .registerSystem({
         schedule: AppSchedule.Update,
+        systemGroup: CoreSystems.PostMain,
         label: `registerMaterialTypes<${typeid(asset)}>`,
         system: genBinRenderables2D(asset, component)
       })
@@ -95,8 +97,18 @@ export class Material3DPlugin extends Plugin {
 
     app
       .registerType(component)
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerMaterialTypes(component, asset) })
-      .registerSystem({ schedule: AppSchedule.Update, system: genBinRenderables3D(asset, component) })
+      .registerSystem({
+        schedule: AppSchedule.Startup,
+        systemGroup: CoreSystems.Start,
+        label: `initRenderPipeline<${typeid(asset)}>`,
+        system: registerMaterialTypes(component, asset)
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        systemGroup: CoreSystems.PostMain,
+        label: `binRenders3D<${typeid(asset)}>`,
+        system: genBinRenderables3D(asset, component)
+      })
   }
 
   /**

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -1,5 +1,5 @@
 import { App, Plugin } from '../app/index.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 import { Entity, Query, World } from '../ecs/index.js'
 import { warn } from '../logger/index.js'
 import { MeshAttribute, ProgramCache, BasicMaterial } from '../render-core/index.js'
@@ -25,15 +25,15 @@ export class WebglRendererPlugin extends Plugin {
       .setResource(new ClearColor())
       .setResource(attribute)
       .setResource(new WebglProgramCache())
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerWebglTypes })
-      .registerSystem({ schedule: AppSchedule.Update, system: registerBuffers })
+      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerWebglTypes })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.Start, system: registerBuffers })
       .registerPlugin(new WebglMaterialPlugin({
         material: BasicMaterial,
         vertex3d: basicMaterial3DVertex,
         fragment3d: basicMaterial3DFragment
       }))
-      .registerSystem({ schedule: AppSchedule.Update, system: disposeDroppedMeshes })
-      .registerSystem({ schedule: AppSchedule.Update, system: queueMeshes })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.PostMain, system: disposeDroppedMeshes })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.PostMain, system: queueMeshes })
   }
 }
 

--- a/src/render-webgl/plugins/index.js
+++ b/src/render-webgl/plugins/index.js
@@ -3,7 +3,8 @@
 
 import { App } from '../../app/app.js'
 import { AppSchedule } from '../../core/core/schedules.js'
-import { typeidGeneric } from '../../type/index.js'
+import { CoreSystems } from '../../core/core/systemgroups.js'
+import { typeid, typeidGeneric } from '../../type/index.js'
 import { Material } from '../../render-core/index.js'
 import { genRegisterBuffer, genRender, genRenderPipeline } from '../systems/index.js'
 
@@ -50,9 +51,24 @@ export class WebglMaterialPlugin {
     const { material, vertex3d, fragment3d } = this
 
     app
-      .registerSystem({ schedule: AppSchedule.Startup, system: genRegisterBuffer(material) })
-      .registerSystem({ schedule: AppSchedule.Update, system: genRenderPipeline(material, vertex3d, fragment3d) })
-      .registerSystem({ schedule: AppSchedule.Update, system: genRender(material) })
+      .registerSystem({
+        schedule: AppSchedule.Startup,
+        systemGroup: CoreSystems.Start,
+        label: `registerBuffers<${typeid(material)}>`,
+        system: genRegisterBuffer(material)
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        systemGroup: CoreSystems.PostMain,
+        label: `initRenderPipeline<${typeid(material)}>`,
+        system: genRenderPipeline(material, vertex3d, fragment3d)
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        systemGroup: CoreSystems.PostMain,
+        label: `renderToWebgl<${typeid(material)}>`,
+        system: genRender(material)
+      })
   }
 
   name() {

--- a/src/scene/plugin.js
+++ b/src/scene/plugin.js
@@ -8,7 +8,7 @@ import { AssetPlugin, Assets } from '../asset/index.js'
 import { SceneAdded, SceneDropped, SceneModified } from './events/index.js'
 import { typeidGeneric } from '../type/index.js'
 import { spawnScenes } from './systems/index.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 
 export class ScenePlugin extends Plugin {
 
@@ -30,7 +30,7 @@ export class ScenePlugin extends Plugin {
       .setComponentHooks(SceneInstance, new ComponentHooks(
         initSceneInstance
       ))
-      .registerSystem({ schedule: AppSchedule.Update, system: spawnScenes })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: spawnScenes })
 
     const world = app.getWorld()
 

--- a/src/time/plugin.js
+++ b/src/time/plugin.js
@@ -4,7 +4,7 @@ import { registerTimeTypes, updateTimers } from './systems/index.js'
 import { VirtualClock } from './resource/index.js'
 import { Clock } from './clock.js'
 import { Timer } from './components/timer.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 
 export class TimePlugin extends Plugin {
 
@@ -14,10 +14,10 @@ export class TimePlugin extends Plugin {
   register(app) {
     app
       .registerType(Timer)
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerTimeTypes })
+      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerTimeTypes })
       .setResource(new VirtualClock())
-      .registerSystem({ schedule: AppSchedule.Update, system: updateVirtualClock })
-      .registerSystem({ schedule: AppSchedule.Update, system: updateTimers })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.Start, system: updateVirtualClock })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.Start, system: updateTimers })
   }
 }
 

--- a/src/touch/plugin.js
+++ b/src/touch/plugin.js
@@ -1,5 +1,5 @@
 import { App, Plugin } from '../app/index.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 import { World } from '../ecs/index.js'
 import { Events } from '../event/index.js'
 import { typeidGeneric } from '../type/index.js'
@@ -15,9 +15,9 @@ export class TouchPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerSystem({ schedule: AppSchedule.Update, system: updateTouch })
+      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.Start, system: updateTouch })
       .setResource(new Touches())
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerTouchTypes })
+      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerTouchTypes })
   }
 }
 

--- a/src/window/plugin.js
+++ b/src/window/plugin.js
@@ -19,7 +19,7 @@ import { World } from '../ecs/index.js'
 import { Window, MainWindow } from './components/index.js'
 import { Windows } from './resources/index.js'
 import { EventPlugin } from '../event/plugin.js'
-import { AppSchedule, EntityCommands } from '../core/index.js'
+import { AppSchedule, CoreSystems, EntityCommands } from '../core/index.js'
 import { registerWindowTypes } from './systems/index.js'
 
 export class WindowPlugin extends Plugin {
@@ -55,7 +55,7 @@ export class WindowPlugin extends Plugin {
     app
       .registerType(Window)
       .registerType(MainWindow)
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerWindowTypes })
+      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerWindowTypes })
       .registerPlugin(new EventPlugin({
         event:WindowMove
       }))


### PR DESCRIPTION
## Objective

Introduce explicit `CoreSystems` scheduling groups across engine plugins to establish deterministic execution phases for startup, input, asset processing, rendering, diagnostics, and cleanup systems. Previously, many systems were registered into schedules without explicit ordering groups, relying on insertion order or incidental topology. This standardizes system placement into well-defined execution phases.

## Solution

### Root cause

A large portion of engine systems were registered without explicit scheduling groups creating several issues:

* Execution order depended on plugin registration order
* Rendering systems could run before asset or buffer preparation
* Cleanup systems could execute too early
* Startup initialization ordering was inconsistent
* Event clearing and command execution timing was ambiguous
* Cross-plugin scheduling behavior became difficult to reason about

As the engine ecosystem grew, implicit ordering became increasingly fragile.

### Changes made

- Startup initialization: Initialization and registration systems now consistently execute at the beginning of startup/update flows. Examples include type registration, asset registration, parser registration, renderer setup, input initialization and window registration

- Runtime input and timing: Input and timing updates now execute early in the frame lifecycle. Examples include keyboard updates, mouse updates, touch updates, virtual clock updates, timer updates and render buffer registration. This guarantees downstream gameplay and rendering systems observe fresh frame state.

- Rendering pipeline: Rendering preparation and rendering execution were moved into post-main phase. Examples render bin generation, render pipeline initialization, canvas rendering, mesh queueing and rendering submission. This separates gameplay/update logic from rendering execution more cleanly.

> [!Note]
> This will later be moved into its own schedule

- Cleanup and deferred processing: Late-frame systems now consistently execute at the end of the frame.This ensures deferred operations occur after gameplay and rendering preparation phases. Examples command execution, asset event propagation, dropped asset unloading, event clearing, diagnostics updates, profiler updates and  scene spawning.

- Added startup command execution: Command flushing now also runs in the end of `AppSchedule.Startup`: allowing deferred startup commands to run deterministically during initialization.

### Why this approach

Alternative approaches considered:

- preserving implicit plugin registration ordering
- adding more localized before/after constraints
- introducing plugin-specific scheduling stages

These approaches scale poorly as subsystem interactions increase.

Using shared core scheduling phases provides:

- predictable frame structure
- clearer subsystem responsibilities
- easier plugin interoperability
- reduced ordering bugs
- simpler debugging and profiling

without significantly increasing scheduling complexity.

## Showcase

N/A

## Migration guide

### Behavioral changes

Systems that previously relied on implicit plugin registration order may now execute in different relative positions due to explicit phase assignment.

This primarily affects:

* rendering timing
* event clearing timing
* command execution timing
* asset update ordering

### Plugin authors

Custom plugins can now integrate more predictably by targeting appropriate core phases:

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
