### PR TITLE
Update examples

### DIFF
--- a/examples/samples/animation/2d/basic.js
+++ b/examples/samples/animation/2d/basic.js
@@ -26,14 +26,9 @@ import {
   Canvas2DRendererPlugin,
   DefaultPlugin,
   DOMWindowPlugin,
-  Entity,
-  FPSDebugger,
-  MainWindow,
-  Query,
-  warn,
-  WindowCommands
+  FPSDebugger
 } from 'wima'
-import { addDefaultCamera2D, HackPlugin } from '../../utils.js'
+import { addDefaultCamera2D, HackPlugin, setupViewport } from '../../utils.js'
 
 const app = new App()
 
@@ -48,20 +43,6 @@ app
   .registerSystem({ schedule: AppSchedule.Startup, system: addDefaultCamera2D })
   .registerDebugger(new FPSDebugger())
   .run()
-
-/**
- * @param {World} world
- */
-function setupViewport(world) {
-  const windowcommands = new WindowCommands(world)
-  const window = new Query(world, [Entity, MainWindow]).single()
-
-  if (!window) return warn('No main window defined.')
-
-  windowcommands
-    .window(window[0])
-    .resize(innerWidth, innerHeight)
-}
 
 /**
  * @param {World} world

--- a/examples/samples/audio/audioGraph.js
+++ b/examples/samples/audio/audioGraph.js
@@ -39,7 +39,7 @@ app
   .registerPlugin(new Canvas2DRendererPlugin())
   .registerSystem({ schedule: AppSchedule.Startup, system: init })
   .registerSystem({ schedule: AppSchedule.Update, system: setupViewport })
-  .registerSystem({ schedule: AppSchedule.Update, system: playAudio })
+  .registerSystem({ schedule: AppSchedule.Update, system: playAudioSource })
   .registerDebugger(new FPSDebugger())
   .run()
 
@@ -56,7 +56,7 @@ function init(world) {
 /**
  * @param {World} world
  */
