### PR TITLE
Expose type registry to exporters and parsers

### DIFF
--- a/src/asset/core/exporter.js
+++ b/src/asset/core/exporter.js
@@ -1,3 +1,4 @@
+/** @import { TypeRegistry } from '../../reflect/resources/index.js' */
 /** @import { Constructor } from '../../type/index.js' */
 import { throws } from '../../logger/index.js'
 
@@ -22,9 +23,10 @@ export class Exporter {
 
   /**
    * @param {T} _asset
+   * @param {TypeRegistry} _typeRegistry
    * @returns {Promise<BodyInit | undefined>}
    */
-  async serialize(_asset) {
+  async serialize(_asset, _typeRegistry) {
     throws(`Implement the method \`serialize\` on \`${this.constructor.name}\``)
 
     return undefined

--- a/src/asset/core/parser.js
+++ b/src/asset/core/parser.js
@@ -1,3 +1,4 @@
+/** @import { TypeRegistry } from '../../reflect/resources/index.js' */
 /** @import { Constructor } from '../../type/index.js' */
 import { throws } from '../../logger/index.js'
 
@@ -22,9 +23,10 @@ export class Parser {
 
   /**
    * @param {Response} _response
+   * @param {TypeRegistry} _typeRegistry
    * @returns {Promise<T | undefined>}
    */
-  async parse(_response) {
+  async parse(_response, _typeRegistry) {
     throws(`Implement the method \`parse\` on \`${this.constructor.name}\``)
 
     return undefined

--- a/src/asset/plugins/assetServer.js
+++ b/src/asset/plugins/assetServer.js
@@ -2,7 +2,7 @@ import { App, Plugin } from '../../app/index.js'
 import { EventPlugin } from '../../event/index.js'
 import { AssetServer } from '../resources/index.js'
 import { AssetLoadFail, AssetLoadSuccess, AssetSaveSuccess } from '../events/index.js'
-import { updateAssets, updateAssetLoadEvents, updateAssetSaveEvents, logFailedLoads, registerAssetServerTypes } from '../systems/index.js'
+import { updateAssets, logFailedLoads, registerAssetServerTypes } from '../systems/index.js'
 import { AppSchedule, CoreSystems } from '../../core/index.js'
 
 export class AssetServerPlugin extends Plugin {
@@ -22,10 +22,16 @@ export class AssetServerPlugin extends Plugin {
       .registerPlugin(new EventPlugin({
         event: AssetLoadFail
       }))
-      .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerAssetServerTypes })
-      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: updateAssets })
-      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: updateAssetLoadEvents })
-      .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: updateAssetSaveEvents })
+      .registerSystem({
+        schedule: AppSchedule.Startup,
+        systemGroup: CoreSystems.Start,
+        system: registerAssetServerTypes
+      })
+      .registerSystem({
+        schedule: AppSchedule.Update,
+        systemGroup: CoreSystems.PostMain,
+        system: updateAssets
+      })
       .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: logFailedLoads })
   }
 }

--- a/src/asset/resources/assetserver.js
+++ b/src/asset/resources/assetserver.js
@@ -4,7 +4,7 @@ import { typeid } from '../../type/index.js'
 import { assert, warn } from '../../logger/index.js'
 import { getFileExtension, swapRemove } from '../../utils/index.js'
 import { Assets, Handle, Parser, Exporter } from '../core/index.js'
-import { AssetLoadSuccess, AssetSaveSuccess, AssetLoadFail, AssetLoadOperation } from '../events/index.js'
+import { AssetLoadOperation } from '../events/index.js'
 
 /**
  * @typedef {number} ParserId
@@ -149,6 +149,7 @@ export class Exporters {
     return /** @type {Exporter<T>} */(exporter)
   }
 }
