### PR TITLE
Rename parsers to importers

### DIFF
--- a/examples/samples/utils.js
+++ b/examples/samples/utils.js
@@ -7,7 +7,6 @@ import {
   createCamera2D,
   Plugin,
   typeidGeneric,
-  Parser,
   Query,
   WindowCommands,
   Entity,
@@ -98,20 +97,6 @@ export function registerAssetOnAssetServer(type) {
     const assets = world.getResourceByTypeId(typeidGeneric(Assets, [type]))
 
     server.registerAsset(assets)
-  }
-}
-
-/**
- * @template T
- * @param {new (...args:any[])=> T} type
- * @param {Parser<T>} parser
- * @returns {(world:World)=>void}
- */
-export function registerAssetParserOnAssetServer(type, parser) {
-  return function registerAssetParsedOnAssetServer(world) {
-    const server = world.getResource(AssetServer)
-
-    server.registerParser(type, parser)
   }
 }
 

--- a/src/asset/core/importer.js
+++ b/src/asset/core/importer.js
@@ -6,7 +6,7 @@ import { throws } from '../../logger/index.js'
  * @abstract
  * @template T
  */
-export class Parser {
+export class Importer {
 
   /**
    * @readonly
@@ -26,8 +26,8 @@ export class Parser {
    * @param {TypeRegistry} _typeRegistry
    * @returns {Promise<T | undefined>}
    */
-  async parse(_response, _typeRegistry) {
-    throws(`Implement the method \`parse\` on \`${this.constructor.name}\``)
+  async deserialize(_response, _typeRegistry) {
+    throws(`Implement the method \`deserialize\` on \`${this.constructor.name}\``)
 
     return undefined
   }

--- a/src/asset/core/index.js
+++ b/src/asset/core/index.js
@@ -1,3 +1,3 @@
 export * from './asset.js'
 export * from './exporter.js'
-export * from './parser.js'
+export * from './importer.js'

--- a/src/asset/plugins/importer.js
+++ b/src/asset/plugins/importer.js
@@ -2,14 +2,14 @@
 import { App, Plugin } from '../../app/index.js'
 import { AppSchedule, CoreSystems } from '../../core/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
-import { Parser } from '../core/index.js'
-import { registerAssetParserOnAssetServer } from '../systems/index.js'
+import { Importer } from '../core/index.js'
+import { registerAssetImporterOnAssetServer } from '../systems/index.js'
 
 /**
  * @template T
  */
 
-export class AssetParserPlugin extends Plugin {
+export class AssetImporterPlugin extends Plugin {
 
   /**
    * @readonly
@@ -19,44 +19,44 @@ export class AssetParserPlugin extends Plugin {
 
   /**
    * @readonly
-   * @type {Parser<T>}
+   * @type {Importer<T>}
    */
-  parser
+  importer
 
   /**
-   * @param {AssetParserPluginOptions<T>} options
+   * @param {AssetImporterPluginOptions<T>} options
    */
   constructor(options) {
     super()
-    const { asset, parser } = options
+    const { asset, importer } = options
 
     this.asset = asset
-    this.parser = parser
+    this.importer = importer
   }
 
   /**
    * @param {App} app
    */
   register(app) {
-    const { asset, parser } = this
+    const { asset, importer } = this
 
     app
       .registerSystem({
-        label: `registerAssetParserOnAssetServer<${typeid(asset)}>`,
+        label: `registerAssetImporterOnAssetServer<${typeid(asset)}>`,
         schedule: AppSchedule.Startup,
         systemGroup: CoreSystems.Start,
-        system: registerAssetParserOnAssetServer(asset, parser)
+        system: registerAssetImporterOnAssetServer(asset, importer)
       })
   }
 
   name() {
-    return typeidGeneric(AssetParserPlugin, [this.asset])
+    return typeidGeneric(AssetImporterPlugin, [this.asset])
   }
 }
 
 /**
  * @template T
- * @typedef AssetParserPluginOptions
+ * @typedef AssetImporterPluginOptions
  * @property {Constructor<T>} asset
- * @property {Parser<T>} parser
+ * @property {Importer<T>} importer
  */

--- a/src/asset/plugins/index.js
+++ b/src/asset/plugins/index.js
@@ -1,4 +1,4 @@
 export * from './asset.js'
 export * from './assetServer.js'
 export * from './exporter.js'
-export * from './parser.js'
+export * from './importer.js'

--- a/src/asset/resources/assetserver.js
+++ b/src/asset/resources/assetserver.js
@@ -3,35 +3,35 @@
 import { typeid } from '../../type/index.js'
 import { assert, warn } from '../../logger/index.js'
 import { getFileExtension, swapRemove } from '../../utils/index.js'
-import { Assets, Handle, Parser, Exporter } from '../core/index.js'
+import { Assets, Handle, Importer, Exporter } from '../core/index.js'
 
 /**
- * @typedef {number} ParserId
+ * @typedef {number} ImporterId
  */
-export class Parsers {
+export class Importers {
 
   /**
    * @private
-   * @type {Parser<unknown>[]}
+   * @type {Importer<unknown>[]}
    */
-  parsers = []
+  importers = []
 
   /**
    * @private
-   * @type {Map<string, Map<TypeId,ParserId>>}
+   * @type {Map<string, Map<TypeId,ImporterId>>}
    */
   extensions = new Map()
 
   /**
    * @template T
-   * @param {Parser<T>} parser
+   * @param {Importer<T>} importer
    */
-  add(parser) {
-    const id = this.parsers.length
-    const typeId = typeid(parser.asset)
-    const extensions = parser.getExtensions()
+  add(importer) {
+    const id = this.importers.length
+    const typeId = typeid(importer.asset)
+    const extensions = importer.getExtensions()
 
-    this.parsers.push(parser)
+    this.importers.push(importer)
 
     for (let i = 0; i < extensions.length; i++) {
       const extension = extensions[i]
@@ -39,7 +39,7 @@ export class Parsers {
 
       if (extensionMap) {
         if (extensionMap.has(typeId)) {
-          warn(`Overriding a parser already present with asset type \`${typeId}\` and with extension "${extension}"".`)
+          warn(`Overriding an importer already present with asset type \`${typeId}\` and with extension "${extension}"".`)
         }
 
         extensionMap.set(typeId, id)
@@ -53,27 +53,27 @@ export class Parsers {
    * @template T
    * @param {TypeId} type
    * @param {string} extension
-   * @returns {Parser<T>}
+   * @returns {Importer<T>}
    * @throws {string}
    */
   get(type, extension) {
     const extensions = this.extensions.get(extension)
 
     if (!extensions) {
-      throw 'The given extension does not have a parser registered'
+      throw 'The given extension does not have an importer registered'
     }
 
-    const parserId = extensions.get(type)
+    const importerId = extensions.get(type)
 
-    if (parserId === undefined) {
+    if (importerId === undefined) {
       throw 'The given asset type does not support the given extension'
     }
 
-    const parser = this.parsers[parserId]
+    const importer = this.importers[importerId]
 
-    assert(parser, 'Internal error: The givk&en parser index is invalid.')
+    assert(importer, 'Internal error: The givk&en importer index is invalid.')
 
-    return /** @type {Parser<T>} */(parser)
+    return /** @type {Importer<T>} */(importer)
   }
 }
 
@@ -161,9 +161,9 @@ export class AssetServer {
   /**
    * @private
    * @readonly
-   * @type {Parsers}
+   * @type {Importers}
    */
-  parsers = new Parsers()
+  importers = new Importers()
 
   /**
    * @private
@@ -211,10 +211,10 @@ export class AssetServer {
   /**
    * @template T
    * @param {Constructor<T>} type
-   * @param {Parser<T>} parser
+   * @param {Importer<T>} importer
    */
-  registerParser(type, parser) {
-    this.parsers.add(parser)
+  registerImporter(type, importer) {
+    this.importers.add(importer)
   }
 
   /**
@@ -288,12 +288,12 @@ export class AssetServer {
    * @template T
    * @param {TypeId} typeId
    * @param {string} path
-   * @returns {Parser<T>}
+   * @returns {Importer<T>}
    */
-  getParser(typeId, path) {
+  getImporter(typeId, path) {
     const extension = getFileExtension(path)
 
-    return this.parsers.get(typeId, extension)
+    return this.importers.get(typeId, extension)
   }
 
   /**

--- a/src/asset/systems/server.js
+++ b/src/asset/systems/server.js
@@ -1,6 +1,6 @@
 /** @import { SystemFunc, World } from '../../ecs/index.js' */
 /** @import { Constructor } from '../../type/index.js' */
-/** @import { AssetDropped, AssetEvent, Parser, Exporter } from '../index.js' */
+/** @import { AssetDropped, AssetEvent, Importer, Exporter } from '../index.js' */
 import { Events } from '../../event/index.js'
 import { typeidGeneric } from '../../type/index.js'
 import { TypeRegistry } from '../../reflect/resources/index.js'
@@ -26,14 +26,14 @@ export function registerAssetOnAssetServer(type) {
 /**
  * @template T
  * @param {Constructor<T>} type
- * @param {Parser<T>} parser
+ * @param {Importer<T>} importer
  * @returns {SystemFunc}
  */
-export function registerAssetParserOnAssetServer(type, parser) {
-  return function registerAssetParsedOnAssetServer(world) {
+export function registerAssetImporterOnAssetServer(type, importer) {
+  return function registerAssetImporterOnAssetServer(world) {
     const server = world.getResource(AssetServer)
 
-    server.registerParser(type, parser)
+    server.registerImporter(type, importer)
   }
 }
 
@@ -74,17 +74,17 @@ export async function updateAssets(world) {
     const { assetId, info, path, typeId } = loadRequests[i]
 
     try {
-      const parser = server.getParser(typeId, path)
+      const importer = server.getImporter(typeId, path)
       const response = await fetch(path)
 
       if (!response.ok) {
         throw response.statusText
       }
 
-      const asset = await parser.parse(response, typeRegistry)
+      const asset = await importer.deserialize(response, typeRegistry)
 
       if (!asset) {
-        throw 'Could not parse the asset.'
+        throw 'Could not deserialize the asset.'
       }
 
       const assets = server.getAssets(typeId)

--- a/src/asset/tests/assetserver.test.js
+++ b/src/asset/tests/assetserver.test.js
@@ -1,6 +1,6 @@
 import { deepStrictEqual, notDeepStrictEqual } from "assert";
 import test, { describe } from "node:test";
-import { Assets, AssetServer, Exporter, Parser } from "../index.js";
+import { Assets, AssetServer, Exporter, Importer } from "../index.js";
 import { typeid, typeidGeneric } from "../../type/index.js";
 import { World } from "../../ecs/index.js";
 import { updateAssets } from "../systems/index.js";
@@ -19,9 +19,9 @@ class Text {
 }
 
 /**
- * @extends {Parser<Text>}
+ * @extends {Importer<Text>}
  */
-class TextParser extends Parser {
+class TextImporter extends Importer {
   constructor(){
     super(Text)
   }
@@ -36,7 +36,7 @@ class TextParser extends Parser {
    * @param {Response} response
    * @param {import("../../reflect/resources/index.js").TypeRegistry} _typeRegistry
    */
-  async parse(response, _typeRegistry){
+  async deserialize(response, _typeRegistry){
     const text = await response.text()
     return new Text(text)
   }
@@ -167,7 +167,7 @@ function createServer() {
   const server = new AssetServer()
 
   server.registerAsset(assets)
-  server.registerParser(Text,new TextParser())
+  server.registerImporter(Text,new TextImporter())
   server.registerExporter(Text,new TextExporter())
 
   return server
@@ -185,7 +185,7 @@ function createWorld() {
   world.setResourceByTypeId(typeidGeneric(Events, [AssetSaveSuccess]), new Events())
   world.setResourceByTypeId(typeidGeneric(Events, [AssetLoadFail]), new Events())
   server.registerAsset(assets)
-  server.registerParser(Text,new TextParser())
+  server.registerImporter(Text,new TextImporter())
   server.registerExporter(Text,new TextExporter())
 
   return world

--- a/src/audio/plugin.js
+++ b/src/audio/plugin.js
@@ -1,12 +1,12 @@
 import { App, Plugin } from '../app/index.js'
-import { AssetParserPlugin, AssetPlugin, Assets } from '../asset/index.js'
+import { AssetImporterPlugin, AssetPlugin, Assets } from '../asset/index.js'
 import { AppSchedule } from '../core/index.js'
 import { ComponentHooks } from '../ecs/index.js'
 import { typeidGeneric } from '../type/index.js'
 import { Audio } from './assets/index.js'
 import { AudioPlayer, AudioOscillator, removeAudioPlayerSink, removeOscillatorSink } from './components/index.js'
 import { AudioAdded, AudioDropped, AudioModified } from './events/index.js'
-import { AudioCommands, AudioParser, AudioAssets, AudioGraph } from './resources/index.js'
+import { AudioCommands, AudioImporter, AudioAssets, AudioGraph } from './resources/index.js'
 import { playAudio, playOscillators, registerAudioTypes } from './systems/index.js'
 
 export class AudioPlugin extends Plugin {
@@ -40,9 +40,9 @@ export class AudioPlugin extends Plugin {
           dropped: AudioDropped
         }
       }))
-      .registerPlugin(new AssetParserPlugin({
+      .registerPlugin(new AssetImporterPlugin({
         asset: Audio,
-        parser: new AudioParser()
+        importer: new AudioImporter()
       }))
       .registerSystem({ schedule: AppSchedule.Update, system: playAudio })
       .registerSystem({ schedule: AppSchedule.Update, system: playOscillators })

--- a/src/audio/resources/importer.js
+++ b/src/audio/resources/importer.js
@@ -1,11 +1,11 @@
 /** @import { TypeRegistry } from '../../reflect/resources/index.js' */
-import { Parser } from '../../asset/index.js'
+import { Importer } from '../../asset/index.js'
 import { Audio } from '../assets/index.js'
 
 /**
- * @augments {Parser<Audio>}
+ * @augments {Importer<Audio>}
  */
-export class AudioParser extends Parser {
+export class AudioImporter extends Importer {
 
   /**
    * @private
@@ -28,7 +28,7 @@ export class AudioParser extends Parser {
    * @param {Response} response
    * @param {TypeRegistry} _typeRegistry
    */
-  async parse(response, _typeRegistry) {
+  async deserialize(response, _typeRegistry) {
     const raw = await response.arrayBuffer()
     const audiobuffer = await this.decoder.decodeAudioData(raw)
 

--- a/src/audio/resources/index.js
+++ b/src/audio/resources/index.js
@@ -1,4 +1,4 @@
 export * from './command.js'
-export * from './parser.js'
+export * from './importer.js'
 export * from './aliases.js'
 export * from './audiograph.js'

--- a/src/render-core/plugin.js
+++ b/src/render-core/plugin.js
@@ -1,9 +1,9 @@
 import { App, Plugin } from '../app/index.js'
 import { AppSchedule, CoreSystems } from '../core/index.js'
-import { AssetParserPlugin, AssetPlugin, Assets } from '../asset/index.js'
+import { AssetImporterPlugin, AssetPlugin, Assets } from '../asset/index.js'
 import { BasicMaterial2D, BasicMaterial3D, Camera, Meshed } from './components/index.js'
 import { Mesh, Shader, Image, BasicMaterial } from './assets/index.js'
-import { BasicMaterialAssets, ImageAssets, ImageParser, MeshAssets } from './resources/index.js'
+import { BasicMaterialAssets, ImageAssets, ImageImporter, MeshAssets } from './resources/index.js'
 import { Material2DPlugin, Material3DPlugin } from './plugins/index.js'
 import {
   ImageAdded,
@@ -42,9 +42,9 @@ export class RenderCorePlugin extends Plugin {
           dropped: ImageDropped
         }
       }))
-      .registerPlugin(new AssetParserPlugin({
+      .registerPlugin(new AssetImporterPlugin({
         asset: Image,
-        parser: new ImageParser()
+        importer: new ImageImporter()
       }))
       .registerPlugin(new AssetPlugin({
         asset: Mesh,

--- a/src/render-core/resources/image.js
+++ b/src/render-core/resources/image.js
@@ -1,12 +1,12 @@
 /** @import { TypeRegistry } from '../../reflect/resources/index.js' */
-import { Parser } from '../../asset/core/parser.js'
+import { Importer } from '../../asset/index.js'
 import { Image } from '../assets/index.js'
 import { Vector2 } from '../../math/index.js'
 
 /**
- * @augments {Parser<Image>}
+ * @augments {Importer<Image>}
  */
-export class ImageParser extends Parser {
+export class ImageImporter extends Importer {
 
   constructor() {
     super(Image)
@@ -22,7 +22,7 @@ export class ImageParser extends Parser {
    * @param {Response} response
    * @param {TypeRegistry} _typeRegistry
    */
-  async parse(response, _typeRegistry) {
+  async deserialize(response, _typeRegistry) {
     const raw = await response.arrayBuffer()
     const dimensions = await getDimensions(raw)
 


### PR DESCRIPTION
## Objective

Rename the asset import pipeline from **Parser** to **Importer** to better reflect its responsibility and align terminology with the existing **Exporter** abstraction. The primary goal is to make asset serialization and deserialization concepts symmetrical:

- `Importer.deserialize()`
- `Exporter.serialize()`

Secondary changes include renaming plugins, registration systems, resources, and examples to use the new importer terminology consistently.

## Solution

The former `Parser` abstraction has been renamed to `Importer`.

## Showcase

### Before

```js
class ImageParser extends Parser {
  async parse(response, typeRegistry) {
    return image
  }
}

server.registerParser(Image, new ImageParser())
```

```js
app.registerPlugin(new AssetParserPlugin({
  asset: Image,
  parser: new ImageParser()
}))
```

### After

```js
class ImageImporter extends Importer {
  async deserialize(response, typeRegistry) {
    return image
  }
}

server.registerImporter(Image, new ImageImporter())
```

```js
app.registerPlugin(new AssetImporterPlugin({
  asset: Image,
  importer: new ImageImporter()
}))
```

## Migration guide

### Rename Parser to Importer

Replace:

```js
class MyParser extends Parser {}
```

with:

```js
class MyImporter extends Importer {}
```

### Rename parse()

Replace:

```js
async parse(response, typeRegistry)
```

with:

```js
async deserialize(response, typeRegistry)
```

### Rename `AssetServer` registration APIs

Replace:

```js
server.registerParser(Type, parser)
```

with:

```js
server.registerImporter(Type, importer)
```

Replace:

```js
server.getParser(typeId, path)
```

with:

```js
server.getImporter(typeId, path)
```

### Rename plugin usage

Replace:

```js
new AssetParserPlugin({
  asset: Type,
  parser: new MyParser()
})
```

with:

```js
new AssetImporterPlugin({
  asset: Type,
  importer: new MyImporter()
})
```

### Rename built-in engine importers

Replace:

```js
AudioParser
ImageParser
```

with:

```js
AudioImporter
ImageImporter
```

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
