### PR TITLE
Add message channels for handle reference counting

### DIFF
--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -1,11 +1,10 @@
 /** @import {AssetId} from '../types/index.js' */
 /** @import {Constructor} from '../../type/index.js'*/
-import { packInto64Int, unpackFrom64Int } from '../../algorithms/index.js'
+import { unpackFrom64Int } from '../../algorithms/index.js'
 import { DenseList } from '../../datastructures/index.js'
-import { typeid } from '../../type/index.js'
 import { AssetAdded, AssetDropped, AssetEvent, AssetModified } from '../events/assets.js'
-import { AssetServer } from '../resources/assetserver.js'
 import { AssetChannel, AssetChannelMessageType } from './channel.js'
+import { Handle } from './handle.js'
 
 /**
  * @template T
@@ -241,8 +240,9 @@ export class Assets {
     if (!entry) {
       return
     }
+
     entry.refCount += 1
-    
+
     return new Handle(this.channel, this.type, index, generation)
   }
 
@@ -321,155 +321,6 @@ export class Assets {
       this.assets.recycle(index)
       this.events.push(new AssetDropped(this.type, assetId))
     }
-  }
-}
-
-/**
- * @template T
- */
-export class Handle {
-
-  /**
-   * @readonly
-   * @type {Constructor<T>}
-   */
-  type
-
-  /**
-   * @private
-   * @type {boolean}
-   */
-  dropped = false
-
-  /**
-   * @private
-   * @readonly
-   * @type {AssetChannel<T>}
-   */
-  channel
-
-  /**
-   * @readonly
-   * @type {number}
-   */
-  index
-
-  /**
-   * @readonly
-   * @type {number}
-   */
-  generation = 0
-
-  /**
-   * @param {AssetChannel<T>} channel
-   * @param {Constructor<T>} type
-   * @param {number} index
-   * @param {number} generation
-   */
-  constructor(channel, type, index, generation) {
-    this.index = index
-    this.generation = generation
-    this.channel = channel
-    this.type = type
-  }
-
-  /**
-   * @returns {AssetId}
-   */
-  id() {
-    return /** @type {AssetId}*/ (packInto64Int(this.index, this.generation))
-  }
-
-  clone() {
-    const { channel, index, generation } = this
-
-    channel.acquire(this.id())
-
-    return new Handle(channel, this.type, index, generation)
-  }
-
-  /**
-   * Snapshot the handle with the asset server path when available.
-   *
-   * @param {import('../../ecs/index.js').World} world
-   * @returns {HandleSnapshot<T>}
-   */
-  toSnapshot(world) {
-    const server = world.getResource(AssetServer)
-    const info = server?.getAssetInfo(this)
-
-    if (info?.path) {
-      return new HandleSnapshot(this.type, info.path)
-    }
-
-    return new HandleSnapshot(this.type, this.id())
-  }
-
-  drop() {
-    if (this.dropped) return
-
-    this.channel.release(this.id())
-    this.dropped = true
-  }
-}
-
-/**
- * A snapshot of an asset handle.
- *
- * The snapshot preserves the asset type and id, and stores the asset server
- * path when one is registered so the handle can be reloaded by path.
- *
- * @template T
- */
-export class HandleSnapshot {
-
-  /**
-   * @readonly
-   * @type {Constructor<T>}
-   */
-  type
-
-  /**
-   * @readonly
-   * @type {AssetId | string}
-   */
-  asset
-
-  /**
-   * @param {Constructor<T>} type
-   * @param {AssetId | string} asset
-   */
-  constructor(type, asset) {
-    this.type = type
-    this.asset = asset
-  }
-
-  /**
-   * Restore the live handle from the asset server.
-   *
-   * If the asset server knows the path, we reload it by path. Otherwise we
-   * upgrade the stored asset id against the asset pool.
-   *
-   * @param {import('../../ecs/index.js').World} world
-   * @returns {Handle<T>}
-   */
-  fromSnapshot(world) {
-    const server = world.getResource(AssetServer)
-
-    if (typeof this.asset === 'string') {
-      return /** @type {Handle<T>} */ (server.load(this.type, this.asset))
-    }
-
-    const assets = /** @type {Assets<T>} */ (server.getAssets(typeid(this.type)))
-
-    // TODO: This is inherently incorrect. When scene resources are added,
-    // the assetid will point to the wrong asset in the scene due to desync between
-    // the scene and world when an assets are added/removed from the world or scene.
-    // Add a mapping between scene assets and world assets and use that to create
-    // the asset handle. Also ensure the assets are loaded into world before spawning
-    // the scene into the world.
-
-    return /** @type {Handle<T>} */ (assets.upgrade(this.asset))
   }
 }
 