+
 export class AssetServer {
 
   /**
@@ -188,26 +189,15 @@ export class AssetServer {
 
   /**
    * @private
-   * @type {UntypedAsset[]}
+   * @type {AssetLoadRequest[]}
    */
-  loadedAssets = []
+  loadRequests = []
 
   /**
    * @private
-   * @type {AssetLoadSuccess[]}
+   * @type {AssetSaveRequest[]}
    */
-  loaded = []
-
-  /**
-   * @private
-   * @type {AssetSaveSuccess[]}
-   */
-  saved = []
-
-  /**
-   * @type {AssetLoadFail[]}
-   */
-  failed = []
+  saveRequests = []
 
   /**
    * @template T
@@ -265,7 +255,7 @@ export class AssetServer {
     const newAssetInfo = new AssetInfo(completePath, assetId)
 
     this.assetInfos.add(newAssetInfo)
-    this.fetch(assetId, typeId, completePath, newAssetInfo)
+    this.loadRequests.push(new AssetLoadRequest(typeId, assetId, completePath, newAssetInfo))
 
     return handle
   }
@@ -282,138 +272,40 @@ export class AssetServer {
     const targetPath = path ?? info?.path
 
     if (!targetPath) {
-      this.recordFailure(
+      this.saveRequests.push(new AssetSaveRequest(
         typeId,
         assetId,
         path || '<unknown>',
-        'The given asset handle does not have a registered asset path.',
-        AssetLoadOperation.Saving
-      )
-
+        'The given asset handle does not have a registered asset path.'
+      ))
       return
     }
 
-    return this.post(assetId, typeId, targetPath)
+    this.saveRequests.push(new AssetSaveRequest(typeId, assetId, targetPath))
   }
 
   /**
-   * @param {AssetId} assetId
+   * @template T
    * @param {TypeId} typeId
    * @param {string} path
-   * @param {AssetInfo} info
+   * @returns {Parser<T>}
    */
-  async fetch(assetId, typeId, path, info) {
-    try {
-      const asset = await this.internalFetch(assetId, typeId, path)
-
-      this.loaded.push(new AssetLoadSuccess(typeId, assetId, path))
-      this.loadedAssets.push(asset)
-      info.loadstate = LoadState.Loaded
-    } catch(error) {
-      this.recordFailure(typeId, assetId, path, error)
-      info.loadstate = LoadState.Failed
-    }
-  }
-
-  /**
-   * @private
-   * @param {AssetId} assetId
-   * @param {TypeId} typeId
-   * @param {string} path
-   */
-  async post(assetId, typeId, path) {
-    try {
-      const response = await fetch(path, {
-        method: 'POST',
-        body: await this.serialize(assetId, typeId, path)
-      })
-
-      if (!response.ok) {
-        this.recordFailure(typeId, assetId, path, response.statusText, AssetLoadOperation.Saving)
-      } else {
-        this.saved.push(new AssetSaveSuccess(typeId, assetId, path))
-      }
-    } catch(error) {
-      let message = 'Could not export the asset.'
-
-      if (typeof error === 'string') {
-        message = error
-      } else if (error instanceof Error) {
-        const { message: errorMessage } = error
-
-        message = errorMessage
-      }
-
-      this.recordFailure(typeId, assetId, path, message, AssetLoadOperation.Saving)
-    }
-  }
-
-  /**
-   * @private
-   * @param {AssetId} assetId
-   * @param {TypeId} typeId
-   * @param {string} path
-   * @returns {Promise<BodyInit | undefined>}
-   */
-  async serialize(assetId, typeId, path) {
+  getParser(typeId, path) {
     const extension = getFileExtension(path)
-    const assets = this.assets.get(typeId)
-    const exporter = this.exporters.get(typeId, extension)
 
-    assert(assets, `No assets registered for the asset type \`${typeId}\` on \`AssetServer\``)
-
-    const asset = assets.getByAssetId(assetId)
-
-    if (asset === undefined) {
-      throw 'Could not find the asset to export.'
-    }
-
-    return exporter.serialize(asset)
+    return this.parsers.get(typeId, extension)
   }
 
   /**
-   * @private
-   * @param {TypeId} typeId
-   * @param {AssetId} assetId
-   * @param {string} path
-   * @param {string} message
-   * @param {number} [operation=AssetLoadOperation.Loading]
-   */
-  recordFailure(typeId, assetId, path, message, operation = AssetLoadOperation.Loading) {
-    this.failed.push(new AssetLoadFail(
-      typeId,
-      assetId,
-      path,
-      message,
-      operation
-    ))
-  }
-
-  /**
-   * @private
-   * @param {AssetId} assetId
+   * @template T
    * @param {TypeId} typeId
    * @param {string} path
-   * @throws {string | Error}
-   * @returns {Promise<UntypedAsset>}
+   * @returns {Exporter<T>}
    */
-  async internalFetch(assetId, typeId, path) {
+  getExporter(typeId, path) {
     const extension = getFileExtension(path)
-    const parser = this.parsers.get(typeId, extension)
 
-    const response = await fetch(path)
-
-    if (!response.ok) {
-      throw response.statusText
-    }
-
-    const result = await parser.parse(response)
-
-    if (!result) {
-      throw 'Could not parse the asset.'
-    }
-
-    return new UntypedAsset(typeId, assetId, result)
+    return this.exporters.get(typeId, extension)
   }
 
   /**
@@ -454,79 +346,33 @@ export class AssetServer {
   }
 
   /**
-   * @returns {readonly AssetLoadSuccess[]}
+   * @returns {readonly AssetLoadRequest[]}
    */
-  flushLoadSuccess() {
-    const buffer = this.loaded
+  flushLoadRequests() {
+    const buffer = this.loadRequests
 
-    this.loaded = []
+    this.loadRequests = []
 
     return buffer
   }
 
   /**
-   * @returns {readonly AssetSaveSuccess[]}
+   * @returns {readonly AssetSaveRequest[]}
    */
-  flushSaveSuccess() {
-    const buffer = this.saved
+  flushSaveRequests() {
+    const buffer = this.saveRequests
 
-    this.saved = []
+    this.saveRequests = []
 
     return buffer
   }
 
   /**
-   * @returns {readonly AssetLoadFail[]}
+   * @param {AssetInfo} info
+   * @param {number} state
    */
-  flushLoadFail() {
-    const buffer = this.failed
-
-    this.failed = []
-
-    return buffer
-  }
-
-  /**
-   * @returns {readonly UntypedAsset[]}
-   */
-  flushLoadedAssets() {
-    const buffer = this.loadedAssets
-
-    this.loadedAssets = []
-
-    return buffer
-  }
-}
-
-class UntypedAsset {
-
-  /**
-   * @readonly
-   * @type {TypeId}
-   */
-  typeId
-
-  /**
-   * @readonly
-   * @type {AssetId}
-   */
-  assetId
-
-  /**
-   * @readonly
-   * @type {unknown}
-   */
-  asset
-
-  /**
-   * @param {TypeId} typeId
-   * @param {AssetId} assetId
-   * @param {unknown} asset
-   */
-  constructor(typeId, assetId, asset) {
-    this.typeId = typeId
-    this.asset = asset
-    this.assetId = assetId
+  setLoadState(info, state) {
+    info.loadstate = state
   }
 }
 
@@ -555,6 +401,86 @@ class AssetInfo {
   constructor(path, assetId) {
     this.path = path
     this.id = assetId
+  }
+}
+
+class AssetLoadRequest {
+
+  /**
+   * @readonly
+   * @type {TypeId}
+   */
+  typeId
+
+  /**
+   * @readonly
+   * @type {AssetId}
+   */
+  assetId
+
+  /**
+   * @readonly
+   * @type {string}
+   */
+  path
+
+  /**
+   * @readonly
+   * @type {AssetInfo}
+   */
+  info
+
+  /**
+   * @param {TypeId} typeId
+   * @param {AssetId} assetId
+   * @param {string} path
+   * @param {AssetInfo} info
+   */
+  constructor(typeId, assetId, path, info) {
+    this.typeId = typeId
+    this.assetId = assetId
+    this.path = path
+    this.info = info
+  }
+}
+
+class AssetSaveRequest {
+
+  /**
+   * @readonly
+   * @type {TypeId}
+   */
+  typeId
+
+  /**
+   * @readonly
+   * @type {AssetId}
+   */
+  assetId
+
+  /**
+   * @readonly
+   * @type {string}
+   */
+  path
+
+  /**
+   * @readonly
+   * @type {string | undefined}
+   */
+  reason
+
+  /**
+   * @param {TypeId} typeId
+   * @param {AssetId} assetId
+   * @param {string} path
+   * @param {string} [reason]
+   */
+  constructor(typeId, assetId, path, reason) {
+    this.typeId = typeId
+    this.assetId = assetId
+    this.path = path
+    this.reason = reason
   }
 }
 

--- a/src/asset/resources/assetserver.js
+++ b/src/asset/resources/assetserver.js
@@ -4,7 +4,6 @@ import { typeid } from '../../type/index.js'
 import { assert, warn } from '../../logger/index.js'
 import { getFileExtension, swapRemove } from '../../utils/index.js'
 import { Assets, Handle, Parser, Exporter } from '../core/index.js'
-import { AssetLoadOperation } from '../events/index.js'
 
 /**
  * @typedef {number} ParserId
@@ -278,6 +277,7 @@ export class AssetServer {
         path || '<unknown>',
         'The given asset handle does not have a registered asset path.'
       ))
+
       return
     }
 

--- a/src/asset/systems/events.js
+++ b/src/asset/systems/events.js
@@ -4,9 +4,8 @@
 import { Assets } from '../core/index.js'
 import { Events } from '../../event/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
-import { AssetServer } from '../resources/index.js'
-import { AssetAdded, AssetDropped, AssetModified, AssetLoadSuccess, AssetSaveSuccess, AssetLoadFail } from '../events/index.js'
-import { warnOnce } from '../../logger/index.js'
+import { AssetAdded, AssetDropped, AssetModified, AssetLoadFail, AssetLoadOperation } from '../events/index.js'
+import { error, warnOnce } from '../../logger/index.js'
 
 /**
  * @template T
@@ -55,44 +54,18 @@ export function updateAssetEvents(assetType, eventType) {
 }
 
 /**
- * @template T
  * @param {World} world
  * @returns {void}
  */
-export function updateAssetLoadEvents(world) {
-  const server = world.getResource(AssetServer)
-
-  /** @type {Events<AssetLoadSuccess>} */
-  const sucessEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadSuccess]))
+export function logFailedLoads(world) {
 
   /** @type {Events<AssetLoadFail>} */
-  const failEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadFail]))
+  const events = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadFail]))
 
