### PR TITLE
Fix transform systems ordering

### DIFF
--- a/src/transform/plugins/transform.js
+++ b/src/transform/plugins/transform.js
@@ -12,6 +12,7 @@ import { App, Plugin } from '../../app/index.js'
 import { propagateTransform2D, propagateTransform3D, registerTransform2DTypes, registerTransform3DTypes, synctransform2D, synctransform3D } from '../systems/index.js'
 import { AppSchedule } from '../../core/index.js'
 
+export class TransformSystems { }
 export class Transform2DPlugin extends Plugin {
 
   /**
@@ -19,13 +20,29 @@ export class Transform2DPlugin extends Plugin {
    */
   register(app) {
     app
+
+      // TODO: Also register this in the 3d variant
+      .registerSystemGroup({
+        label: TransformSystems,
+        schedule: AppSchedule.Update
+      })
       .registerType(Position2D)
       .registerType(Orientation2D)
       .registerType(Scale2D)
       .registerType(GlobalTransform2D)
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerTransform2DTypes })
-      .registerSystem({ schedule: AppSchedule.Update, system: synctransform2D })
-      .registerSystem({ schedule: AppSchedule.Update, system: propagateTransform2D })
+      .registerSystem({
+        schedule: AppSchedule.Startup,
+        system: registerTransform2DTypes
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        system: synctransform2D
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        system: propagateTransform2D,
+        after: [synctransform2D]
+      })
   }
 }
 
@@ -40,8 +57,20 @@ export class Transform3DPlugin extends Plugin {
       .registerType(Orientation3D)
       .registerType(Scale3D)
       .registerType(GlobalTransform3D)
-      .registerSystem({ schedule: AppSchedule.Startup, system: registerTransform3DTypes })
-      .registerSystem({ schedule: AppSchedule.Update, system: synctransform3D })
-      .registerSystem({ schedule: AppSchedule.Update, system: propagateTransform3D })
+      .registerSystem({
+        schedule: AppSchedule.Startup,
+        system: registerTransform3DTypes
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        systemGroup: TransformSystems,
+        system: synctransform3D
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        systemGroup: TransformSystems,
+        system: propagateTransform3D,
+        after: [synctransform3D]
+      })
   }
 }


### PR DESCRIPTION
## Objective

Introduce a dedicated transform system group and explicit transform ordering to guarantee deterministic transform propagation behavior across the engine. This also prepares the scheduling pipeline for future ordering integrations with rendering, physics, animation and runtime schedule inspection tooling.

## Solution

Previously, transform synchronization and propagation systems relied primarily on implicit registration order. This made execution ordering dependent on registration sequence and plugin initialization order, which becomes fragile as more engine systems integrate with transforms.

### Changes made

#### Introduced `TransformSystems` system group

This group acts as a stable scheduling anchor for transform-related systems. The group is registered on the update schedule.

#### Added explicit transform ordering

Transform propagation systems now explicitly depend on transform synchronization systems. This guarantees propagation always executes after local transforms are synchronized.

### Why this approach

Using a dedicated transform system group provides:

- a stable ordering target for external systems
- clearer execution semantics
- easier runtime inspection/debugging
- safer future schedule manipulation

Explicit ordering constraints are preferred over implicit registration order because they:

- document dependencies directly
- prevent accidental ordering regressions
- scale better as engine subsystems grow

This also aligns transform scheduling with the newer schedule graph architecture.

## Showcase

N/A

## Migration guide

No migration required.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