--- a/src/asset/core/asset.js
+++ b/src/asset/core/asset.js
@@ -5,6 +5,7 @@ import { DenseList } from '../../datastructures/index.js'
 import { typeid } from '../../type/index.js'
 import { AssetAdded, AssetDropped, AssetEvent, AssetModified } from '../events/assets.js'
 import { AssetServer } from '../resources/assetserver.js'
+import { AssetChannel, AssetChannelMessageType } from './channel.js'
 
 /**
  * @template T
@@ -33,6 +34,12 @@ export class Assets {
    * @type {AssetEvent<T>[]}
    */
   events = []
+
+  /**
+   * @readonly
+   * @type {AssetChannel<T>}
+   */
+  channel = new AssetChannel()
 
   /**
    * @param {Constructor<T>} type
@@ -192,7 +199,6 @@ export class Assets {
    * @returns {Handle<T> | undefined}
    */
   getHandleByUUID(uuid) {
-
     return this.uuids.get(uuid)?.clone()
   }
 
@@ -213,6 +219,8 @@ export class Assets {
   drop(handle) {
     const entry = this.getEntry(handle)
 
+    if (!entry) return
+
     entry.refCount -= 1
 
     if (entry.refCount <= 0) {
@@ -224,11 +232,18 @@ export class Assets {
 
   /**
    * @param {AssetId} assetId
+   * @returns {Handle<T> | undefined}
    */
   upgrade(assetId) {
     const [index, generation] = unpackFrom64Int(assetId)
+    const entry = this.getEntryInternal(index, generation)
 
-    return new Handle(this, index, generation)
+    if (!entry) {
+      return
+    }
+    entry.refCount += 1
+    
+    return new Handle(this.channel, this.type, index, generation)
   }
 
   /**
@@ -241,20 +256,71 @@ export class Assets {
 
     if (entry) {
       entry.generation += 1
+      entry.refCount = 1
 
-      return new Handle(this, index, entry.generation)
+      return new Handle(this.channel, this.type, index, entry.generation)
     }
 
     const newEntry = new AssetEntry(undefined)
 
     newEntry.generation += 1
+    newEntry.refCount = 1
     this.assets.set(index, newEntry)
 
-    return new Handle(this, index, newEntry.generation)
+    return new Handle(this.channel, this.type, index, newEntry.generation)
   }
 
   values() {
     return this.assets.values()
+  }
+
+  /**
+   * Drain and apply queued handle lifecycle messages.
+   */
+  update() {
+    const messages = this.channel.flush()
+
+    for (let i = 0; i < messages.length; i++) {
+      const message = messages[i]
+
+      if (message.type === AssetChannelMessageType.Acquire) {
+        this.acquire(message.assetId)
+      } else if (message.type === AssetChannelMessageType.Release) {
+        this.release(message.assetId)
+      }
+    }
+  }
+
+  /**
+   * @private
+   * @param {AssetId} assetId
+   */
+  acquire(assetId) {
+    const entry = this.getEntryByAssetId(assetId)
+
+    if (!entry) return
+
+    entry.refCount += 1
+  }
+
+  /**
+   * @private
+   * @param {AssetId} assetId
+   */
+  release(assetId) {
+    const entry = this.getEntryByAssetId(assetId)
+
+    if (!entry) return
+
+    entry.refCount -= 1
+
+    if (entry.refCount <= 0) {
+      const [index] = unpackFrom64Int(assetId)
+
+      entry.asset = undefined
+      this.assets.recycle(index)
+      this.events.push(new AssetDropped(this.type, assetId))
+    }
   }
 }
 
@@ -276,13 +342,11 @@ export class Handle {
   dropped = false
 
   /**
-   * This only exists as a channel for reference counting, do not use for any
-   * other purpose!
    * @private
    * @readonly
-   * @type {Assets<T>}
+   * @type {AssetChannel<T>}
    */
-  assets
+  channel
 
   /**
    * @readonly
@@ -297,21 +361,16 @@ export class Handle {
   generation = 0
 
   /**
-   * @param {Assets<T>} assets
+   * @param {AssetChannel<T>} channel
+   * @param {Constructor<T>} type
    * @param {number} index
    * @param {number} generation
    */
-  constructor(assets, index, generation) {
+  constructor(channel, type, index, generation) {
     this.index = index
     this.generation = generation
-    this.assets = assets
-    this.type = assets.type
-
-    const entry = assets.getEntry(this)
-
-    if (entry && entry.generation === generation) {
-      entry.refCount += 1
-    }
+    this.channel = channel
+    this.type = type
   }
 
   /**
@@ -322,9 +381,11 @@ export class Handle {
   }
 
   clone() {
-    const { assets, index, generation } = this
+    const { channel, index, generation } = this
 
-    return new Handle(assets, index, generation)
+    channel.acquire(this.id())
+
+    return new Handle(channel, this.type, index, generation)
   }
 
   /**
@@ -347,7 +408,7 @@ export class Handle {
   drop() {
     if (this.dropped) return
 
-    this.assets.drop(this)
+    this.channel.release(this.id())
     this.dropped = true
   }
 }

--- a/src/asset/core/channel.js
+++ b/src/asset/core/channel.js
@@ -1,0 +1,80 @@
+/** @import { AssetId } from '../types/index.js' */
+
+/**
+ * @readonly
+ * @enum {number}
+ */
+export const AssetChannelMessageType = {
+  Acquire: 0,
+  Release: 1
+}
+
+/**
+ * @template T
+ */
+export class AssetChannel {
+
+  /**
+   * @private
+   * @type {AssetChannelMessage<T>[]}
+   */
+  queue = []
+
+  /**
+   * Queue a reference acquisition.
+   *
+   * @param {AssetId} assetId
+   */
+  acquire(assetId) {
+    this.queue.push(new AssetChannelMessage(AssetChannelMessageType.Acquire, assetId))
+  }
+
+  /**
+   * Queue a reference release.
+   *
+   * @param {AssetId} assetId
+   */
+  release(assetId) {
+    this.queue.push(new AssetChannelMessage(AssetChannelMessageType.Release, assetId))
+  }
+
+  /**
+   * Drain the queued messages.
+   *
+   * @returns {Readonly<AssetChannelMessage<T>[]>}
+   */
+  flush() {
+    const { queue } = this
+
+    if (queue.length) this.queue = []
+
+    return queue
+  }
+}
+
+/**
+ * @template T
+ */
+export class AssetChannelMessage {
+
+  /**
+   * @readonly
+   * @type {AssetChannelMessageType}
+   */
+  type
+
+  /**
+   * @readonly
+   * @type {AssetId}
+   */
+  assetId
+
+  /**
+   * @param {AssetChannelMessageType} type
+   * @param {AssetId} assetId
+   */
+  constructor(type, assetId) {
+    this.type = type
+    this.assetId = assetId
+  }
+}

--- a/src/asset/core/handle.js
+++ b/src/asset/core/handle.js
@@ -1,5 +1,5 @@
 /** @import {AssetId} from '../types/index.js' */
-/** @import {Assets} from './asset.js' */
+/** @import {Assets} from '../resources/assets.js' */
 /** @import {Constructor} from '../../type/index.js'*/
 
 import { packInto64Int } from '../../algorithms/index.js'

--- a/src/asset/core/handle.js
+++ b/src/asset/core/handle.js
@@ -1,0 +1,157 @@
+/** @import {AssetId} from '../types/index.js' */
+/** @import {Assets} from './asset.js' */
+/** @import {Constructor} from '../../type/index.js'*/
+
+import { packInto64Int } from '../../algorithms/index.js'
+import { typeid } from '../../type/index.js'
+import { AssetServer } from '../resources/assetserver.js'
+import { AssetChannel } from './channel.js'
+
+/**
+ * @template T
+ */
+export class Handle {
+
+  /**
+   * @readonly
+   * @type {Constructor<T>}
+   */
+  type
+
+  /**
+   * @private
+   * @type {boolean}
+   */
+  dropped = false
+
+  /**
+   * @private
+   * @readonly
+   * @type {AssetChannel<T>}
+   */
+  channel
+
+  /**
+   * @readonly
+   * @type {number}
+   */
+  index
+
+  /**
+   * @readonly
+   * @type {number}
+   */
+  generation = 0
+
+  /**
+   * @param {AssetChannel<T>} channel
+   * @param {Constructor<T>} type
+   * @param {number} index
+   * @param {number} generation
+   */
+  constructor(channel, type, index, generation) {
+    this.index = index
+    this.generation = generation
+    this.channel = channel
+    this.type = type
+  }
+
+  /**
+   * @returns {AssetId}
+   */
+  id() {
+    return /** @type {AssetId}*/ (packInto64Int(this.index, this.generation))
+  }
+
+  clone() {
+    const { channel, index, generation } = this
+
+    channel.acquire(this.id())
+
+    return new Handle(channel, this.type, index, generation)
+  }
+
+  /**
+   * Snapshot the handle with the asset server path when available.
+   *
+   * @param {import('../../ecs/index.js').World} world
+   * @returns {HandleSnapshot<T>}
+   */
+  toSnapshot(world) {
+    const server = world.getResource(AssetServer)
+    const info = server?.getAssetInfo(this)
+
+    if (info?.path) {
+      return new HandleSnapshot(this.type, info.path)
+    }
+
+    return new HandleSnapshot(this.type, this.id())
+  }
+
+  drop() {
+    if (this.dropped) return
+
+    this.channel.release(this.id())
+    this.dropped = true
+  }
+}
+
+/**
+ * A snapshot of an asset handle.
+ *
+ * The snapshot preserves the asset type and id, and stores the asset server
+ * path when one is registered so the handle can be reloaded by path.
+ *
+ * @template T
+ */
+export class HandleSnapshot {
+
+  /**
+   * @readonly
+   * @type {Constructor<T>}
+   */
+  type
+
+  /**
+   * @readonly
+   * @type {AssetId | string}
+   */
+  asset
+
+  /**
+   * @param {Constructor<T>} type
+   * @param {AssetId | string} asset
+   */
+  constructor(type, asset) {
+    this.type = type
+    this.asset = asset
+  }
+
+  /**
+   * Restore the live handle from the asset server.
+   *
+   * If the asset server knows the path, we reload it by path. Otherwise we
+   * upgrade the stored asset id against the asset pool.
+   *
+   * @param {import('../../ecs/index.js').World} world
+   * @returns {Handle<T>}
+   */
+  fromSnapshot(world) {
+    const server = world.getResource(AssetServer)
+
+    if (typeof this.asset === 'string') {
+      return /** @type {Handle<T>} */ (server.load(this.type, this.asset))
+    }
+
+    const assets = /** @type {Assets<T>} */ (server.getAssets(typeid(this.type)))
+
+    // TODO: This is inherently incorrect. When scene resources are added,
+    // the assetid will point to the wrong asset in the scene due to desync between
+    // the scene and world when an assets are added/removed from the world or scene.
+    // Add a mapping between scene assets and world assets and use that to create
+    // the asset handle. Also ensure the assets are loaded into world before spawning
+    // the scene into the world.
+
+    return /** @type {Handle<T>} */ (assets.upgrade(this.asset))
+  }
+}

--- a/src/asset/core/index.js
+++ b/src/asset/core/index.js
@@ -1,4 +1,3 @@
-export * from './asset.js'
 export * from './channel.js'
 export * from './handle.js'
 export * from './exporter.js'

--- a/src/asset/core/index.js
+++ b/src/asset/core/index.js
@@ -1,3 +1,4 @@
 export * from './asset.js'
+export * from './channel.js'
 export * from './exporter.js'
 export * from './importer.js'

--- a/src/asset/core/index.js
+++ b/src/asset/core/index.js
@@ -1,4 +1,5 @@
 export * from './asset.js'
 export * from './channel.js'
+export * from './handle.js'
 export * from './exporter.js'
 export * from './importer.js'

--- a/src/asset/plugins/asset.js
+++ b/src/asset/plugins/asset.js
@@ -6,7 +6,7 @@ import { EventPlugin } from '../../event/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
 import { Assets } from '../core/index.js'
 import { AssetAdded, AssetDropped, AssetModified } from '../events/index.js'
-import { registerAssetTypes, registerAssetOnAssetServer, unloadDroppedAssets, updateAssetEvents } from '../systems/index.js'
+import { registerAssetTypes, registerAssetOnAssetServer, unloadDroppedAssets, updateAssetChannel, updateAssetEvents } from '../systems/index.js'
 
 /**
  * @template T
@@ -43,6 +43,13 @@ export class AssetPlugin extends Plugin {
   register(app) {
     const { asset, events } = this
     const world = app.getWorld()
+
+    app.registerSystem({
+      label: `updateAssetChannel<${typeid(asset)}>`,
+      schedule: AppSchedule.Update,
+      systemGroup: CoreSystems.End,
+      system: updateAssetChannel(asset)
+    })
 
     if (events) {
       app

--- a/src/asset/plugins/asset.js
+++ b/src/asset/plugins/asset.js
@@ -4,7 +4,7 @@ import { App, Plugin } from '../../app/index.js'
 import { AppSchedule, CoreSystems } from '../../core/index.js'
 import { EventPlugin } from '../../event/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
-import { Assets } from '../core/index.js'
+import { Assets } from '../resources/index.js'
 import { AssetAdded, AssetDropped, AssetModified } from '../events/index.js'
 import { registerAssetTypes, registerAssetOnAssetServer, unloadDroppedAssets, updateAssetChannel, updateAssetEvents } from '../systems/index.js'
 

--- a/src/asset/resources/assets.js
+++ b/src/asset/resources/assets.js
@@ -1,10 +1,11 @@
 /** @import {AssetId} from '../types/index.js' */
-/** @import {Constructor} from '../../type/index.js'*/
+/** @import {Constructor} from '../../type/index.js' */
+
 import { unpackFrom64Int } from '../../algorithms/index.js'
 import { DenseList } from '../../datastructures/index.js'
 import { AssetAdded, AssetDropped, AssetEvent, AssetModified } from '../events/assets.js'
-import { AssetChannel, AssetChannelMessageType } from './channel.js'
-import { Handle } from './handle.js'
+import { AssetChannel, AssetChannelMessageType } from '../core/channel.js'
+import { Handle } from '../core/handle.js'
 
 /**
  * @template T

--- a/src/asset/resources/assetserver.js
+++ b/src/asset/resources/assetserver.js
@@ -3,7 +3,8 @@
 import { typeid } from '../../type/index.js'
 import { assert, warn } from '../../logger/index.js'
 import { getFileExtension, swapRemove } from '../../utils/index.js'
-import { Assets, Handle, Importer, Exporter } from '../core/index.js'
+import { Handle, Importer, Exporter } from '../core/index.js'
+import { Assets } from './assets.js'
 
 /**
  * @typedef {number} ImporterId

--- a/src/asset/resources/index.js
+++ b/src/asset/resources/index.js
@@ -1,1 +1,2 @@
+export * from './assets.js'
 export * from './assetserver.js'

--- a/src/asset/systems/channel.js
+++ b/src/asset/systems/channel.js
@@ -2,7 +2,7 @@
 /** @import { Constructor } from '../../type/index.js' */
 
 import { typeidGeneric } from '../../type/index.js'
-import { Assets } from '../core/index.js'
+import { Assets } from '../resources/index.js'
 
 /**
  * Drain the queued handle lifecycle messages for a single asset pool.

--- a/src/asset/systems/channel.js
+++ b/src/asset/systems/channel.js
@@ -1,0 +1,24 @@
+/** @import { SystemFunc } from '../../ecs/index.js' */
+/** @import { Constructor } from '../../type/index.js' */
+
+import { typeidGeneric } from '../../type/index.js'
+import { Assets } from '../core/index.js'
+
+/**
+ * Drain the queued handle lifecycle messages for a single asset pool.
+ *
+ * @template T
+ * @param {Constructor<T>} asset
+ * @returns {SystemFunc}
+ */
+export function updateAssetChannel(asset) {
+  const assetsId = typeidGeneric(Assets, [asset])
+
+  return function updateAssetChannel(world) {
+
+    /** @type {Assets<T>} */
+    const assets = world.getResourceByTypeId(assetsId)
+
+    assets.update()
+  }
+}

--- a/src/asset/systems/events.js
+++ b/src/asset/systems/events.js
@@ -1,7 +1,7 @@
 /** @import { SystemFunc, World } from '../../ecs/index.js' */
 /** @import { Constructor } from '../../type/index.js' */
 /** @import { AssetEvents } from '../index.js' */
-import { Assets } from '../core/index.js'
+import { Assets as ResourceAssets } from '../resources/index.js'
 import { Events } from '../../event/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
 import { AssetAdded, AssetDropped, AssetModified, AssetLoadFail, AssetLoadOperation } from '../events/index.js'
@@ -14,14 +14,14 @@ import { error, warnOnce } from '../../logger/index.js'
  * @returns {SystemFunc}
  */
 export function updateAssetEvents(assetType, eventType) {
-  const assetsId = typeidGeneric(Assets, [assetType])
+  const assetsId = typeidGeneric(ResourceAssets, [assetType])
   const addEventsId = typeidGeneric(Events, [eventType.added])
   const modifiedEventsId = typeidGeneric(Events, [eventType.modified])
   const droppedEventsId = typeidGeneric(Events, [eventType.dropped])
 
   return function updateAssetEvents(world) {
 
-    /** @type {Assets<T>} */
+    /** @type {ResourceAssets<T>} */
     const assets = world.getResourceByTypeId(assetsId)
 
     /** @type {Events<AssetAdded<T>>} */

--- a/src/asset/systems/index.js
+++ b/src/asset/systems/index.js
@@ -1,3 +1,4 @@
 export * from './events.js'
+export * from './channel.js'
 export * from './server.js'
 export * from './types.js'

--- a/src/asset/systems/server.js
+++ b/src/asset/systems/server.js
@@ -4,8 +4,7 @@
 import { Events } from '../../event/index.js'
 import { typeidGeneric } from '../../type/index.js'
 import { TypeRegistry } from '../../reflect/resources/index.js'
-import { Assets } from '../core/index.js'
-import { AssetServer, LoadState } from '../resources/index.js'
+import { AssetServer, Assets, LoadState } from '../resources/index.js'
 import { AssetLoadFail, AssetLoadOperation, AssetLoadSuccess, AssetSaveSuccess } from '../events/index.js'
 import { assert } from '../../logger/index.js'
 

--- a/src/asset/systems/types.js
+++ b/src/asset/systems/types.js
@@ -3,9 +3,9 @@
 import { World } from '../../ecs/index.js'
 import { ArrayInfo, Field, StructInfo } from '../../reflect/core/index.js'
 import { TypeRegistry } from '../../reflect/resources/index.js'
-import { Assets, Handle, HandleSnapshot } from '../core/index.js'
+import { AssetServer, Assets } from '../resources/index.js'
+import { Handle, HandleSnapshot } from '../core/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
-import { AssetServer } from '../resources/index.js'
 import { AssetLoadFail, AssetSaveSuccess } from '../events/index.js'
 
 /**

--- a/src/asset/tests/asset.test.js
+++ b/src/asset/tests/asset.test.js
@@ -54,7 +54,7 @@ describe("Testing `Assets`", () => {
     test('`Assets.get` returns undefined on invalid handle', () => {
         const assets = new Assets(String)
 
-        const handle = new Handle(assets,0, 1)
+        const handle = new Handle(assets.channel, String, 0, 1)
         const actual = assets.get(handle)
 
         strictEqual(actual, undefined)
@@ -182,7 +182,7 @@ describe("Testing `Assets`", () => {
     test('`Assets.getByAssetId` returns undefined on invalid assetid', () => {
         const assets = new Assets(String)
 
-        const handle = new Handle(assets,0, 1).id()
+        const handle = new Handle(assets.channel, String, 0, 1).id()
         const actual = assets.getByAssetId(handle)
 
         strictEqual(actual, undefined)
@@ -271,6 +271,7 @@ describe("Testing `Assets`", () => {
 
         const handle = assets.add(asset)
         assets.drop(handle)
+        assets.update()
         const events = assets.flushEvents()
 
         deepStrictEqual(events[1], new AssetDropped(String, handle.id()))

--- a/src/asset/tests/asset.test.js
+++ b/src/asset/tests/asset.test.js
@@ -1,6 +1,7 @@
 import { test, describe } from "node:test";
 import { deepStrictEqual, strictEqual } from "node:assert";
-import { Assets,Handle } from "../core/index.js";
+import { Handle } from "../core/index.js";
+import { Assets } from "../resources/index.js";
 import { AssetAdded, AssetDropped, AssetModified } from "../events/assets.js";
 
 describe("Testing `Assets`", () => {

--- a/src/asset/tests/assetserver.test.js
+++ b/src/asset/tests/assetserver.test.js
@@ -1,6 +1,7 @@
 import { deepStrictEqual, notDeepStrictEqual } from "assert";
 import test, { describe } from "node:test";
-import { Assets, AssetServer, Exporter, Importer } from "../index.js";
+import { AssetServer, Exporter, Importer } from "../index.js";
+import { Assets } from "../resources/index.js";
 import { typeid, typeidGeneric } from "../../type/index.js";
 import { World } from "../../ecs/index.js";
 import { updateAssets } from "../systems/index.js";

--- a/src/asset/tests/handle.test.js
+++ b/src/asset/tests/handle.test.js
@@ -1,6 +1,6 @@
 import { deepStrictEqual, strictEqual } from "assert";
 import test, { describe } from "node:test";
-import { Assets } from "../core/index.js";
+import { Assets } from "../resources/index.js";
 import { AssetServer } from "../resources/index.js";
 import { World } from "../../ecs/index.js";
 

--- a/src/asset/tests/handle.test.js
+++ b/src/asset/tests/handle.test.js
@@ -59,6 +59,7 @@ describe('Testing `Handle`',()=>{
         const handle = assets.add(asset)
         handle.clone()
         handle.clone()
+        assets.update()
         const entry = assets.getEntry(handle)
 
         strictEqual(entry.refCount, 3)
@@ -90,6 +91,7 @@ describe('Testing `Handle`',()=>{
 
         const handle = assets.add(asset)
         handle.drop()
+        assets.update()
         const actual = assets.get(handle)
 
         deepStrictEqual(actual, undefined)
@@ -106,6 +108,7 @@ describe('Testing `Handle`',()=>{
         handle1.drop()
         handle2.drop()
         handle3.drop()
+        assets.update()
 
         const actual = assets.get(handle1)
 
@@ -122,6 +125,7 @@ describe('Testing `Handle`',()=>{
 
         handle2.drop()
         handle3.drop()
+        assets.update()
         
         const actual = assets.get(handle1)
 
@@ -137,6 +141,7 @@ describe('Testing `Handle`',()=>{
 
         handle2.drop()
         handle2.drop()
+        assets.update()
         
         const actual = assets.get(handle1)
 
@@ -169,8 +174,10 @@ describe('Testing `Handle`',()=>{
 
         const handle1 = assets.add(asset)
         handle1.drop()
+        assets.update()
         const handle2 = assets.add(asset)
         handle2.drop()
+        assets.update()
         const handle3 = assets.add(asset)
 
         deepStrictEqual(handle1.index, 0)


### PR DESCRIPTION
## Objective

Introduce deferred asset handle reference counting through a dedicated asset channel and separate handle lifecycle management from asset storage.

## Solution

The previous implementation tightly coupled `Handle` reference counting to the `Assets` resource. Cloning or dropping a handle immediately mutated asset reference counts, requiring handles to retain a direct reference to the assets container. This made handle lifecycle management difficult to decouple from asset storage and complicated serialization/snapshot workflows. This introduces an `AssetChannel` that queues handle lifecycle operations and processes them during the asset container update phase.

Why this approach:

* Decouples handle lifetime management from asset storage.
* Makes handles lightweight and independent of the assets container implementation.
* Provides a foundation for scene serialization and future asset remapping workflows.
* Centralizes reference count mutations into a predictable update stage.

## Showcase

N/A

## Migration guide

### Breaking changes

### Behaviour changes

Reference count updates are no longer applied immediately.

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