-  const succeeded = server.flushLoadSuccess()
-  const failed = server.flushLoadFail()
+  events.each((event) => {
+    const { data } = event
+    const operation = data.operation === AssetLoadOperation.Saving ? 'saving' : 'loading'
 
-  for (let i = 0; i < succeeded.length; i++) {
-    sucessEvents.write(succeeded[i])
-  }
-
-  for (let i = 0; i < failed.length; i++) {
-    failEvents.write(failed[i])
-  }
-}
-
-/**
- * @param {World} world
- * @returns {void}
- */
-export function updateAssetSaveEvents(world) {
-  const server = world.getResource(AssetServer)
-
-  /** @type {Events<AssetSaveSuccess>} */
-  const saveEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetSaveSuccess]))
-
-  const saved = server.flushSaveSuccess()
-
-  for (let i = 0; i < saved.length; i++) {
-    saveEvents.write(saved[i])
-  }
+    error(`\`AssetServer\` error ${operation} "${data.path}": ${data.reason}`)
+  })
 }

--- a/src/asset/systems/server.js
+++ b/src/asset/systems/server.js
@@ -4,9 +4,9 @@
 import { Events } from '../../event/index.js'
 import { typeidGeneric } from '../../type/index.js'
 import { Assets } from '../core/index.js'