-function playAudio(world) {
+function playAudioSource(world) {
   const current = world.getResource(Playing)
   const audioGraph = world.getResource(AudioGraph)
   const audioSources = world.getResource(AudioAssets)

--- a/examples/samples/audio/audioGraph.js
+++ b/examples/samples/audio/audioGraph.js
@@ -10,8 +10,7 @@ import {
   Canvas2DRendererPlugin,
   DefaultPlugin,
   DOMWindowPlugin,
-  FPSDebugger,
-  Plugin
+  FPSDebugger
 } from 'wima'
 import { HackPlugin, setupViewport } from '../utils.js'
 
@@ -31,18 +30,6 @@ class Playing {
   }
 }
 
-// Why use a plugin? The current implentation does not have system sets and
-// systems registered directly on the App are precede ones registered by plugins.
-// This conflict is between internal engine system and external engine systems ordering.
-class MyPlugin extends Plugin {
-
-  /**
-   * @param {App} app
-   */
-  register(app) {
-    app.registerSystem({ schedule: AppSchedule.Startup, system: init })
-  }
-}
 const app = new App()
 
 app
@@ -50,7 +37,7 @@ app
   .registerPlugin(new DefaultPlugin())
   .registerPlugin(new DOMWindowPlugin())
   .registerPlugin(new Canvas2DRendererPlugin())
-  .registerPlugin(new MyPlugin())
+  .registerSystem({ schedule: AppSchedule.Startup, system: init })
   .registerSystem({ schedule: AppSchedule.Update, system: setupViewport })
   .registerSystem({ schedule: AppSchedule.Update, system: playAudio })
   .registerDebugger(new FPSDebugger())

--- a/examples/samples/audio/audioPlayback.js
+++ b/examples/samples/audio/audioPlayback.js
@@ -13,8 +13,7 @@ import {
   AppSchedule,
   Canvas2DRendererPlugin,
   DOMWindowPlugin,
-  FPSDebugger,
-  Plugin
+  FPSDebugger
 } from 'wima'
 import { HackPlugin, setupViewport } from '../utils.js'
 

--- a/examples/samples/audio/audioPlayback.js
+++ b/examples/samples/audio/audioPlayback.js
@@ -18,20 +18,7 @@ import {
 } from 'wima'
 import { HackPlugin, setupViewport } from '../utils.js'
 
-class AudioTimer extends Timer {}
-
-// Why use a plugin? The current implentation does not have system sets and
-// systems registered directly on the App are precede ones registered by plugins.
-// This conflict is between internal engine system and external engine systems ordering.
-class MyPlugin extends Plugin {
-
-  /**
-   * @param {App} app
-   */
-  register(app) {
-    app.registerSystem({ schedule: AppSchedule.Startup, system: init })
-  }
-}
+class AudioTimer extends Timer { }
 
 const app = new App()
 
@@ -40,8 +27,8 @@ app
   .registerPlugin(new DefaultPlugin())
   .registerPlugin(new DOMWindowPlugin())
   .registerPlugin(new Canvas2DRendererPlugin())
-  .registerPlugin(new MyPlugin())
   .registerSystem({ schedule: AppSchedule.Update, system: setupViewport })
+  .registerSystem({ schedule: AppSchedule.Startup, system: init })
   .registerSystem({ schedule: AppSchedule.Update, system: update })
   .registerDebugger(new FPSDebugger())
   .run()

--- a/examples/samples/audio/audioPlayer.js
+++ b/examples/samples/audio/audioPlayer.js
@@ -11,23 +11,9 @@ import {
   Canvas2DRendererPlugin,
   DefaultPlugin,
   DOMWindowPlugin,
-  FPSDebugger,
-  Plugin
+  FPSDebugger
 } from 'wima'
 import { HackPlugin, setupViewport } from '../utils.js'
-
-// Why use a plugin? The current implentation does not have system sets and
-// systems registered directly on the App are precede ones registered by plugins.
-// This conflict is between internal engine system and external engine systems ordering.
-class MyPlugin extends Plugin {
-
-  /**
-   * @param {App} app
-   */
-  register(app) {
-    app.registerSystem({ schedule: AppSchedule.Startup, system: init })
-  }
-}
 
 const app = new App()
 
@@ -36,7 +22,7 @@ app
   .registerPlugin(new DefaultPlugin())
   .registerPlugin(new DOMWindowPlugin())
   .registerPlugin(new Canvas2DRendererPlugin())
-  .registerPlugin(new MyPlugin())
+  .registerSystem({ schedule: AppSchedule.Startup, system: init })
   .registerSystem({ schedule: AppSchedule.Update, system: setupViewport })
   .registerDebugger(new FPSDebugger())
   .run()

--- a/examples/samples/input/keyboard.js
+++ b/examples/samples/input/keyboard.js
@@ -34,27 +34,18 @@ const paddingHeight = 0.03
 const app = new App()
 
 app
+  .setResource(new KeytoEntityMap())
   .registerPlugin(new HackPlugin())
   .registerPlugin(new DefaultPlugin())
   .registerPlugin(new DOMWindowPlugin())
   .registerPlugin(new Canvas2DRendererPlugin())
   .registerSystem({ schedule: AppSchedule.Startup, system: addDefaultCamera2D })
-  .registerSystem({ schedule: AppSchedule.Startup, system: init })
   .registerSystem({ schedule: AppSchedule.Startup, system: spawnAlphabet })
   .registerSystem({ schedule: AppSchedule.Startup, system: spawnDigits })
   .registerSystem({ schedule: AppSchedule.Update, system: setupViewport })
   .registerSystem({ schedule: AppSchedule.Update, system: update })
   .registerDebugger(new FPSDebugger())
   .run()
-
-/**
- * @param {World} world
- */
-function init(world) {
-  const map = new KeytoEntityMap()
-
-  world.setResource(map)
-}
 
 /**
  * @param {World} world

--- a/examples/samples/input/mouse.js
+++ b/examples/samples/input/mouse.js
@@ -27,15 +27,7 @@ import { addDefaultCamera2D, HackPlugin, setupViewport, pxToNdc } from '../utils
 
 /** @type {Map<KeyCode,Entity>} */
 class KeytoEntityMap extends Map { }
-class MouseEntity {
-
-  /**
-   * @param {Entity} entity
-   */
-  constructor(entity) {
-    this.entity = entity
-  }
-}
+class MouseEntity {}
 
 const offsetX = -0.9
 const offsetY = 0.8
@@ -45,6 +37,7 @@ const paddingWidth = 0.05
 const app = new App()
 
 app
+  .setResource(new KeytoEntityMap())
   .registerPlugin(new HackPlugin())
   .registerPlugin(new DefaultPlugin())
   .registerPlugin(new DOMWindowPlugin())
@@ -74,10 +67,10 @@ function spawnMouseFollower(world) {
       new Meshed(mesh),
       new BasicMaterial2D(materials.add(new BasicMaterial({
         color: Color.WHITE.clone()
-      })))])
+      }))),
+      new MouseEntity()
+    ])
     .build()
