### PR TITLE
Add canvas 2d clearing system

### DIFF
--- a/src/render-canvas2d/plugin.js
+++ b/src/render-canvas2d/plugin.js
@@ -1,9 +1,9 @@
 import { App, Plugin } from '../app/index.js'
-import { AppSchedule } from '../core/index.js'
+import { AppSchedule, CoreSystems } from '../core/index.js'
 import { TextureCache, BasicMaterial } from '../render-core/index.js'
 import { renderBasicMaterial } from './core/index.js'
 import { Canvas2DMaterialPlugin } from './plugins/index.js'
-import { registerCanvas2DTypes } from './systems/index.js'
+import { clearCanvas2d, registerCanvas2DTypes } from './systems/index.js'
 
 export class Canvas2DRendererPlugin extends Plugin {
 
@@ -14,6 +14,11 @@ export class Canvas2DRendererPlugin extends Plugin {
     app
       .setResource(new TextureCache())
       .registerSystem({ schedule: AppSchedule.Startup, system: registerCanvas2DTypes })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        systemGroup: CoreSystems.Start,
+        system: clearCanvas2d
+      })
       .registerPlugin(new Canvas2DMaterialPlugin({
         material:BasicMaterial,
         update:renderBasicMaterial

--- a/src/render-canvas2d/systems/clear.js
+++ b/src/render-canvas2d/systems/clear.js
@@ -1,0 +1,27 @@
+/** @import {SystemFunc} from '../../ecs/index.js' */
+import { Entity, Query } from '../../ecs/index.js'
+import { warn } from '../../logger/index.js'
+import { MainWindow, Windows, Window } from '../../window/index.js'
+
+/**
+ * Clears the active canvas2d frame before the main render systems run.
+ *
+ * @type {SystemFunc}
+ */
+export function clearCanvas2d(world) {
+  const windows = new Query(world, [Entity, Window, MainWindow])
+  const canvases = world.getResource(Windows)
+  const window = windows.single()
+
+  if (!window) return warn('Please define the main window before.')
+
+  const canvas = canvases.getWindow(window[0])
+
+  if (!canvas) return
+
+  const ctx = canvas.getContext('2d')
+
+  if (!ctx) return warn('2d context could not be created on the canvas.')
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+}

--- a/src/render-canvas2d/systems/index.js
+++ b/src/render-canvas2d/systems/index.js
@@ -49,8 +49,6 @@ export function genrender(type, renderMaterial) {
 
     if (!ctx) return warn('2d context could not be created on the canvas.')
 
-    // TODO: Return when this becomes default rendering system
-    // ctx.clearRect(0, 0, canvas.width, canvas.height)
     cameras.each(([cameraTransform, renderList, camera]) => {
       const view = GlobalTransform2D.invert(cameraTransform)
 
@@ -117,4 +115,5 @@ export function genrender(type, renderMaterial) {
   }
 }
 
+export * from './clear.js'
 export * from './types.js'


### PR DESCRIPTION
## Objective

Introduce deterministic frame clearing for the Canvas2D renderer and avoid redundant window resize operations. Previously, Canvas2D rendering accumulated previous frame contents because the canvas was never cleared automatically before rendering. Additionally, resize commands always mutated the canvas even when dimensions were unchanged. This adds a dedicated canvas clearing system and optimizes resize handling.

## Solution

### Root cause

The Canvas2D renderer intentionally skipped clearing the canvas each frame. This caused rendered frames to persist between updates, producing visual artifacts such as:

* ghosting
* overdraw accumulation
* stale frame remnants
* incorrect motion rendering

Separately, window resize commands always triggered canvas dimension writes even when dimensions were identical, causing unnecessary canvas resets and potential rendering invalidation. This is what previously cleared the frames

## Solution

Added dedicated `clearCanvas2d` system (scheduled at the beginning of update schedule) which:

* resolves the main window canvas
* acquires the `2d` rendering context
* clears the frame using:

Frame clearing is now treated as a first-class rendering stage rather than implicit renderer behavior.

Optimized resize handling

Added an early bailout for resize commands preventing unnecessary:

* canvas reallocations
* rendering context invalidation
* framebuffer resets
* resize-triggered redraw work

when dimensions have not changed.

### Why this approach

Alternative approaches considered:

* keeping clearing inside render systems
* clearing per material renderer
* clearing conditionally during render submission

Those approaches couple frame lifecycle management to renderer implementations and make multi-pass rendering harder to reason about.

Using a dedicated clearing system:

* centralizes frame preparation
* aligns with ECS scheduling principles
* improves renderer composability
* enables future configurable clear stages
* preserves clean render pipeline separation

The resize optimization similarly avoids unnecessary canvas mutations with minimal complexity.

## Showcase

N/A

## Migration guide

No migration required.

### Behavioral change

Canvas2D rendering now clears the frame automatically every update cycle. Projects that intentionally relied on persistent frame accumulation for effects such as manual trails, paint-style rendering and temporal accumulation must now implement custom persistence behavior explicitly.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