-import { AssetServer } from '../resources/index.js'
-import { AssetLoadFail, AssetLoadOperation } from '../events/index.js'
-import { error } from '../../logger/index.js'
+import { AssetServer, LoadState } from '../resources/index.js'
+import { AssetLoadFail, AssetLoadOperation, AssetLoadSuccess, AssetSaveSuccess } from '../events/index.js'
+import { assert } from '../../logger/index.js'
 
 /**
  * @template T
@@ -53,34 +53,98 @@ export function registerAssetExporterOnAssetServer(type, exporter) {
 /**
  * @param {World} world
  */
-export function updateAssets(world) {
+export async function updateAssets(world) {
   const server = world.getResource(AssetServer)
-  const loaded = server.flushLoadedAssets()
-
-  for (let i = 0; i < loaded.length; i++) {
-    const { asset, typeId, assetId } = loaded[i]
-    const assets = server.getAssets(typeId)
-
-    if (!assets) continue
-
-    assets.setUsingAssetId(assetId, asset)
-  }
-}
-
-/**
- * @param {World} world
- */
-export function logFailedLoads(world) {
-
+  /** @type {Events<AssetLoadSuccess>} */
+  const loadSuccessEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadSuccess]))
+  /** @type {Events<AssetSaveSuccess>} */
+  const saveSuccessEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetSaveSuccess]))
   /** @type {Events<AssetLoadFail>} */