-
-  world.setResource(new MouseEntity(entity))
 }
 
 /**
@@ -86,7 +79,7 @@ function spawnMouseFollower(world) {
 function spawnButtons(world) {
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
-  const map = new KeytoEntityMap()
+  const map = world.getResource(KeytoEntityMap)
   const commands = new EntityCommands(world)
   const mesh = meshes.add(Mesh.quad2D(itemWidth, itemHeight))
   const digits = [
@@ -115,18 +108,15 @@ function spawnButtons(world) {
 
     map.set(digit, entity)
   }
-
-  world.setResource(map)
 }
 
 /**
  * @param {World} world
  */
 function updateFollower(world) {
-  const { entity } = world.getResource(MouseEntity)
   const mouse = world.getResource(Mouse)
-  const query = new Query(world, [Position2D])
-  const components = query.get(entity)
+  const query = new Query(world, [Position2D, MouseEntity])
+  const components = query.single()
 
   if (!components) return
 

--- a/examples/samples/input/mouse.js
+++ b/examples/samples/input/mouse.js
@@ -60,7 +60,7 @@ function spawnMouseFollower(world) {
   const mesh = meshes.add(Mesh.quad2D(0.1, 0.1))
   const commands = new EntityCommands(world)
 
-  const entity = commands
+  commands
     .spawn()
     .insertPrefab([
       ...createTransform2D(),

--- a/examples/samples/input/touch.js
+++ b/examples/samples/input/touch.js
@@ -29,6 +29,7 @@ class TouchtoEntityMap extends Map { }
 const app = new App()
 
 app
+  .setResource(new TouchtoEntityMap())
   .registerPlugin(new HackPlugin())
   .registerPlugin(new DefaultPlugin())
   .registerPlugin(new DOMWindowPlugin())
@@ -46,7 +47,7 @@ app
 function init(world) {
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
-  const map = new TouchtoEntityMap()
+  const map = world.getResource(TouchtoEntityMap)
   const commands = new EntityCommands(world)
 
   if (!window) return warn('No window set up')
@@ -67,8 +68,6 @@ function init(world) {
     map.set(i, entity)
 
   }
-
-  world.setResource(map)
 }
 
 /**


### PR DESCRIPTION
## Objective

Update example applications to align with the new scheduling behavior and resource-driven APIs. This primarily demonstrates that systems can now be registered directly on the `App` without requiring workaround plugins for ordering, while also improving example consistency by using ECS resources/components more idiomatically.

## Solution

Previously, several examples relied on temporary plugins to register startup systems because directly registered app systems executed before plugin-registered systems. This was necessary to avoid ordering conflicts with internal engine systems. With scheduling behavior improved, these workarounds are no longer required.

Several examples previously initialized resources inside startup systems. These are now initialized directly during app construction. This simplifies startup flow and better reflects intended ECS resource usage.

Duplicated viewport setup logic was removed from examples and consolidated into the shared utilities module.

### Why this approach

These changes better demonstrate the intended engine architecture:

* systems should register directly without plugin ordering hacks
* resources should be initialized explicitly during app setup
* entity relationships should use ECS queries/components rather than singleton resources

The examples now reflect cleaner ECS usage patterns and serve as more accurate reference implementations.

## Showcase

N/A

## Migration guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
