### PR TITLE
Change schedule labels to constructor types

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -100,7 +100,7 @@ export class App {
   }
 
   /**
-   * @param {{label: string, delay?: number, repeat?: boolean, errorHandler?: (error: Error, world: World) => void, defaultSystemGroup?: import('../type/index.js').Constructor}} config
+   * @param {{label: import('../type/index.js').Constructor, delay?: number, repeat?: boolean, errorHandler?: (error: Error, world: World) => void, defaultSystemGroup?: import('../type/index.js').Constructor}} config
    */
   createSchedule(config) {
     this.scheduler.set(new Executable(config))

--- a/src/core/core/runner.js
+++ b/src/core/core/runner.js
@@ -10,7 +10,7 @@ export function defaultRunner(scheduler, world) {
   const now = performance.now()
 
   for (const executable of scheduler.values()) {
-    state.set(executable.label, {
+    state.set(executable.typeId, {
       active: true,
       nextRunAt: now + executable.delay
     })
@@ -18,7 +18,7 @@ export function defaultRunner(scheduler, world) {
 
   const update = (/** @type {number} */ time) => {
     for (const executable of scheduler.values()) {
-      const execState = state.get(executable.label)
+      const execState = state.get(executable.typeId)
 
       if (!execState || !execState.active) continue
 

--- a/src/core/core/schedules.js
+++ b/src/core/core/schedules.js
@@ -1,21 +1,24 @@
 /**
- * The core schedules of an {@link App app}.
- *
- * @readonly
- * @enum {string}
+ * Core schedule labels used by an {@link App app}.
  */
-export const AppSchedule = {
+class Startup {}
+
+/**
+ * Main loop schedule.
+ */
+class Update {}
+
+export const AppSchedule = Object.freeze({
 
   /**
    * The schedule that updates systems it contains every frame.
-   * The frame rate is determined by the refesh rate of the device.
-   *
+   * The frame rate is determined by the refresh rate of the device.
    */
-  Update: 'mainupdate',
+  Update,
 
   /**
    * Schedule which runs once when the {@link App app} is
    * {@link App.run run}.
    */
-  Startup: 'startup'
-}
+  Startup
+})

--- a/src/schedule/core/executable.js
+++ b/src/schedule/core/executable.js
@@ -1,4 +1,5 @@
 import { World } from '../../ecs/index.js'
+import { typeid } from '../../type/index.js'
 import { Schedule } from './schedule.js'
 
 /**
@@ -28,7 +29,7 @@ export class Executable {
 
   /**
    * @readonly
-   * @type {string}
+   * @type {import('../../type/index.js').Constructor}
    */
   label
 
@@ -63,7 +64,7 @@ export class Executable {
   errorHandler
 
   /**
-   * @param {{label: string, repeat?: boolean, delay?: number, errorHandler?: (error: Error, world: World) => void, defaultSystemGroup?: import('../../type/index.js').Constructor}} config
+   * @param {{label: import('../../type/index.js').Constructor, repeat?: boolean, delay?: number, errorHandler?: (error: Error, world: World) => void, defaultSystemGroup?: import('../../type/index.js').Constructor}} config
    */
   constructor(config) {
     this.label = config.label
@@ -71,5 +72,12 @@ export class Executable {
     this.delay = config.delay ?? 0
     this.errorHandler = config.errorHandler
     this.defaultSystemGroup = config.defaultSystemGroup
+  }
+
+  /**
+   * @returns {string}
+   */
+  get typeId() {
+    return typeid(this.label)
   }
 }

--- a/src/schedule/core/scheduler.js
+++ b/src/schedule/core/scheduler.js
@@ -1,15 +1,19 @@
 import { Executable } from './executable.js'
 import { Schedule } from './schedule.js'
+import { typeid } from '../../type/index.js'
 
 /**
  * Stores labeled {@link Executable executables}.
  *
  * @example
  * ```ts
- * scheduler.set(new Executable({ label: "primary" }))
- * scheduler.set(new Executable({ label: "secondary" }))
+ * class PrimarySchedule {}
+ * class SecondarySchedule {}
  *
- * const primarySchedule = scheduler.get("primary")
+ * scheduler.set(new Executable({ label: PrimarySchedule }))
+ * scheduler.set(new Executable({ label: SecondarySchedule }))
+ *
+ * const primarySchedule = scheduler.get(PrimarySchedule)
  * ```
  */
 export class Scheduler {
@@ -23,15 +27,15 @@ export class Scheduler {
    * @param {Executable} executable
    */
   set(executable) {
-    this.executables.set(executable.label, executable)
+    this.executables.set(typeid(executable.label), executable)
   }
 
   /**
-   * @param {string} label
+   * @param {import('../../type/index.js').Constructor} label
    * @returns {Schedule | undefined}
    */
   get(label) {
-    return this.executables.get(label)?.schedule
+    return this.executables.get(typeid(label))?.schedule
   }
 
   /**

--- a/src/schedule/core/systembuilder.js
+++ b/src/schedule/core/systembuilder.js
@@ -42,15 +42,15 @@ export class SchedulerBuilder {
     const defaultGroupsBySchedule = new Map()
 
     for (const executable of scheduler.values()) {
-      defaultGroupsBySchedule.set(executable.label, executable.defaultSystemGroup)
+      defaultGroupsBySchedule.set(typeid(executable.label), executable.defaultSystemGroup)
     }
 
     const schedules = this.createScheduleContexts(defaultGroupsBySchedule)
 
-    for (const [scheduleLabel, context] of schedules) {
-      const schedule = scheduler.get(scheduleLabel)
+    for (const [, context] of schedules) {
+      const schedule = scheduler.get(context.label)
 
-      assert(schedule, `The schedule label "${scheduleLabel}" is not set in the provided \`Scheduler\`.`)
+      assert(schedule, `The schedule label "${context.label.name}" is not set in the provided \`Scheduler\`.`)
 
       for (const system of this.sortScheduleSystems(context)) {
         schedule.add(system.config.system)
@@ -74,7 +74,7 @@ export class SchedulerBuilder {
       const groupTypeId = typeid(config.label)
 
       if (context.groupIdsByTypeId.has(groupTypeId)) {
-        throws(`Duplicate system group label "${config.label.name}" on schedule "${config.schedule}".`)
+        throws(`Duplicate system group label "${config.label.name}" on schedule "${config.schedule.name}".`)
       }
 
       /** @type {SystemGroupRegistration} */
@@ -94,7 +94,7 @@ export class SchedulerBuilder {
         const existing = context.nodesByLabel.get(groupLabel)
 
         if (existing) {
-          throws(`Duplicate system group label "${groupLabel}" on schedule "${config.schedule}". Use a unique label or direct function references in ordering.`)
+          throws(`Duplicate system group label "${groupLabel}" on schedule "${config.schedule.name}". Use a unique label or direct function references in ordering.`)
         }
 
         context.nodesByLabel.set(groupLabel, { kind: ScheduleNodeKind.Group, id: group.id })
@@ -116,17 +116,17 @@ export class SchedulerBuilder {
         const existing = context.nodesByLabel.get(systemLabel)
 
         if (existing) {
-          throws(`Duplicate system label "${systemLabel}" on schedule "${config.schedule}". Use a unique label or direct function references in ordering.`)
+          throws(`Duplicate system label "${systemLabel}" on schedule "${config.schedule.name}". Use a unique label or direct function references in ordering.`)
         }
 
         context.nodesByLabel.set(systemLabel, { kind: ScheduleNodeKind.System, id: system.id })
       }
     }
 
-    for (const [scheduleLabel, context] of schedules) {
-      context.defaultSystemGroup = defaultGroupsBySchedule.get(scheduleLabel)
+    for (const [, context] of schedules) {
+      context.defaultSystemGroup = defaultGroupsBySchedule.get(typeid(context.label))
 
-      this.resolveGroupParents(context, scheduleLabel)
+      this.resolveGroupParents(context, context.label)
 
       for (let i = 0; i < context.systems.length; i++) {
         const system = context.systems[i]
@@ -137,7 +137,7 @@ export class SchedulerBuilder {
         const groupId = context.groupIdsByTypeId.get(typeid(groupLabel))
 
         if (groupId === undefined) {
-          throws(`The system group "${groupLabel.name}" must be registered explicitly before it can be used on schedule "${scheduleLabel}".`)
+          throws(`The system group "${groupLabel.name}" must be registered explicitly before it can be used on schedule "${context.label.name}".`)
         }
 
         context.groups[groupId].systems.push(system.id)
@@ -150,7 +150,7 @@ export class SchedulerBuilder {
   /**
    * @private
    * @param {ScheduleContext} context
-   * @param {string} scheduleLabel
+   * @param {Constructor} scheduleLabel
    */
   resolveGroupParents(context, scheduleLabel) {
     for (let i = 0; i < context.groups.length; i++) {
@@ -162,7 +162,7 @@ export class SchedulerBuilder {
       const parentId = context.groupIdsByTypeId.get(typeid(parentLabel))
 
       if (parentId === undefined) {
-        throws(`The parent system group "${parentLabel.name}" must be registered explicitly before it can be used on schedule "${scheduleLabel}".`)
+        throws(`The parent system group "${parentLabel.name}" must be registered explicitly before it can be used on schedule "${scheduleLabel.name}".`)
       }
 
       group.parentId = parentId
@@ -197,7 +197,7 @@ export class SchedulerBuilder {
     if (visitState === GroupVisitState.Visiting) {
       const group = context.groups[groupId]
 
-      throws(`Schedule "${context.label}" contains cyclic system group nesting involving "${group.config.label.name}".`)
+      throws(`Schedule "${context.label.name}" contains cyclic system group nesting involving "${group.config.label.name}".`)
     }
 
     if (visitState === GroupVisitState.Visited) return
@@ -223,7 +223,7 @@ export class SchedulerBuilder {
     const sorted = kahnTopologySort(graph)
 
     if (!sorted) {
-      throws(`Schedule "${context.label}" contains cyclic system ordering constraints.`)
+      throws(`Schedule "${context.label.name}" contains cyclic system ordering constraints.`)
     }
 
     /** @type {SystemRegistration[]} */
@@ -347,7 +347,7 @@ export class SchedulerBuilder {
     const node = context.nodesByLabel.get(stringLabel)
 
     if (!node) {
-      throws(`Could not resolve the system or system group label "${stringLabel}" on schedule "${context.label}".`)
+      throws(`Could not resolve the system or system group label "${stringLabel}" on schedule "${context.label.name}".`)
     }
 
     return node
@@ -374,7 +374,7 @@ export class SchedulerBuilder {
         const toNodeId = toNodes[j]
 
         if (fromNodeId === toNodeId) {
-          throws(`The reference "${describeReference(targetLabel)}" creates a self-referential system ordering on schedule "${context.label}".`)
+          throws(`The reference "${describeReference(targetLabel)}" creates a self-referential system ordering on schedule "${context.label.name}".`)
         }
 
         const key = `${fromNodeId}:${toNodeId}`
@@ -399,7 +399,7 @@ export class SchedulerBuilder {
     if (node.kind === ScheduleNodeKind.System) {
       const graphId = graphIdsBySystemId.get(node.id)
 
-      assert(graphId !== undefined, `Internal error: Could not resolve graph node for system ${node.id} on schedule "${context.label}".`)
+      assert(graphId !== undefined, `Internal error: Could not resolve graph node for system ${node.id} on schedule "${context.label.name}".`)
 
       return [graphId]
     }
@@ -414,7 +414,7 @@ export class SchedulerBuilder {
       for (let i = 0; i < systems.length; i++) {
         const graphId = graphIdsBySystemId.get(systems[i])
 
-        assert(graphId !== undefined, `Internal error: Could not resolve graph node for system ${systems[i]} on schedule "${context.label}".`)
+        assert(graphId !== undefined, `Internal error: Could not resolve graph node for system ${systems[i]} on schedule "${context.label.name}".`)
         graphIds.push(graphId)
       }
 
@@ -435,7 +435,7 @@ export class SchedulerBuilder {
   expandGroupToGraphNode(context, groupId) {
     const graphId = context.graphIdsByGroupId?.get(groupId)
 
-    assert(graphId !== undefined, `Internal error: Could not resolve graph node for system group ${groupId} on schedule "${context.label}".`)
+    assert(graphId !== undefined, `Internal error: Could not resolve graph node for system group ${groupId} on schedule "${context.label.name}".`)
 
     return graphId
   }
@@ -469,7 +469,7 @@ export class SchedulerBuilder {
     if (visiting.has(groupId)) {
       const group = context.groups[groupId]
 
-      throws(`Schedule "${context.label}" contains cyclic system group nesting involving "${group.config.label.name}".`)
+      throws(`Schedule "${context.label.name}" contains cyclic system group nesting involving "${group.config.label.name}".`)
     }
 
     visiting.add(groupId)
@@ -498,11 +498,12 @@ export class SchedulerBuilder {
 
 /**
  * @param {Map<string, ScheduleContext>} schedules
- * @param {string} label
+ * @param {Constructor} label
  * @returns {ScheduleContext}
  */
 function getOrCreateScheduleContext(schedules, label) {
-  const existing = schedules.get(label)
+  const scheduleTypeId = typeid(label)
+  const existing = schedules.get(scheduleTypeId)
 
   if (existing) return existing
 
@@ -516,7 +517,7 @@ function getOrCreateScheduleContext(schedules, label) {
     defaultSystemGroup: undefined
   })
 
-  schedules.set(label, created)
+  schedules.set(scheduleTypeId, created)
 
   return created
 }
@@ -538,7 +539,7 @@ const ScheduleNodeKind = Object.freeze({
 
 /**
  * @typedef ScheduleContext
- * @property {string} label
+ * @property {Constructor} label
  * @property {SystemRegistration[]} systems
  * @property {SystemGroupRegistration[]} groups
  * @property {Map<string, ScheduleNodeRef>} nodesByLabel

--- a/src/schedule/core/systemconfig.js
+++ b/src/schedule/core/systemconfig.js
@@ -8,7 +8,7 @@
 /**
  * @typedef SystemConfig
  * @property {SystemFunc} system
- * @property {string} schedule
+ * @property {Constructor} schedule
  * @property {string | undefined} [label]
  * @property {Constructor | undefined} [systemGroup]
  * @property {SystemOrderReference[] | undefined} [before]
@@ -18,7 +18,7 @@
 /**
  * @typedef SystemGroupConfig
  * @property {Constructor} label
- * @property {string} schedule
+ * @property {Constructor} schedule
  * @property {Constructor | undefined} [parent]
  * @property {SystemOrderReference[] | undefined} [before]
  * @property {SystemOrderReference[] | undefined} [after]

--- a/src/schedule/tests/scheduleBuilder.test.js
+++ b/src/schedule/tests/scheduleBuilder.test.js
@@ -4,6 +4,8 @@ import { World } from '../../ecs/index.js'
 import { Executable, Scheduler, SchedulerBuilder } from '../index.js'
 
 class Phase { }
+class Startup { }
+class Update { }
 class ParentPhase { }
 class ChildPhase { }
 class MissingPhase { }
@@ -22,25 +24,25 @@ describe('Testing `SchedulerBuilder`', () => {
     function early() { order.push('early') }
     function middle() { order.push('middle') }
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
 
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       after: [middle],
       system: late
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       before: ['middle'],
       system: early
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       system: middle
     })
 
     builder.pushToScheduler(scheduler)
-    scheduler.get('update')?.run(world)
+    scheduler.get(Update)?.run(world)
 
     deepStrictEqual(order, ['early', 'middle', 'late'])
   })
@@ -54,21 +56,21 @@ describe('Testing `SchedulerBuilder`', () => {
     function systemA() { order.push('a') }
     function systemB() { order.push('b') }
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
 
     builder.add({
       label: 'first',
-      schedule: 'update',
+      schedule: Update,
       system: systemA
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       after: ['first'],
       system: systemB
     })
 
     builder.pushToScheduler(scheduler)
-    scheduler.get('update')?.run(world)
+    scheduler.get(Update)?.run(world)
 
     deepStrictEqual(order, ['a', 'b'])
   })
@@ -87,48 +89,48 @@ describe('Testing `SchedulerBuilder`', () => {
     function input() { updateOrder.push('input') }
     function render() { updateOrder.push('render') }
 
-    scheduler.set(new Executable({ label: 'startup' }))
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Startup }))
+    scheduler.set(new Executable({ label: Update }))
 
     builder.addGroup({
       label: Phase,
-      schedule: 'startup'
+      schedule: Startup
     })
     builder.add({
-      schedule: 'startup',
+      schedule: Startup,
       before: [Phase],
       system: boot
     })
     builder.add({
-      schedule: 'startup',
+      schedule: Startup,
       systemGroup: Phase,
       system: register
     })
 
     builder.addGroup({
       label: Phase,
-      schedule: 'update',
+      schedule: Update,
       after: ['input']
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: Phase,
       before: [render],
       system: simulate
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       system: input
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: Phase,
       system: render
     })
 
     builder.pushToScheduler(scheduler)
-    scheduler.get('startup')?.run(world)
-    scheduler.get('update')?.run(world)
+    scheduler.get(Startup)?.run(world)
+    scheduler.get(Update)?.run(world)
 
     deepStrictEqual(startupOrder, ['boot', 'register'])
     deepStrictEqual(updateOrder, ['input', 'simulate', 'render'])
@@ -148,36 +150,36 @@ describe('Testing `SchedulerBuilder`', () => {
     function second() { order.push('second') }
     function finish() { order.push('finish') }
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
 
     builder.addGroup({
       label: Phase,
-      schedule: 'update',
+      schedule: Update,
       after: ['prepare'],
       before: ['finish']
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       system: prepare
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: Phase,
       system: first
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: Phase,
       after: [first],
       system: second
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       system: finish
     })
 
     builder.pushToScheduler(scheduler)
-    scheduler.get('update')?.run(world)
+    scheduler.get(Update)?.run(world)
 
     deepStrictEqual(order, ['prepare', 'first', 'second', 'finish'])
   })
@@ -194,36 +196,36 @@ describe('Testing `SchedulerBuilder`', () => {
     function other() { order.push('other') }
 
     scheduler.set(new Executable({
-      label: 'update',
+      label: Update,
       defaultSystemGroup: DefaultPhase
     }))
 
     builder.addGroup({
       label: DefaultPhase,
-      schedule: 'update',
+      schedule: Update,
       before: [AlternatePhase]
     })
     builder.addGroup({
       label: AlternatePhase,
-      schedule: 'update'
+      schedule: Update
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: DefaultPhase,
       system: explicit
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       system: implicit
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: AlternatePhase,
       system: other
     })
 
     builder.pushToScheduler(scheduler)
-    scheduler.get('update')?.run(world)
+    scheduler.get(Update)?.run(world)
 
     deepStrictEqual(order, ['explicit', 'implicit', 'other'])
   })
@@ -240,41 +242,41 @@ describe('Testing `SchedulerBuilder`', () => {
     function fence() { order.push('fence') }
 
     scheduler.set(new Executable({
-      label: 'update',
+      label: Update,
       defaultSystemGroup: DefaultPhase
     }))
 
     builder.addGroup({
       label: DefaultPhase,
-      schedule: 'update',
+      schedule: Update,
       before: [FencePhase]
     })
     builder.addGroup({
       label: AlternatePhase,
-      schedule: 'update',
+      schedule: Update,
       after: [FencePhase]
     })
     builder.addGroup({
       label: FencePhase,
-      schedule: 'update'
+      schedule: Update
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       system: implicit
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: AlternatePhase,
       system: explicit
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: FencePhase,
       system: fence
     })
 
     builder.pushToScheduler(scheduler)
-    scheduler.get('update')?.run(world)
+    scheduler.get(Update)?.run(world)
 
     deepStrictEqual(order, ['implicit', 'fence', 'explicit'])
   })
@@ -294,42 +296,42 @@ describe('Testing `SchedulerBuilder`', () => {
     function lateOne() { order.push('lateOne') }
     function lateTwo() { order.push('lateTwo') }
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
 
     builder.addGroup({
       label: EarlyPhase,
-      schedule: 'update',
+      schedule: Update,
       before: [LatePhase]
     })
     builder.addGroup({
       label: LatePhase,
-      schedule: 'update'
+      schedule: Update
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: EarlyPhase,
       system: earlyOne
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: EarlyPhase,
       after: [earlyOne],
       system: earlyTwo
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: LatePhase,
       system: lateOne
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: LatePhase,
       after: [lateOne],
       system: lateTwo
     })
 
     builder.pushToScheduler(scheduler)
-    scheduler.get('update')?.run(world)
+    scheduler.get(Update)?.run(world)
 
     deepStrictEqual(order, ['earlyOne', 'earlyTwo', 'lateOne', 'lateTwo'])
   })
@@ -348,35 +350,35 @@ describe('Testing `SchedulerBuilder`', () => {
     function startSystem() { order.push('start') }
     function endSystem() { order.push('end') }
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
 
     builder.addGroup({
       label: StartPhase,
-      schedule: 'update',
+      schedule: Update,
       before: [MiddlePhase]
     })
     builder.addGroup({
       label: MiddlePhase,
-      schedule: 'update',
+      schedule: Update,
       before: [EndPhase]
     })
     builder.addGroup({
       label: EndPhase,
-      schedule: 'update'
+      schedule: Update
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: EndPhase,
       system: endSystem
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: StartPhase,
       system: startSystem
     })
 
     builder.pushToScheduler(scheduler)
-    scheduler.get('update')?.run(world)
+    scheduler.get(Update)?.run(world)
 
     deepStrictEqual(order, ['start', 'end'])
   })
@@ -396,40 +398,40 @@ describe('Testing `SchedulerBuilder`', () => {
     function tail() { order.push('tail') }
     function nested() { order.push('nested') }
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
 
     builder.addGroup({
       label: RootPhase,
-      schedule: 'update',
+      schedule: Update,
       after: [head],
       before: [middle, tail]
     })
     builder.addGroup({
       label: NestedPhase,
       parent: RootPhase,
-      schedule: 'update'
+      schedule: Update
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       system: head
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       before: [tail],
       system: middle
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: NestedPhase,
       system: nested
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       system: tail
     })
 
     builder.pushToScheduler(scheduler)
-    scheduler.get('update')?.run(world)
+    scheduler.get(Update)?.run(world)
 
     deepStrictEqual(order, ['head', 'nested', 'middle', 'tail'])
   })
@@ -450,46 +452,46 @@ describe('Testing `SchedulerBuilder`', () => {
     function tail() { order.push('tail') }
     function nested() { order.push('nested') }
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
 
     builder.addGroup({
       label: GrandPhase,
-      schedule: 'update',
+      schedule: Update,
       before: [tail]
     })
     builder.addGroup({
       label: ParentPhase,
       parent: GrandPhase,
-      schedule: 'update',
+      schedule: Update,
       after: [head],
       before: [middle]
     })
     builder.addGroup({
       label: ChildPhase,
       parent: ParentPhase,
-      schedule: 'update'
+      schedule: Update
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       system: head
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       before: [tail],
       system: middle
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: ChildPhase,
       system: nested
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       system: tail
     })
 
     builder.pushToScheduler(scheduler)
-    scheduler.get('update')?.run(world)
+    scheduler.get(Update)?.run(world)
 
     deepStrictEqual(order, ['head', 'nested', 'middle', 'tail'])
   })
@@ -506,23 +508,23 @@ describe('Testing `SchedulerBuilder`', () => {
     function sharedStartup() { startupOrder.push('sharedStartup') }
     function sharedUpdate() { updateOrder.push('sharedUpdate') }
 
-    scheduler.set(new Executable({ label: 'startup' }))
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Startup }))
+    scheduler.set(new Executable({ label: Update }))
 
     builder.add({
-      schedule: 'startup',
+      schedule: Startup,
       label: 'shared',
       system: sharedStartup
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       label: 'shared',
       system: sharedUpdate
     })
 
     builder.pushToScheduler(scheduler)
-    scheduler.get('startup')?.run(world)
-    scheduler.get('update')?.run(world)
+    scheduler.get(Startup)?.run(world)
+    scheduler.get(Update)?.run(world)
 
     deepStrictEqual(startupOrder, ['sharedStartup'])
     deepStrictEqual(updateOrder, ['sharedUpdate'])
@@ -532,14 +534,14 @@ describe('Testing `SchedulerBuilder`', () => {
     const builder = new SchedulerBuilder()
     const scheduler = new Scheduler()
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       label: 'duplicate',
       system: () => { }
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       label: 'duplicate',
       system: () => { }
     })
@@ -551,14 +553,14 @@ describe('Testing `SchedulerBuilder`', () => {
     const builder = new SchedulerBuilder()
     const scheduler = new Scheduler()
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
     builder.addGroup({
       label: Phase,
-      schedule: 'update'
+      schedule: Update
     })
     builder.addGroup({
       label: Phase,
-      schedule: 'update'
+      schedule: Update
     })
 
     throws(() => builder.pushToScheduler(scheduler), /Duplicate system group label/)
@@ -569,20 +571,20 @@ describe('Testing `SchedulerBuilder`', () => {
     const scheduler = new Scheduler()
 
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       system: () => { }
     })
 
-    throws(() => builder.pushToScheduler(scheduler), /The schedule label "update" is not set/)
+    throws(() => builder.pushToScheduler(scheduler), /The schedule label "Update" is not set/)
   })
 
   test('requires system groups to be registered explicitly', () => {
     const builder = new SchedulerBuilder()
     const scheduler = new Scheduler()
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       systemGroup: MissingPhase,
       system: () => { }
     })
@@ -594,11 +596,11 @@ describe('Testing `SchedulerBuilder`', () => {
     const builder = new SchedulerBuilder()
     const scheduler = new Scheduler()
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
     builder.addGroup({
       label: ParentPhase,
       parent: MissingPhase,
-      schedule: 'update'
+      schedule: Update
     })
 
     throws(() => builder.pushToScheduler(scheduler), /parent system group/)
@@ -608,16 +610,16 @@ describe('Testing `SchedulerBuilder`', () => {
     const builder = new SchedulerBuilder()
     const scheduler = new Scheduler()
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
     builder.addGroup({
       label: ParentPhase,
       parent: ChildPhase,
-      schedule: 'update'
+      schedule: Update
     })
     builder.addGroup({
       label: ChildPhase,
       parent: ParentPhase,
-      schedule: 'update'
+      schedule: Update
     })
 
     throws(() => builder.pushToScheduler(scheduler), /cyclic system group nesting/)
@@ -629,14 +631,14 @@ describe('Testing `SchedulerBuilder`', () => {
     function first() { }
     function second() { }
 
-    scheduler.set(new Executable({ label: 'update' }))
+    scheduler.set(new Executable({ label: Update }))
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       after: [second],
       system: first
     })
     builder.add({
-      schedule: 'update',
+      schedule: Update,
       after: [first],
       system: second
     })


### PR DESCRIPTION
## Objective

Refactor schedule identification to use constructor-based schedule labels instead of string labels. Previously, schedules were identified using raw strings such as 'startup' and 'update' This introduces typed constructor-based schedule labels, improving schedule isolation, type safety, internal consistency and integration with the engine’s existing type identity system.

## Solution

The scheduling system previously relied on string identifiers. This has several possible problems:

* string collisions across unrelated schedules
* weak type safety
* inconsistent identity handling compared to system groups/types
* fragile internal lookups
* harder refactoring and tooling support
* runtime ambiguity when labels changed

The engine already uses constructor/type-based identity extensively elsewhere through `typeid()`, but schedules remained string-based.

## Why this approach

Alternative approaches considered:

- namespaced string constants
- symbols
- UUID-based schedule labels

Constructor-based labels integrate best with the existing ECS/type architecture because:

- schedules already behave like engine types
- type infrastructure already exists
- constructors provide readable names
- APIs become more self-documenting
- tooling/autocomplete improves significantly
- accidental collisions become much harder

This also creates consistency between:

- schedules
- system groups
- components
- resources
- assets

all of which already use constructor identity semantics.

## Showcase

### Before

```js
scheduler.set(new Executable({
  label: 'update'
}))

scheduler.get('update')
```

### After

```js
class Update {}

scheduler.set(new Executable({
  label: Update
}))

scheduler.get(Update)
```

## Migration guide

String schedule labels are no longer supported. All schedule registration and lookup now relies on constructor identity.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