-  const events = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadFail]))
+  const loadFailEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadFail]))
 
-  events.each((event) => {
-    const { data } = event
-    const operation = data.operation === AssetLoadOperation.Saving ? 'saving' : 'loading'
+  const loadRequests = server.flushLoadRequests()
+  const saveRequests = server.flushSaveRequests()
 
-    error(`\`AssetServer\` error ${operation} "${data.path}": ${data.reason}`)
-  })
+  for (let i = 0; i < loadRequests.length; i++) {
+    const { assetId, info, path, typeId } = loadRequests[i]
+
+    try {
+      const parser = server.getParser(typeId, path)
+      const response = await fetch(path)
+
+      if (!response.ok) {
+        throw response.statusText
+      }
+
+      const asset = await parser.parse(response)
+
+      if (!asset) {
+        throw 'Could not parse the asset.'
+      }
+
+      const assets = server.getAssets(typeId)
+
+      assert(assets, `No assets registered for the asset type \`${typeId}\` on \`AssetServer\``)
+
+      assets.setUsingAssetId(assetId, asset)
+      server.setLoadState(info, LoadState.Loaded)
+      loadSuccessEvents.write(new AssetLoadSuccess(typeId, assetId, path))
+    } catch(error) {
+      server.setLoadState(info, LoadState.Failed)
+      let message = 'Could not load the asset.'
+
+      if (typeof error === 'string') {
+        message = error
+      } else if (error instanceof Error) {
+        message = error.message
+      }
+
+      loadFailEvents.write(new AssetLoadFail(typeId, assetId, path, message))
+    }
+  }
+
+  for (let i = 0; i < saveRequests.length; i++) {
+    const { assetId, path, reason, typeId } = saveRequests[i]
+
+    if (reason) {
+      loadFailEvents.write(new AssetLoadFail(typeId, assetId, path, reason, AssetLoadOperation.Saving))
+      continue
+    }
+
+    try {
+      const assets = server.getAssets(typeId)
+
+      assert(assets, `No assets registered for the asset type \`${typeId}\` on \`AssetServer\``)
+
+      const asset = assets.getByAssetId(assetId)
+
+      if (asset === undefined) {
+        throw 'Could not find the asset to export.'
+      }
+
+      const exporter = server.getExporter(typeId, path)
+      const response = await fetch(path, {
+        method: 'POST',
+        body: await exporter.serialize(asset)
+      })
+
+      if (!response.ok) {
+        throw response.statusText
+      }
+
+      saveSuccessEvents.write(new AssetSaveSuccess(typeId, assetId, path))
+    } catch(error) {
+      let message = 'Could not export the asset.'
+
+      if (typeof error === 'string') {
+        message = error
+      } else if (error instanceof Error) {
+        message = error.message
+      }
+
+      loadFailEvents.write(new AssetLoadFail(typeId, assetId, path, message, AssetLoadOperation.Saving))
+    }
+  }
 }
 
 /**

--- a/src/asset/systems/server.js
+++ b/src/asset/systems/server.js
@@ -3,6 +3,7 @@
 /** @import { AssetDropped, AssetEvent, Parser, Exporter } from '../index.js' */
 import { Events } from '../../event/index.js'
 import { typeidGeneric } from '../../type/index.js'
+import { TypeRegistry } from '../../reflect/resources/index.js'
 import { Assets } from '../core/index.js'
 import { AssetServer, LoadState } from '../resources/index.js'
 import { AssetLoadFail, AssetLoadOperation, AssetLoadSuccess, AssetSaveSuccess } from '../events/index.js'
@@ -61,6 +62,7 @@ export async function updateAssets(world) {
   const saveSuccessEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetSaveSuccess]))
   /** @type {Events<AssetLoadFail>} */
   const loadFailEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadFail]))
+  const typeRegistry = world.getResource(TypeRegistry)
 
   const loadRequests = server.flushLoadRequests()
   const saveRequests = server.flushSaveRequests()
@@ -76,7 +78,7 @@ export async function updateAssets(world) {
         throw response.statusText
       }
 
-      const asset = await parser.parse(response)
+      const asset = await parser.parse(response, typeRegistry)
 
       if (!asset) {
         throw 'Could not parse the asset.'
@@ -125,7 +127,7 @@ export async function updateAssets(world) {
       const exporter = server.getExporter(typeId, path)
       const response = await fetch(path, {
         method: 'POST',
-        body: await exporter.serialize(asset)
+        body: await exporter.serialize(asset, typeRegistry)
       })
 
       if (!response.ok) {

--- a/src/asset/systems/server.js
+++ b/src/asset/systems/server.js
@@ -56,10 +56,13 @@ export function registerAssetExporterOnAssetServer(type, exporter) {
  */
 export async function updateAssets(world) {
   const server = world.getResource(AssetServer)
+
   /** @type {Events<AssetLoadSuccess>} */
   const loadSuccessEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadSuccess]))
+
   /** @type {Events<AssetSaveSuccess>} */
   const saveSuccessEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetSaveSuccess]))
+
   /** @type {Events<AssetLoadFail>} */
   const loadFailEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadFail]))
   const typeRegistry = world.getResource(TypeRegistry)
@@ -98,7 +101,9 @@ export async function updateAssets(world) {
       if (typeof error === 'string') {
         message = error
       } else if (error instanceof Error) {
-        message = error.message
+        const { message: errorMessage } = error
+
+        message = errorMessage
       }
 
       loadFailEvents.write(new AssetLoadFail(typeId, assetId, path, message))
@@ -141,7 +146,9 @@ export async function updateAssets(world) {
       if (typeof error === 'string') {
         message = error
       } else if (error instanceof Error) {
-        message = error.message
+        const { message: errorMessage } = error
+
+        message = errorMessage
       }
 
       loadFailEvents.write(new AssetLoadFail(typeId, assetId, path, message, AssetLoadOperation.Saving))

--- a/src/asset/tests/assetserver.test.js
+++ b/src/asset/tests/assetserver.test.js
@@ -1,7 +1,11 @@
 import { deepStrictEqual, notDeepStrictEqual } from "assert";
-import test, { describe,todo } from "node:test";
+import test, { describe } from "node:test";
 import { Assets, AssetServer, Exporter, Parser } from "../index.js";
-import { typeid } from "../../type/index.js";
+import { typeid, typeidGeneric } from "../../type/index.js";
+import { World } from "../../ecs/index.js";
+import { updateAssets } from "../systems/index.js";
+import { Events } from "../../event/index.js";
+import { AssetLoadSuccess, AssetSaveSuccess, AssetLoadFail } from "../events/index.js";
 
 class Text {
   inner = ''
@@ -83,16 +87,56 @@ describe('Testing `AssetServer`', () => {
   })
 
   test('Asset load state cycle.', () => {
-    todo()
+    const server = createServer()
+    const handle = server.load(Text,"/assets/text/sample.txt")
+
+    deepStrictEqual(server.flushLoadRequests().length, 1)
+    deepStrictEqual(handle.id(), server.getAssetInfo(handle).id)
   })
 
-  test('Asset save uses exporter.', async () => {
-    const server = createServer()
-    const assets = server.getAssets(typeid(Text))
-    const handle = assets.add(new Text('hello'))
+  test('Asset load system parses and stores the asset.', async () => {
+    const world = createWorld()
+    const server = world.getResource(AssetServer)
+    const assets = world.getResourceByTypeId(typeidGeneric(Assets, [Text]))
+    const loadSuccessEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetLoadSuccess]))
+    const handle = server.load(Text,"/assets/text/sample.txt")
 
     const originalFetch = globalThis.fetch
+    let path
+
+    globalThis.fetch = async (requestPath) => {
+      path = requestPath
+
+      return /**@type {Response}*/({
+        ok: true,
+        statusText: 'OK',
+        async text() {
+          return 'hello'
+        }
+      })
+    }
+
+    try {
+      await updateAssets(world)
+      loadSuccessEvents.clear()
+      deepStrictEqual(path, '/assets/text/sample.txt')
+      deepStrictEqual(assets.get(handle).inner, 'hello')
+      deepStrictEqual(loadSuccessEvents.count(), 1)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test('Asset save uses exporter through the asset system.', async () => {
+    const world = createWorld()
+    const server = world.getResource(AssetServer)
+    const assets = world.getResourceByTypeId(typeidGeneric(Assets, [Text]))
+    const saveSuccessEvents = world.getResourceByTypeId(typeidGeneric(Events, [AssetSaveSuccess]))
+    const handle = assets.add(new Text('hello'))
+
     let body
+
+    const originalFetch = globalThis.fetch
 
     globalThis.fetch = async (_path, init) => {
       body = init.body
@@ -104,8 +148,11 @@ describe('Testing `AssetServer`', () => {
     }
 
     try {
-      await server.save(handle, '/assets/text/sample.txt')
+      server.save(handle, '/assets/text/sample.txt')
+      await updateAssets(world)
+      saveSuccessEvents.clear()
       deepStrictEqual(body, JSON.stringify({ inner: 'hello' }))
+      deepStrictEqual(saveSuccessEvents.count(), 1)
     } finally {
       globalThis.fetch = originalFetch
     }
@@ -121,4 +168,21 @@ function createServer() {
   server.registerExporter(Text,new TextExporter())
 
   return server
+}
+
+function createWorld() {
+  const world = new World()
+  const assets = new Assets(Text)
+  const server = new AssetServer()
+
+  world.setResource(server)
+  world.setResourceByTypeId(typeidGeneric(Assets, [Text]), assets)
+  world.setResourceByTypeId(typeidGeneric(Events, [AssetLoadSuccess]), new Events())
+  world.setResourceByTypeId(typeidGeneric(Events, [AssetSaveSuccess]), new Events())
+  world.setResourceByTypeId(typeidGeneric(Events, [AssetLoadFail]), new Events())
+  server.registerAsset(assets)
+  server.registerParser(Text,new TextParser())
+  server.registerExporter(Text,new TextExporter())
+
+  return world
 }

--- a/src/asset/tests/assetserver.test.js
+++ b/src/asset/tests/assetserver.test.js
@@ -6,6 +6,7 @@ import { World } from "../../ecs/index.js";
 import { updateAssets } from "../systems/index.js";
 import { Events } from "../../event/index.js";
 import { AssetLoadSuccess, AssetSaveSuccess, AssetLoadFail } from "../events/index.js";
+import { TypeRegistry } from "../../reflect/resources/index.js";
 
 class Text {
   inner = ''
@@ -33,8 +34,9 @@ class TextParser extends Parser {
 
   /**
    * @param {Response} response
+   * @param {import("../../reflect/resources/index.js").TypeRegistry} _typeRegistry
    */
-  async parse(response){
+  async parse(response, _typeRegistry){
     const text = await response.text()
     return new Text(text)
   }
@@ -57,8 +59,9 @@ class TextExporter extends Exporter {
 
   /**
    * @param {Text} asset
+   * @param {import("../../reflect/resources/index.js").TypeRegistry} _typeRegistry
    */
-  async serialize(asset){
+  async serialize(asset, _typeRegistry){
     return JSON.stringify(asset)
   }
 }
@@ -176,6 +179,7 @@ function createWorld() {
   const server = new AssetServer()
 
   world.setResource(server)
+  world.setResource(new TypeRegistry())
   world.setResourceByTypeId(typeidGeneric(Assets, [Text]), assets)
   world.setResourceByTypeId(typeidGeneric(Events, [AssetLoadSuccess]), new Events())
   world.setResourceByTypeId(typeidGeneric(Events, [AssetSaveSuccess]), new Events())

--- a/src/audio/resources/parser.js
+++ b/src/audio/resources/parser.js
@@ -1,3 +1,4 @@
+/** @import { TypeRegistry } from '../../reflect/resources/index.js' */
 import { Parser } from '../../asset/index.js'
 import { Audio } from '../assets/index.js'
 
@@ -25,8 +26,9 @@ export class AudioParser extends Parser {
 
   /**
    * @param {Response} response
+   * @param {TypeRegistry} _typeRegistry
    */
-  async parse(response) {
+  async parse(response, _typeRegistry) {
     const raw = await response.arrayBuffer()
     const audiobuffer = await this.decoder.decodeAudioData(raw)
 

--- a/src/render-core/resources/image.js
+++ b/src/render-core/resources/image.js
@@ -1,3 +1,4 @@
+/** @import { TypeRegistry } from '../../reflect/resources/index.js' */
 import { Parser } from '../../asset/core/parser.js'
 import { Image } from '../assets/index.js'
 import { Vector2 } from '../../math/index.js'
@@ -19,8 +20,9 @@ export class ImageParser extends Parser {
 
   /**
    * @param {Response} response
+   * @param {TypeRegistry} _typeRegistry
    */
-  async parse(response) {
+  async parse(response, _typeRegistry) {
     const raw = await response.arrayBuffer()
     const dimensions = await getDimensions(raw)
 


### PR DESCRIPTION
## Objective

Introduce `TypeRegistry` access to asset parsers and exporters, enabling serialization and deserialization logic to leverage runtime type information. As part of this work, asset loading and saving responsibilities were moved out of `AssetServer` and into the asset update system, making asset I/O execution part of the ECS pipeline rather than being performed directly by the resource. Secondary changes include simplifying `AssetServer` into a request-driven resource and consolidating asset event handling.

## Solution

### Type-aware parsing and exporting

`Parser.parse()` and `Exporter.serialize()` now receive a `TypeRegistry` instance allowing custom asset formats to:

* Resolve reflected types during parsing
* Serialize type information consistently
* Access runtime registration data without relying on global state

The `TypeRegistry` is retrieved from the ECS world during asset processing and passed to parsers/exporters automatically.

### AssetServer refactor

Previously, `AssetServer`:

* Performed fetch requests directly
* Performed export requests directly
* Managed success/failure buffers
* Managed loaded asset buffers

This tightly coupled request scheduling with execution.

The implementation now follows a request-based model:

* `AssetServer.load()` queues an `AssetLoadRequest`
* `AssetServer.save()` queues an `AssetSaveRequest`
* `updateAssets()` performs all loading/saving work
* ECS events are emitted directly from the asset system

Benefits:

* Centralized asset execution logic
* Easier integration with scheduling systems
* Cleaner separation between asset state and asset processing
* Future support for batching, async execution, or worker-based processing

## Showcase

### Before

Parser and exporter implementations had no access to reflected type information:

```js
class MyParser extends Parser {
  async parse(response) {
    return asset
  }
}

class MyExporter extends Exporter {
  async serialize(asset) {
    return body
  }
}
```

### After

Parsers and exporters now receive the active type registry:

```js
class MyParser extends Parser {
  async parse(response, typeRegistry) {
    return asset
  }
}

class MyExporter extends Exporter {
  async serialize(asset, typeRegistry) {
    return body
  }
}
```

## Migration guide

### Parser API

Replace:

```js
async parse(response) {
  ...
}
```

with:

```js
async parse(response, typeRegistry) {
  ...
}
```

### Exporter API

Replace:

```js
async serialize(asset) {
  ...
}
```

with:

```js
async serialize(asset, typeRegistry) {
  ...
}
```

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
