### PR TITLE
Add serialize deserialize static methods to components and resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "SEE LICENSE in LICENSE.txt",
       "dependencies": {
-        "vifaa": "^0.3.0"
+        "vifaa": "^0.4.0"
       },
       "devDependencies": {
         "@rollup/plugin-terser": "^1.0.0",
@@ -4603,9 +4603,9 @@
       }
     },
     "node_modules/vifaa": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/vifaa/-/vifaa-0.3.0.tgz",
-      "integrity": "sha512-Q9x0RWc7LjP1TUTrap99AlbPA/TUy0cxFrfT4MVxLCyB8PJWKENQH4m6ErpYYoaz/oHDvMQVwp4cYVhss4vJ5w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/vifaa/-/vifaa-0.4.0.tgz",
+      "integrity": "sha512-yxTdA84HRt0UKmtewC01zvtlPN6N5Foi/g5q9Q8TWo3UZdgUh6JYMEog+MoSjNja/5VWLrNTYCZiYA8lRUKU7Q==",
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "dist/*"
   ],
   "dependencies": {
-    "vifaa": "^0.3.0"
+    "vifaa": "^0.4.0"
   }
 }

--- a/src/animation/assets/clip.js
+++ b/src/animation/assets/clip.js
@@ -1,3 +1,4 @@
+/** @import { AnimationTrackSerial } from '../core/track.js' */
 import { AnimationTrack } from '../core/index.js'
 
 export class AnimationClip {
@@ -74,4 +75,81 @@ export class AnimationClip {
   default() {
     return new AnimationClip()
   }
+
+  /**
+   * @param {AnimationClip} value
+   */
+  static serialize(value) {
+    return {
+      duration: value.duration,
+      tracks: Array.from(value.tracks.entries()).map(([name, tracks]) => [
+        name,
+        tracks.map((track) => AnimationTrack.serialize(track))
+      ])
+    }
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is AnimationClipSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('duration' in value) || !('tracks' in value)) {
+      return false
+    }
+
+    if (typeof value.duration !== 'number' || !Array.isArray(value.tracks)) {
+      return false
+    }
+
+    for (let i = 0; i < value.tracks.length; i++) {
+      const entry = value.tracks[i]
+
+      if (!Array.isArray(entry) || entry.length !== 2) {
+        return false
+      }
+
+      const [name, tracks] = entry
+
+      if (typeof name !== 'string' || !Array.isArray(tracks)) {
+        return false
+      }
+
+      for (let j = 0; j < tracks.length; j++) {
+        if (!AnimationTrack.validateSerial(tracks[j])) {
+          return false
+        }
+      }
+    }
+
+    return true
+  }
+
+  /**
+   * @param {AnimationClipSerial} value
+   * @param {AnimationClip} [out]
+   */
+  static deserialize(value, out = new AnimationClip()) {
+    out.duration = value.duration
+    out.tracks = new Map(
+      value.tracks.map(([name, tracks]) => [
+        name,
+        tracks.map((track) => AnimationTrack.deserialize(track))
+      ])
+    )
+
+    return out
+  }
 }
+
+/**
+ * Serialized form of `AnimationClip`.
+ *
+ * @typedef AnimationClipSerial
+ * @property {number} duration
+ * @property {[string, AnimationTrackSerial[]][]} tracks
+ */

--- a/src/animation/components/player.js
+++ b/src/animation/components/player.js
@@ -41,6 +41,70 @@ export class AnimationPlayer {
   }
 
   /**
+   * @param {AnimationPlayer} value
+   */
+  static serialize(value) {
+    return {
+      animations: Array.from(value.animations.entries()).map(([id, playback]) => [
+        id,
+        Playback.serialize(playback)
+      ]),
+      current: value.current
+    }
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is AnimationPlayerSerial}
+   */
+  static validateSerial(value) {
+    if (typeof value !== 'object') {
+      return false
+    }
+
+    if (!('animations' in value) || !('current' in value)) {
+      return false
+    }
+
+    if (!Array.isArray(value.animations)) {
+      return false
+    }
+
+    if (value.current !== null && typeof value.current !== 'number') {
+      return false
+    }
+
+    for (let i = 0; i < value.animations.length; i++) {
+      const entry = value.animations[i]
+
+      if (!Array.isArray(entry) || entry.length !== 2) {
+        return false
+      }
+
+      const [id, playback] = entry
+
+      if (typeof id !== 'number' || !Playback.validateSerial(playback)) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  /**
+   * @param {AnimationPlayerSerial} value
+   * @param {AnimationPlayer} [out]
+   */
+  static deserialize(value, out = new AnimationPlayer()) {
+    out.animations = new Map(
+      value.animations.map(([id, playback]) => [id, Playback.deserialize(playback)])
+    )
+    out.current = value.current
+
+    return out
+  }
+
+  /**
    * @param {Handle<AnimationClip>} handle
    * @param {PlaybackSettings} settings
    */
@@ -152,3 +216,11 @@ export class AnimationPlayer {
     return this
   }
 }
+
+/**
+ * Serialized form of `AnimationPlayer`.
+ *
+ * @typedef AnimationPlayerSerial
+ * @property {[AssetId, any][]} animations
+ * @property {number | null} current
+ */

--- a/src/animation/components/target.js
+++ b/src/animation/components/target.js
@@ -53,7 +53,7 @@ export class AnimationTarget {
    * @param {AnimationTargetSerial} value
    * @param {AnimationTarget} [out]
    */
-  static deserialize(value, out = new AnimationTarget(new Entity(0, 0) , '')) {
+  static deserialize(value, out = new AnimationTarget(new Entity(0, 0), '')) {
     out.player = Entity.deserialize(value.player, out.player)
     out.id = value.id
 

--- a/src/animation/components/target.js
+++ b/src/animation/components/target.js
@@ -1,4 +1,4 @@
-/** @import { Entity } from '../../ecs/index.js' */
+import { Entity } from '../../ecs/index.js'
 
 export class AnimationTarget {
 
@@ -38,4 +38,49 @@ export class AnimationTarget {
   static clone(target) {
     return AnimationTarget.copy(target)
   }
+
+  /**
+   * @param {AnimationTarget} value
+   */
+  static serialize(value) {
+    return {
+      player: Entity.serialize(value.player),
+      id: value.id
+    }
+  }
+
+  /**
+   * @param {AnimationTargetSerial} value
+   * @param {AnimationTarget} [out]
+   */
+  static deserialize(value, out = new AnimationTarget(new Entity(0, 0) , '')) {
+    out.player = Entity.deserialize(value.player, out.player)
+    out.id = value.id
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is AnimationTargetSerial}
+   */
+  static validateSerial(value) {
+    if (typeof value !== 'object') {
+      return false
+    }
+
+    if (!('player' in value) || !('id' in value)) {
+      return false
+    }
+
+    return !!value.player && typeof value.id === 'string'
+  }
 }
+
+/**
+ * Serialized form of `AnimationTarget`.
+ *
+ * @typedef AnimationTargetSerial
+ * @property {any} player
+ * @property {string} id
+ */

--- a/src/animation/core/playback.js
+++ b/src/animation/core/playback.js
@@ -61,6 +61,58 @@ export class Playback {
     return Playback.copy(target)
   }
 
+  /**
+   * @param {Playback} value
+   */
+  static serialize(value) {
+    return {
+      speed: value.speed,
+      duration: value.duration,
+      elapsed: value.elapsed,
+      repeatMode: value.repeatMode,
+      paused: value.paused
+    }
+  }
+
+  /**
+   * @param {PlaybackSerial} value
+   * @param {Playback} [out]
+   */
+  static deserialize(value, out = new Playback()) {
+    out.speed = value.speed
+    out.duration = value.duration
+    out.elapsed = value.elapsed
+    out.repeatMode = value.repeatMode
+    out.paused = value.paused
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is PlaybackSerial}
+   */
+  static validateSerial(value) {
+    if (typeof value !== 'object') {
+      return false
+    }
+
+    if (!('speed' in value)
+      || !('duration' in value)
+      || !('elapsed' in value)
+      || !('repeatMode' in value)
+      || !('paused' in value)
+    ) {
+      return false
+    }
+
+    return typeof value.speed === 'number'
+      && typeof value.duration === 'number'
+      && typeof value.elapsed === 'number'
+      && typeof value.repeatMode === 'number'
+      && typeof value.paused === 'boolean'
+  }
+
   start() {
     this.elapsed = 0
     this.play()
@@ -99,6 +151,17 @@ export class Playback {
     }
   }
 }
+
+/**
+ * Serialized form of `Playback`.
+ *
+ * @typedef PlaybackSerial
+ * @property {number} speed
+ * @property {number} duration
+ * @property {number} elapsed
+ * @property {number} repeatMode
+ * @property {boolean} paused
+ */
 
 /**
  * @typedef PlaybackSettings

--- a/src/animation/core/playback.js
+++ b/src/animation/core/playback.js
@@ -97,20 +97,20 @@ export class Playback {
       return false
     }
 
-    if (!('speed' in value)
-      || !('duration' in value)
-      || !('elapsed' in value)
-      || !('repeatMode' in value)
-      || !('paused' in value)
+    if (!('speed' in value) ||
+      !('duration' in value) ||
+      !('elapsed' in value) ||
+      !('repeatMode' in value) ||
+      !('paused' in value)
     ) {
       return false
     }
 
-    return typeof value.speed === 'number'
-      && typeof value.duration === 'number'
-      && typeof value.elapsed === 'number'
-      && typeof value.repeatMode === 'number'
-      && typeof value.paused === 'boolean'
+    return typeof value.speed === 'number' &&
+      typeof value.duration === 'number' &&
+      typeof value.elapsed === 'number' &&
+      typeof value.repeatMode === 'number' &&
+      typeof value.paused === 'boolean'
   }
 
   start() {

--- a/src/animation/core/track.js
+++ b/src/animation/core/track.js
@@ -49,6 +49,61 @@ export class AnimationTrack {
   }
 
   /**
+   * @param {AnimationTrack} value
+   */
+  static serialize(value) {
+    return {
+      times: value.times.slice(),
+      keyframes: value.keyframes.slice(),
+      effector: value.effector
+    }
+  }
+
+  /**
+   * @param {AnimationTrackSerial} value
+   * @param {AnimationTrack} [out]
+   */
+  static deserialize(value, out = new AnimationTrack(/** @type {any} */ (null))) {
+    out.times = value.times.slice()
+    out.keyframes = value.keyframes.slice()
+    out.effector = value.effector
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is AnimationTrackSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('times' in value) || !('keyframes' in value) || !('effector' in value)) {
+      return false
+    }
+
+    if (!Array.isArray(value.times) || !Array.isArray(value.keyframes)) {
+      return false
+    }
+
+    for (let i = 0; i < value.times.length; i++) {
+      if (typeof value.times[i] !== 'number') {
+        return false
+      }
+    }
+
+    for (let i = 0; i < value.keyframes.length; i++) {
+      if (typeof value.keyframes[i] !== 'number') {
+        return false
+      }
+    }
+
+    return value.effector !== undefined && value.effector !== null
+  }
+
+  /**
    * @param {any} delta
    */
   getCurrent(delta) {
@@ -101,3 +156,12 @@ export class AnimationTrack {
     return [timestamp - 1, timestamp, centage]
   }
 }
+
+/**
+ * Serialized form of `AnimationTrack`.
+ *
+ * @typedef AnimationTrackSerial
+ * @property {number[]} times
+ * @property {number[]} keyframes
+ * @property {any} effector
+ */

--- a/src/animation/systems/types.js
+++ b/src/animation/systems/types.js
@@ -42,16 +42,26 @@ export function registerAnimationTypes(world) {
   }))
   registry.get(Playback)?.setMethod(Playback.copy)
   registry.get(Playback)?.setMethod(Playback.clone)
+  registry.get(Playback)?.setMethod(Playback.serialize)
+  registry.get(Playback)?.setMethod(Playback.deserialize)
   registry.register(AnimationPlayer, new StructInfo({
     animations: new Field(playbackMapId),
     current: new Field(typeid(Number), true)
   }))
   registry.get(AnimationPlayer)?.setMethod(AnimationPlayer.copy)
   registry.get(AnimationPlayer)?.setMethod(AnimationPlayer.clone)
+  registry.get(AnimationPlayer)?.setMethod(AnimationPlayer.serialize)
+  registry.get(AnimationPlayer)?.setMethod(AnimationPlayer.deserialize)
   registry.register(AnimationTarget, new StructInfo({
     player: new Field(typeid(Entity)),
     id: new Field(typeid(String))
   }))
   registry.get(AnimationTarget)?.setMethod(AnimationTarget.copy)
   registry.get(AnimationTarget)?.setMethod(AnimationTarget.clone)
+  registry.get(AnimationTarget)?.setMethod(AnimationTarget.serialize)
+  registry.get(AnimationTarget)?.setMethod(AnimationTarget.deserialize)
+  registry.get(AnimationTrack)?.setMethod(AnimationTrack.serialize)
+  registry.get(AnimationTrack)?.setMethod(AnimationTrack.deserialize)
+  registry.get(AnimationClip)?.setMethod(AnimationClip.serialize)
+  registry.get(AnimationClip)?.setMethod(AnimationClip.deserialize)
 }

--- a/src/asset/core/handle.js
+++ b/src/asset/core/handle.js
@@ -165,7 +165,7 @@ export class HandleSnapshot {
    * @param {HandleSnapshotSerial} value
    * @param {HandleSnapshot} [out]
    */
-  static deserialize(value, out =  new HandleSnapshot(typeid(Object), "")) {
+  static deserialize(value, out = new HandleSnapshot(typeid(Object), '')) {
     out.type = value.type
     out.asset = value.asset
 
@@ -185,8 +185,8 @@ export class HandleSnapshot {
       return false
     }
 
-    return typeof value.type === 'string'
-      && (typeof value.asset === 'number' || typeof value.asset === 'string')
+    return typeof value.type === 'string' &&
+      (typeof value.asset === 'number' || typeof value.asset === 'string')
   }
 }
 

--- a/src/asset/core/handle.js
+++ b/src/asset/core/handle.js
@@ -1,6 +1,6 @@
 /** @import {AssetId} from '../types/index.js' */
 /** @import {Assets} from '../resources/assets.js' */
-/** @import {Constructor} from '../../type/index.js'*/
+/** @import {Constructor, TypeId} from '../../type/index.js'*/
 
 import { packInto64Int } from '../../datastructures/index.js'
 import { typeid } from '../../type/index.js'
@@ -75,17 +75,17 @@ export class Handle {
    * Snapshot the handle with the asset server path when available.
    *
    * @param {import('../../ecs/index.js').World} world
-   * @returns {HandleSnapshot<T>}
+   * @returns {HandleSnapshot}
    */
   toSnapshot(world) {
     const server = world.getResource(AssetServer)
     const info = server?.getAssetInfo(this)
 
     if (info?.path) {
-      return new HandleSnapshot(this.type, info.path)
+      return new HandleSnapshot(typeid(this.type), info.path)
     }
 
-    return new HandleSnapshot(this.type, this.id())
+    return new HandleSnapshot(typeid(this.type), this.id())
   }
 
   drop() {
@@ -101,29 +101,25 @@ export class Handle {
  *
  * The snapshot preserves the asset type and id, and stores the asset server
  * path when one is registered so the handle can be reloaded by path.
- *
- * @template T
  */
 export class HandleSnapshot {
 
   /**
-   * @readonly
    * @type {import('../../type/index.js').TypeId}
    */
   type
 
   /**
-   * @readonly
    * @type {AssetId | string}
    */
   asset
 
   /**
-   * @param {Constructor<T>} type
+   * @param {TypeId} typeId
    * @param {AssetId | string} asset
    */
-  constructor(type, asset) {
-    this.type = typeid(type)
+  constructor(typeId, asset) {
+    this.type = typeId
     this.asset = asset
   }
 
@@ -134,16 +130,16 @@ export class HandleSnapshot {
    * upgrade the stored asset id against the asset pool.
    *
    * @param {import('../../ecs/index.js').World} world
-   * @returns {Handle<T>}
+   * @returns {UntypedHandle}
    */
   fromSnapshot(world) {
     const server = world.getResource(AssetServer)
 
     if (typeof this.asset === 'string') {
-      return /** @type {Handle<T>} */ (server.loadUntyped(this.type, this.asset))
+      return server.loadUntyped(this.type, this.asset)
     }
 
-    const assets = /** @type {Assets<T>} */ (server.getAssets(this.type))
+    const assets = server.getAssets(this.type)
 
     // TODO: This is inherently incorrect. When scene resources are added,
     // the assetid will point to the wrong asset in the scene due to desync between
@@ -152,10 +148,54 @@ export class HandleSnapshot {
     // the asset handle. Also ensure the assets are loaded into world before spawning
     // the scene into the world.
 
-    return /** @type {Handle<T>} */ (assets.upgrade(this.asset))
+    return assets.upgrade(this.asset)
+  }
+
+  /**
+   * @param {HandleSnapshot} value
+   */
+  static serialize(value) {
+    return {
+      type: value.type,
+      asset: value.asset
+    }
+  }
+
+  /**
+   * @param {HandleSnapshotSerial} value
+   * @param {HandleSnapshot} [out]
+   */
+  static deserialize(value, out =  new HandleSnapshot(typeid(Object), "")) {
+    out.type = value.type
+    out.asset = value.asset
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is HandleSnapshotSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('type' in value) || !('asset' in value)) {
+      return false
+    }
+
+    return typeof value.type === 'string'
+      && (typeof value.asset === 'number' || typeof value.asset === 'string')
   }
 }
 
 /**
  * @typedef {Handle<unknown>} UntypedHandle
+ */
+
+/**
+ * @typedef HandleSnapshotSerial
+ * @property {TypeId} type
+ * @property {AssetId | string} asset
  */

--- a/src/asset/systems/types.js
+++ b/src/asset/systems/types.js
@@ -32,6 +32,8 @@ export function registerAssetTypes(asset) {
       type: new Field(typeid(Function)),
       asset: new Field(typeid(Object))
     }))
+    registry.get(HandleSnapshot)?.setMethod(HandleSnapshot.serialize)
+    registry.get(HandleSnapshot)?.setMethod(HandleSnapshot.deserialize)
     registry.get(HandleSnapshot)?.setMethod(HandleSnapshot.prototype.fromSnapshot)
     registry.get(Handle)?.setMethod(Handle.prototype.toSnapshot)
   }

--- a/src/audio/components/audiooscillator.js
+++ b/src/audio/components/audiooscillator.js
@@ -105,11 +105,11 @@ export class AudioOscillator {
       return false
     }
 
-    return (value.sourceNode === undefined || typeof value.sourceNode === 'number')
-      && (value.attach === undefined || typeof value.attach === 'number')
-      && typeof value.type === 'number'
-      && typeof value.detune === 'number'
-      && typeof value.frequency === 'number'
+    return (value.sourceNode === undefined || typeof value.sourceNode === 'number') &&
+      (value.attach === undefined || typeof value.attach === 'number') &&
+      typeof value.type === 'number' &&
+      typeof value.detune === 'number' &&
+      typeof value.frequency === 'number'
   }
 }
 

--- a/src/audio/components/audiooscillator.js
+++ b/src/audio/components/audiooscillator.js
@@ -64,6 +64,53 @@ export class AudioOscillator {
   static clone(target) {
     return AudioOscillator.copy(target)
   }
+
+  /**
+   * @param {AudioOscillator} value
+   */
+  static serialize(value) {
+    return {
+      sourceNode: value.sourceNode,
+      attach: value.attach,
+      type: value.type,
+      detune: value.detune,
+      frequency: value.frequency
+    }
+  }
+
+  /**
+   * @param {AudioOscillatorSerial} value
+   * @param {AudioOscillator} [out]
+   */
+  static deserialize(value, out = new AudioOscillator()) {
+    out.sourceNode = value.sourceNode
+    out.attach = value.attach
+    out.type = value.type
+    out.detune = value.detune
+    out.frequency = value.frequency
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is AudioOscillatorSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('sourceNode' in value) || !('attach' in value) || !('type' in value) || !('detune' in value) || !('frequency' in value)) {
+      return false
+    }
+
+    return (value.sourceNode === undefined || typeof value.sourceNode === 'number')
+      && (value.attach === undefined || typeof value.attach === 'number')
+      && typeof value.type === 'number'
+      && typeof value.detune === 'number'
+      && typeof value.frequency === 'number'
+  }
 }
 
 /**
@@ -101,4 +148,13 @@ export const AudioOscillatorType = {
  * @property {AudioOscillatorType} [type]
  * @property {number} [frequency]
  * @property {number} [detune]
+ */
+
+/**
+ * @typedef AudioOscillatorSerial
+ * @property {NodeId | undefined} sourceNode
+ * @property {NodeId | undefined} attach
+ * @property {AudioOscillatorType} type
+ * @property {number} detune
+ * @property {number} frequency
  */

--- a/src/audio/components/audioplayer.js
+++ b/src/audio/components/audioplayer.js
@@ -99,7 +99,7 @@ export class AudioPlayerSnapshot {
   fromSnapshot(world) {
     const player = new AudioPlayer({
       attach: this.attach,
-      audio: /**@type {Handle<Audio>} */(this.audio?.fromSnapshot(world))
+      audio: /** @type {Handle<Audio>} */(this.audio?.fromSnapshot(world))
     })
 
     player.sourceNode = this.sourceNode
@@ -143,9 +143,9 @@ export class AudioPlayerSnapshot {
       return false
     }
 
-    return (value.sourceNode === undefined || typeof value.sourceNode === 'number')
-      && (value.attach === undefined || typeof value.attach === 'number')
-      && (value.audio === undefined || HandleSnapshot.validateSerial(value.audio))
+    return (value.sourceNode === undefined || typeof value.sourceNode === 'number') &&
+      (value.attach === undefined || typeof value.attach === 'number') &&
+      (value.audio === undefined || HandleSnapshot.validateSerial(value.audio))
   }
 }
 

--- a/src/audio/components/audioplayer.js
+++ b/src/audio/components/audioplayer.js
@@ -77,14 +77,14 @@ export class AudioPlayerSnapshot {
   attach
 
   /**
-   * @type {HandleSnapshot<Audio> | undefined}
+   * @type {HandleSnapshot | undefined}
    */
   audio
 
   /**
    * @param {NodeId | undefined} sourceNode
    * @param {NodeId | undefined} attach
-   * @param {HandleSnapshot<Audio> | undefined} audio
+   * @param {HandleSnapshot | undefined} audio
    */
   constructor(sourceNode, attach, audio) {
     this.sourceNode = sourceNode
@@ -99,12 +99,53 @@ export class AudioPlayerSnapshot {
   fromSnapshot(world) {
     const player = new AudioPlayer({
       attach: this.attach,
-      audio: this.audio?.fromSnapshot(world)
+      audio: /**@type {Handle<Audio>} */(this.audio?.fromSnapshot(world))
     })
 
     player.sourceNode = this.sourceNode
 
     return player
+  }
+
+  /**
+   * @param {AudioPlayerSnapshot} value
+   */
+  static serialize(value) {
+    return {
+      sourceNode: value.sourceNode,
+      attach: value.attach,
+      audio: value.audio ? HandleSnapshot.serialize(value.audio) : undefined
+    }
+  }
+
+  /**
+   * @param {AudioPlayerSnapshotSerial} value
+   * @param {AudioPlayerSnapshot} [out]
+   */
+  static deserialize(value, out = new AudioPlayerSnapshot(undefined, undefined, undefined)) {
+    out.sourceNode = value.sourceNode
+    out.attach = value.attach
+    out.audio = value.audio ? HandleSnapshot.deserialize(value.audio, out.audio) : undefined
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is AudioPlayerSnapshotSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('sourceNode' in value) || !('attach' in value) || !('audio' in value)) {
+      return false
+    }
+
+    return (value.sourceNode === undefined || typeof value.sourceNode === 'number')
+      && (value.attach === undefined || typeof value.attach === 'number')
+      && (value.audio === undefined || HandleSnapshot.validateSerial(value.audio))
   }
 }
 
@@ -136,4 +177,11 @@ export function removeAudioPlayerSink(entity, world) {
  * @typedef AudioPlayerOptions
  * @property {NodeId} [attach]
  * @property {Handle<Audio>} [audio]
+ */
+
+/**
+ * @typedef AudioPlayerSnapshotSerial
+ * @property {NodeId | undefined} sourceNode
+ * @property {NodeId | undefined} attach
+ * @property {import('../../asset/core/handle.js').HandleSnapshotSerial | undefined} audio
  */

--- a/src/audio/systems/types.js
+++ b/src/audio/systems/types.js
@@ -37,6 +37,8 @@ export function registerAudioTypes(world) {
     attach: new Field(typeid(Number), true),
     audio: new Field(typeid(HandleSnapshot), true)
   }))
+  registry.get(AudioPlayerSnapshot)?.setMethod(AudioPlayerSnapshot.serialize)
+  registry.get(AudioPlayerSnapshot)?.setMethod(AudioPlayerSnapshot.deserialize)
   registry.get(AudioPlayerSnapshot)?.setMethod(AudioPlayerSnapshot.prototype.fromSnapshot)
   registry.register(AudioOscillator, new StructInfo({
     sourceNode: new Field(typeid(Number), true),
@@ -47,6 +49,8 @@ export function registerAudioTypes(world) {
   }))
   registry.get(AudioOscillator)?.setMethod(AudioOscillator.copy)
   registry.get(AudioOscillator)?.setMethod(AudioOscillator.clone)
+  registry.get(AudioOscillator)?.setMethod(AudioOscillator.serialize)
+  registry.get(AudioOscillator)?.setMethod(AudioOscillator.deserialize)
   registry.register(AudioGraph, new StructInfo({
     graph: new Field(typeid(Graph))
   }))

--- a/src/broadphase/components/hitbox.js
+++ b/src/broadphase/components/hitbox.js
@@ -16,4 +16,19 @@ export class PhysicsHitbox extends BoundingBox2D {
   static clone(target) {
     return PhysicsHitbox.copy(target)
   }
+
+  /**
+   * @param {PhysicsHitbox} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../geometry/index.js').BoundingBox2DSerial} value
+   * @param {PhysicsHitbox} [out]
+   */
+  static deserialize(value, out = new PhysicsHitbox()) {
+    return super.deserialize(value, out)
+  }
 }

--- a/src/broadphase/systems/types.js
+++ b/src/broadphase/systems/types.js
@@ -24,6 +24,8 @@ export function registerBroadphaseTypes2D(world) {
   }))
   registry.get(PhysicsHitbox)?.setMethod(PhysicsHitbox.copy)
   registry.get(PhysicsHitbox)?.setMethod(PhysicsHitbox.clone)
+  registry.get(PhysicsHitbox)?.setMethod(PhysicsHitbox.serialize)
+  registry.get(PhysicsHitbox)?.setMethod(PhysicsHitbox.deserialize)
   registry.register(Broadphase2D, new StructInfo({}))
   registry.register(CollisionPairs, new ArrayInfo(typeid(CollisionPair)))
 }

--- a/src/color/core/color.js
+++ b/src/color/core/color.js
@@ -188,10 +188,10 @@ export class Color {
       return false
     }
 
-    return typeof value.r === 'number'
-      && typeof value.g === 'number'
-      && typeof value.b === 'number'
-      && typeof value.a === 'number'
+    return typeof value.r === 'number' &&
+      typeof value.g === 'number' &&
+      typeof value.b === 'number' &&
+      typeof value.a === 'number'
   }
 
   /**

--- a/src/color/core/color.js
+++ b/src/color/core/color.js
@@ -151,6 +151,50 @@ export class Color {
   }
 
   /**
+   * @param {Color} value
+   */
+  static serialize(value) {
+    return {
+      r: value.r,
+      g: value.g,
+      b: value.b,
+      a: value.a
+    }
+  }
+
+  /**
+   * @param {ColorSerial} value
+   * @param {Color} [out]
+   */
+  static deserialize(value, out = new Color()) {
+    out.r = value.r
+    out.g = value.g
+    out.b = value.b
+    out.a = value.a
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is ColorSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('r' in value) || !('g' in value) || !('b' in value) || !('a' in value)) {
+      return false
+    }
+
+    return typeof value.r === 'number'
+      && typeof value.g === 'number'
+      && typeof value.b === 'number'
+      && typeof value.a === 'number'
+  }
+
+  /**
    * @param {Color} color1
    * @param {Color} color2
    * @param {Color} [out]
@@ -295,3 +339,11 @@ export class Color {
    */
   static CYAN = new Color(0, 1, 1)
 }
+
+/**
+ * @typedef ColorSerial
+ * @property {number} r
+ * @property {number} g
+ * @property {number} b
+ * @property {number} a
+ */

--- a/src/color/systems/types.js
+++ b/src/color/systems/types.js
@@ -17,4 +17,6 @@ export function registerColorTypes(world) {
     a: new Field(typeid(Number))
   }))
   registry.get(Color)?.setMethod(Color.copy)
+  registry.get(Color)?.setMethod(Color.serialize)
+  registry.get(Color)?.setMethod(Color.deserialize)
 }

--- a/src/core/systems/types.js
+++ b/src/core/systems/types.js
@@ -12,4 +12,6 @@ export function registerCoreTypes(world) {
     index: new Field(typeid(Number)),
     generation: new Field(typeid(Number))
   }))
+  registry.get(Entity)?.setMethod(Entity.serialize)
+  registry.get(Entity)?.setMethod(Entity.deserialize)
 }

--- a/src/damping/resources/angulardampen.js
+++ b/src/damping/resources/angulardampen.js
@@ -11,7 +11,50 @@ export class Angular2DDamping {
   constructor(value = 0) {
     this.value = value
   }
+
+  /**
+   * @param {Angular2DDamping} value
+   * @returns {Angular2DDampingSerial}
+   */
+  static serialize(value) {
+    return {
+      value: value.value
+    }
+  }
+
+  /**
+   * @param {Angular2DDampingSerial} value
+   * @param {Angular2DDamping} [out]
+   */
+  static deserialize(value, out = new Angular2DDamping()) {
+    out.value = value.value
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Angular2DDampingSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('value' in value)) {
+      return false
+    }
+
+    return typeof value.value === 'number'
+  }
 }
+
+/**
+ * Serialized form of `Angular2DDamping`.
+ *
+ * @typedef Angular2DDampingSerial
+ * @property {number} value
+ */
 export class Angular3DDamping {
 
   /**
@@ -25,4 +68,47 @@ export class Angular3DDamping {
   constructor(value = 0) {
     this.value = value
   }
+
+  /**
+   * @param {Angular3DDamping} value
+   * @returns {Angular3DDampingSerial}
+   */
+  static serialize(value) {
+    return {
+      value: value.value
+    }
+  }
+
+  /**
+   * @param {Angular3DDampingSerial} value
+   * @param {Angular3DDamping} [out]
+   */
+  static deserialize(value, out = new Angular3DDamping()) {
+    out.value = value.value
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Angular3DDampingSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('value' in value)) {
+      return false
+    }
+
+    return typeof value.value === 'number'
+  }
 }
+
+/**
+ * Serialized form of `Angular3DDamping`.
+ *
+ * @typedef Angular3DDampingSerial
+ * @property {number} value
+ */

--- a/src/damping/resources/lineardampen.js
+++ b/src/damping/resources/lineardampen.js
@@ -11,7 +11,50 @@ export class Linear2DDamping {
   constructor(value = 0) {
     this.value = value
   }
+
+  /**
+   * @param {Linear2DDamping} value
+   * @returns {Linear2DDampingSerial}
+   */
+  static serialize(value) {
+    return {
+      value: value.value
+    }
+  }
+
+  /**
+   * @param {Linear2DDampingSerial} value
+   * @param {Linear2DDamping} [out]
+   */
+  static deserialize(value, out = new Linear2DDamping()) {
+    out.value = value.value
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Linear2DDampingSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('value' in value)) {
+      return false
+    }
+
+    return typeof value.value === 'number'
+  }
 }
+
+/**
+ * Serialized form of `Linear2DDamping`.
+ *
+ * @typedef Linear2DDampingSerial
+ * @property {number} value
+ */
 
 export class Linear3DDamping {
 
@@ -26,4 +69,47 @@ export class Linear3DDamping {
   constructor(value = 0) {
     this.value = value
   }
+
+  /**
+   * @param {Linear3DDamping} value
+   * @returns {Linear3DDampingSerial}
+   */
+  static serialize(value) {
+    return {
+      value: value.value
+    }
+  }
+
+  /**
+   * @param {Linear3DDampingSerial} value
+   * @param {Linear3DDamping} [out]
+   */
+  static deserialize(value, out = new Linear3DDamping()) {
+    out.value = value.value
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Linear3DDampingSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('value' in value)) {
+      return false
+    }
+
+    return typeof value.value === 'number'
+  }
 }
+
+/**
+ * Serialized form of `Linear3DDamping`.
+ *
+ * @typedef Linear3DDampingSerial
+ * @property {number} value
+ */

--- a/src/damping/systems/types.js
+++ b/src/damping/systems/types.js
@@ -13,9 +13,13 @@ export function registerDamping2DTypes(world) {
   registry.register(Linear2DDamping, new StructInfo({
     value: new Field(typeid(Number))
   }))
+  registry.get(Linear2DDamping)?.setMethod(Linear2DDamping.serialize)
+  registry.get(Linear2DDamping)?.setMethod(Linear2DDamping.deserialize)
   registry.register(Angular2DDamping, new StructInfo({
     value: new Field(typeid(Number))
   }))
+  registry.get(Angular2DDamping)?.setMethod(Angular2DDamping.serialize)
+  registry.get(Angular2DDamping)?.setMethod(Angular2DDamping.deserialize)
 }
 
 /**
@@ -27,7 +31,11 @@ export function registerDamping3DTypes(world) {
   registry.register(Linear3DDamping, new StructInfo({
     value: new Field(typeid(Number))
   }))
+  registry.get(Linear3DDamping)?.setMethod(Linear3DDamping.serialize)
+  registry.get(Linear3DDamping)?.setMethod(Linear3DDamping.deserialize)
   registry.register(Angular3DDamping, new StructInfo({
     value: new Field(typeid(Number))
   }))
+  registry.get(Angular3DDamping)?.setMethod(Angular3DDamping.serialize)
+  registry.get(Angular3DDamping)?.setMethod(Angular3DDamping.deserialize)
 }

--- a/src/device/resources/device.js
+++ b/src/device/resources/device.js
@@ -39,6 +39,30 @@ export class Device {
       this.platform === PlatformOS.Windows
     )
   }
+
+  /**
+   * @param {Device} value
+   */
+  static serialize(value) {
+    return {
+      capabilities: DeviceCapabilities.serialize(value.capabilities),
+      platform: value.platform,
+      browser: value.browser
+    }
+  }
+
+  /**
+   * @param {DeviceSerial} value
+   * @param {Device} [out]
+   */
+  static deserialize(value, out = new Device()) {
+
+    out.capabilities = DeviceCapabilities.deserialize(value.capabilities, out.capabilities)
+    out.platform = value.platform
+    out.browser = value.browser
+
+    return out
+  }
 }
 
 export class DeviceCapabilities {
@@ -70,4 +94,44 @@ export class DeviceCapabilities {
    * @type {boolean}
    */
   webAudio = false
+
+  /**
+   * @param {DeviceCapabilities} value
+   */
+  static serialize(value) {
+    return {
+      webgpu: value.webgpu,
+      webgl: value.webgl,
+      canvas: value.canvas,
+      webAudio: value.webAudio
+    }
+  }
+
+  /**
+   * @param {DeviceCapabilitiesSerial} value
+   * @param {DeviceCapabilities} [out]
+   */
+  static deserialize(value, out = new DeviceCapabilities()) {
+    out.webgpu = value.webgpu
+    out.webgl = value.webgl
+    out.canvas = value.canvas
+    out.webAudio = value.webAudio
+
+    return out
+  }
 }
+
+/**
+ * @typedef DeviceCapabilitiesSerial
+ * @property {boolean} webgpu
+ * @property {boolean} webgl
+ * @property {boolean} canvas
+ * @property {boolean} webAudio
+ */
+
+/**
+ * @typedef DeviceSerial
+ * @property {DeviceCapabilitiesSerial} capabilities
+ * @property {import('../core/platform.js').PlatformOS} platform
+ * @property {import('../core/browser.js').Browser} browser
+ */

--- a/src/device/systems/types.js
+++ b/src/device/systems/types.js
@@ -24,9 +24,13 @@ export function registerDeviceTypes(world) {
     canvas: new Field(typeid(Boolean)),
     webAudio: new Field(typeid(Boolean))
   }))
+  registry.get(DeviceCapabilities)?.setMethod(DeviceCapabilities.serialize)
+  registry.get(DeviceCapabilities)?.setMethod(DeviceCapabilities.deserialize)
   registry.register(Device, new StructInfo({
     capabilities: new Field(typeid(DeviceCapabilities)),
     platform: new Field(platformOsId),
     browser: new Field(browserId)
   }))
+  registry.get(Device)?.setMethod(Device.serialize)
+  registry.get(Device)?.setMethod(Device.deserialize)
 }

--- a/src/ecs/entities/entity.js
+++ b/src/ecs/entities/entity.js
@@ -50,6 +50,38 @@ export class Entity {
 
     return new Entity(index, generation)
   }
+
+  /**
+   * @param {Entity} value
+   */
+  static serialize(value) {
+    return {
+      index: value.index,
+      generation: value.generation
+    }
+  }
+
+  /**
+   * @param {EntityId} value
+   * @param {Entity} [out]
+   */
+  static deserialize(value, out = new Entity(0, 0)) {
+    const [index, generation] = unpackFrom64Int(value)
+    const target = /** @type {any} */ (out)
+
+    target.index = index
+    target.generation = generation
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is EntityId}
+   */
+  static validateSerial(value) {
+    return typeof value === 'number'
+  }
 }
 
 /**

--- a/src/emitter/components/emitter.js
+++ b/src/emitter/components/emitter.js
@@ -108,13 +108,13 @@ export class Emitter {
       return false
     }
 
-    return (value.prefab === undefined || typeof value.prefab === 'function')
-      && (value.patch === undefined || typeof value.patch === 'function')
-      && typeof value.burstCount === 'object'
-      && Range.validSerial(value.burstCount)
-      && typeof value.enabled === 'boolean'
-      && typeof value.lifetime === 'object'
-      && Range.validSerial(value.lifetime)
+    return (value.prefab === undefined || typeof value.prefab === 'function') &&
+      (value.patch === undefined || typeof value.patch === 'function') &&
+      typeof value.burstCount === 'object' &&
+      Range.validSerial(value.burstCount) &&
+      typeof value.enabled === 'boolean' &&
+      typeof value.lifetime === 'object' &&
+      Range.validSerial(value.lifetime)
   }
 }
 

--- a/src/emitter/components/emitter.js
+++ b/src/emitter/components/emitter.js
@@ -67,7 +67,65 @@ export class Emitter {
   static clone(target) {
     return Emitter.copy(target)
   }
+
+  /**
+   * @param {Emitter} value
+   */
+  static serialize(value) {
+    return {
+      prefab: value.prefab,
+      patch: value.patch,
+      burstCount: Range.serialize(value.burstCount),
+      enabled: value.enabled,
+      lifetime: Range.serialize(value.lifetime)
+    }
+  }
+
+  /**
+   * @param {EmitterSerial} value
+   * @param {Emitter} [out]
+   */
+  static deserialize(value, out = new Emitter()) {
+    out.prefab = value.prefab
+    out.patch = value.patch
+    out.lifetime = Range.deserialize(value.lifetime, out.lifetime)
+    out.burstCount = Range.deserialize(value.burstCount, out.burstCount)
+    out.enabled = value.enabled
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is EmitterSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('prefab' in value) || !('patch' in value) || !('burstCount' in value) || !('enabled' in value) || !('lifetime' in value)) {
+      return false
+    }
+
+    return (value.prefab === undefined || typeof value.prefab === 'function')
+      && (value.patch === undefined || typeof value.patch === 'function')
+      && typeof value.burstCount === 'object'
+      && Range.validSerial(value.burstCount)
+      && typeof value.enabled === 'boolean'
+      && typeof value.lifetime === 'object'
+      && Range.validSerial(value.lifetime)
+  }
 }
+
+/**
+ * @typedef EmitterSerial
+ * @property {(() => unknown[]) | undefined} [prefab]
+ * @property {((commands:EntityCommands,entity:Entity)=>void) | undefined} [patch]
+ * @property {{ start: number, end: number }} burstCount
+ * @property {boolean} enabled
+ * @property {{ start: number, end: number }} lifetime
+ */
 
 /**
  * @typedef EmitterOptions

--- a/src/geometry/AABB/boundingbox.js
+++ b/src/geometry/AABB/boundingbox.js
@@ -81,6 +81,44 @@ export class BoundingBox2D {
   }
 
   /**
+   * @param {BoundingBox2D} value
+   */
+  static serialize(value) {
+    return {
+      max: Vector2.serialize(value.max),
+      min: Vector2.serialize(value.min)
+    }
+  }
+
+  /**
+   * @param {BoundingBox2DSerial} value
+   * @param {BoundingBox2D} [out]
+   */
+  static deserialize(value, out = new BoundingBox2D()) {
+    out.max = Vector2.deserialize(value.max, out.max)
+    out.min = Vector2.deserialize(value.min, out.min)
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is BoundingBox2DSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('max' in value) || !('min' in value)) {
+      return false
+    }
+
+    return Vector2.validateSerial(value.max)
+      && Vector2.validateSerial(value.min)
+  }
+
+  /**
    * @param {BoundingBox2D} bound
    * @param {number} x
    * @param {number} y
@@ -112,3 +150,10 @@ export class BoundingBox2D {
     return out
   }
 }
+
+/**
+ * @typedef BoundingBox2DSerial
+ * @property {number} type
+ * @property {import('../../math/core/vectors/float/vector2.js').Vector2Serial} max
+ * @property {import('../../math/core/vectors/float/vector2.js').Vector2Serial} min
+ */

--- a/src/geometry/AABB/boundingbox.js
+++ b/src/geometry/AABB/boundingbox.js
@@ -114,8 +114,8 @@ export class BoundingBox2D {
       return false
     }
 
-    return Vector2.validateSerial(value.max)
-      && Vector2.validateSerial(value.min)
+    return Vector2.validateSerial(value.max) &&
+      Vector2.validateSerial(value.min)
   }
 
   /**

--- a/src/geometry/AABB/boundingcircle.js
+++ b/src/geometry/AABB/boundingcircle.js
@@ -66,4 +66,49 @@ export class BoundingCircle {
 
     return out
   }
+
+  /**
+   * @param {BoundingCircle} value
+   */
+  static serialize(value) {
+    return {
+      r: value.r,
+      pos: Vector2.serialize(value.pos)
+    }
+  }
+
+  /**
+   * @param {BoundingCircleSerial} value
+   * @param {BoundingCircle} [out]
+   */
+  static deserialize(value, out = new BoundingCircle()) {
+    out.r = value.r
+    Vector2.deserialize(value.pos, out.pos)
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is BoundingCircleSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if ( !('r' in value) || !('pos' in value)) {
+      return false
+    }
+
+    return typeof value.r === 'number'
+      && Vector2.validateSerial(value.pos)
+  }
 }
+
+/**
+ * @typedef BoundingCircleSerial
+ * @property {number} type
+ * @property {number} r
+ * @property {import('../../math/core/vectors/float/vector2.js').Vector2Serial} pos
+ */

--- a/src/geometry/AABB/boundingcircle.js
+++ b/src/geometry/AABB/boundingcircle.js
@@ -97,12 +97,12 @@ export class BoundingCircle {
       return false
     }
 
-    if ( !('r' in value) || !('pos' in value)) {
+    if (!('r' in value) || !('pos' in value)) {
       return false
     }
 
-    return typeof value.r === 'number'
-      && Vector2.validateSerial(value.pos)
+    return typeof value.r === 'number' &&
+      Vector2.validateSerial(value.pos)
   }
 }
 

--- a/src/geometry/systems/types.js
+++ b/src/geometry/systems/types.js
@@ -22,10 +22,14 @@ export function registerGeometryTypes(world) {
     min: new Field(typeid(Vector2))
   }))
   registry.get(BoundingBox2D)?.setMethod(BoundingBox2D.copy)
+  registry.get(BoundingBox2D)?.setMethod(BoundingBox2D.serialize)
+  registry.get(BoundingBox2D)?.setMethod(BoundingBox2D.deserialize)
   registry.register(BoundingCircle, new StructInfo({
     type: new Field(boundTypeId),
     r: new Field(typeid(Number)),
     pos: new Field(typeid(Vector2))
   }))
   registry.get(BoundingCircle)?.setMethod(BoundingCircle.copy)
+  registry.get(BoundingCircle)?.setMethod(BoundingCircle.serialize)
+  registry.get(BoundingCircle)?.setMethod(BoundingCircle.deserialize)
 }

--- a/src/gravity/resources/gravity.js
+++ b/src/gravity/resources/gravity.js
@@ -1,6 +1,7 @@
 import { Vector2, Vector3 } from '../../math/index.js'
 
 export class Gravity2D extends Vector2 {
+
   /**
    * @param {Gravity2D} value
    */
@@ -18,6 +19,7 @@ export class Gravity2D extends Vector2 {
 }
 
 export class Gravity3D extends Vector3 {
+
   /**
    * @param {Gravity3D} value
    */

--- a/src/gravity/resources/gravity.js
+++ b/src/gravity/resources/gravity.js
@@ -1,4 +1,35 @@
 import { Vector2, Vector3 } from '../../math/index.js'
 
-export class Gravity2D extends Vector2 {}
-export class Gravity3D extends Vector3 {}
+export class Gravity2D extends Vector2 {
+  /**
+   * @param {Gravity2D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../math/core/vectors/float/vector2.js').Vector2Serial} value
+   * @param {Gravity2D} [out]
+   */
+  static deserialize(value, out = new Gravity2D()) {
+    return super.deserialize(value, out)
+  }
+}
+
+export class Gravity3D extends Vector3 {
+  /**
+   * @param {Gravity3D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../math/core/vectors/float/vector3.js').Vector3Serial} value
+   * @param {Gravity3D} [out]
+   */
+  static deserialize(value, out = new Gravity3D()) {
+    return super.deserialize(value, out)
+  }
+}

--- a/src/gravity/systems/types.js
+++ b/src/gravity/systems/types.js
@@ -14,6 +14,8 @@ export function registerGravity2DTypes(world) {
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number))
   }))
+  registry.get(Gravity2D)?.setMethod(Gravity2D.serialize)
+  registry.get(Gravity2D)?.setMethod(Gravity2D.deserialize)
 }
 
 /**
@@ -27,4 +29,6 @@ export function registerGravity3DTypes(world) {
     y: new Field(typeid(Number)),
     z: new Field(typeid(Number))
   }))
+  registry.get(Gravity3D)?.setMethod(Gravity3D.serialize)
+  registry.get(Gravity3D)?.setMethod(Gravity3D.deserialize)
 }

--- a/src/hierarchy/components/children.js
+++ b/src/hierarchy/components/children.js
@@ -1,5 +1,4 @@
-/** @import { Entity } from '../../ecs/index.js' */
-
+import { Entity } from '../../ecs/index.js'
 import { VisitEntities } from '../../relationship/index.js'
 
 /**
@@ -38,6 +37,41 @@ export class Children {
   }
 
   /**
+   * @param {Children} value
+   */
+  static serialize(value) {
+    return value.list.map((entity) => entity.id())
+  }
+
+  /**
+   * @param {ChildrenSerial} value
+   * @param {Children} [out]
+   */
+  static deserialize(value, out = new Children([])) {
+    out.list = value.map((entity) => Entity.deserialize(entity))
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is ChildrenSerial}
+   */
+  static validateSerial(value) {
+    if (!Array.isArray(value)) {
+      return false
+    }
+
+    for (let i = 0; i < value.length; i++) {
+      if (!Entity.validateSerial(value[i])) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  /**
    * @param {Entity} entity
    */
   add(entity) {
@@ -60,3 +94,7 @@ export class Children {
     this.list.length = 0
   }
 }
+
+/**
+ * @typedef {import('../../ecs/entities/entity.js').EntityId[]} ChildrenSerial
+ */

--- a/src/hierarchy/components/parent.js
+++ b/src/hierarchy/components/parent.js
@@ -1,5 +1,4 @@
-/** @import { Entity } from '../../ecs/index.js' */
-
+import { Entity } from '../../ecs/index.js'
 import { VisitEntities } from '../../relationship/index.js'
 
 /**
@@ -36,7 +35,36 @@ export class Parent {
   static clone(target) {
     return Parent.copy(target)
   }
+
+  /**
+   * @param {Parent} value
+   */
+  static serialize(value) {
+    return value.entity.id()
+  }
+
+  /**
+   * @param {ParentSerial} value
+   * @param {Parent} [out]
+   */
+  static deserialize(value, out = new Parent(new Entity(0, 0))) {
+    out.entity = Entity.deserialize(value, out.entity)
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is ParentSerial}
+   */
+  static validateSerial(value) {
+    return Entity.validateSerial(value)
+  }
   visit() {
     return [this.entity]
   }
 }
+
+/**
+ * @typedef {import('../../ecs/entities/entity.js').EntityId} ParentSerial
+ */

--- a/src/hierarchy/systems/types.js
+++ b/src/hierarchy/systems/types.js
@@ -19,9 +19,13 @@ export function registerHierarchyTypes(world) {
   }))
   registry.get(Children)?.setMethod(Children.copy)
   registry.get(Children)?.setMethod(Children.clone)
+  registry.get(Children)?.setMethod(Children.serialize)
+  registry.get(Children)?.setMethod(Children.deserialize)
   registry.register(Parent, new StructInfo({
     entity: new Field(typeid(Entity))
   }))
   registry.get(Parent)?.setMethod(Parent.copy)
   registry.get(Parent)?.setMethod(Parent.clone)
+  registry.get(Parent)?.setMethod(Parent.serialize)
+  registry.get(Parent)?.setMethod(Parent.deserialize)
 }

--- a/src/math/core/affines/affine2.js
+++ b/src/math/core/affines/affine2.js
@@ -275,14 +275,14 @@ export class Affine2 {
    * @returns {value is Affine2Serial}
    */
   static validateSerial(value) {
-    return Array.isArray(value)
-      && value.length === 6
-      && typeof value[0] === 'number'
-      && typeof value[1] === 'number'
-      && typeof value[2] === 'number'
-      && typeof value[3] === 'number'
-      && typeof value[4] === 'number'
-      && typeof value[5] === 'number'
+    return Array.isArray(value) &&
+      value.length === 6 &&
+      typeof value[0] === 'number' &&
+      typeof value[1] === 'number' &&
+      typeof value[2] === 'number' &&
+      typeof value[3] === 'number' &&
+      typeof value[4] === 'number' &&
+      typeof value[5] === 'number'
   }
 
   /**

--- a/src/math/core/affines/affine2.js
+++ b/src/math/core/affines/affine2.js
@@ -247,6 +247,45 @@ export class Affine2 {
   }
 
   /**
+   * @param {Affine2} value
+   * @returns {Affine2Serial}
+   */
+  static serialize(value) {
+    return [value.a, value.b, value.c, value.d, value.x, value.y]
+  }
+
+  /**
+   * @param {Affine2Serial} value
+   * @param {Affine2} [out]
+   */
+  static deserialize(value, out = new Affine2()) {
+
+    out.a = value[0]
+    out.b = value[1]
+    out.c = value[2]
+    out.d = value[3]
+    out.x = value[4]
+    out.y = value[5]
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Affine2Serial}
+   */
+  static validateSerial(value) {
+    return Array.isArray(value)
+      && value.length === 6
+      && typeof value[0] === 'number'
+      && typeof value[1] === 'number'
+      && typeof value[2] === 'number'
+      && typeof value[3] === 'number'
+      && typeof value[4] === 'number'
+      && typeof value[5] === 'number'
+  }
+
+  /**
    * @param {Affine2} out
    * @returns {Affine2}
    */
@@ -499,3 +538,10 @@ export class Affine2 {
    */
   static Zero = Affine2.zero()
 }
+
+/**
+ * Serialized form of `Affine2`.
+ *
+ * @typedef Affine2Serial
+ * @type {[number, number, number, number, number, number]}
+ */

--- a/src/math/core/affines/affine3.js
+++ b/src/math/core/affines/affine3.js
@@ -357,20 +357,20 @@ export class Affine3 {
    * @returns {value is Affine3Serial}
    */
   static validateSerial(value) {
-    return Array.isArray(value)
-      && value.length === 12
-      && typeof value[0] === 'number'
-      && typeof value[1] === 'number'
-      && typeof value[2] === 'number'
-      && typeof value[3] === 'number'
-      && typeof value[4] === 'number'
-      && typeof value[5] === 'number'
-      && typeof value[6] === 'number'
-      && typeof value[7] === 'number'
-      && typeof value[8] === 'number'
-      && typeof value[9] === 'number'
-      && typeof value[10] === 'number'
-      && typeof value[11] === 'number'
+    return Array.isArray(value) &&
+      value.length === 12 &&
+      typeof value[0] === 'number' &&
+      typeof value[1] === 'number' &&
+      typeof value[2] === 'number' &&
+      typeof value[3] === 'number' &&
+      typeof value[4] === 'number' &&
+      typeof value[5] === 'number' &&
+      typeof value[6] === 'number' &&
+      typeof value[7] === 'number' &&
+      typeof value[8] === 'number' &&
+      typeof value[9] === 'number' &&
+      typeof value[10] === 'number' &&
+      typeof value[11] === 'number'
   }
 
   /**

--- a/src/math/core/affines/affine3.js
+++ b/src/math/core/affines/affine3.js
@@ -311,6 +311,69 @@ export class Affine3 {
   }
 
   /**
+   * @param {Affine3} value
+   * @returns {Affine3Serial}
+   */
+  static serialize(value) {
+    return [
+      value.a,
+      value.b,
+      value.c,
+      value.d,
+      value.e,
+      value.f,
+      value.g,
+      value.h,
+      value.i,
+      value.x,
+      value.y,
+      value.z
+    ]
+  }
+
+  /**
+   * @param {Affine3Serial} value
+   * @param {Affine3} [out]
+   */
+  static deserialize(value, out = new Affine3()) {
+    out.a = value[0]
+    out.b = value[1]
+    out.c = value[2]
+    out.d = value[3]
+    out.e = value[4]
+    out.f = value[5]
+    out.g = value[6]
+    out.h = value[7]
+    out.i = value[8]
+    out.x = value[9]
+    out.y = value[10]
+    out.z = value[11]
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Affine3Serial}
+   */
+  static validateSerial(value) {
+    return Array.isArray(value)
+      && value.length === 12
+      && typeof value[0] === 'number'
+      && typeof value[1] === 'number'
+      && typeof value[2] === 'number'
+      && typeof value[3] === 'number'
+      && typeof value[4] === 'number'
+      && typeof value[5] === 'number'
+      && typeof value[6] === 'number'
+      && typeof value[7] === 'number'
+      && typeof value[8] === 'number'
+      && typeof value[9] === 'number'
+      && typeof value[10] === 'number'
+      && typeof value[11] === 'number'
+  }
+
+  /**
    * @param {Affine3} out
    * @returns {Affine3}
    */
@@ -823,3 +886,10 @@ export class Affine3 {
    */
   static Zero = Affine3.zero()
 }
+
+/**
+ * Serialized form of `Affine3`.
+ *
+ * @typedef Affine3Serial
+ * @type {[number, number, number, number, number, number, number, number, number, number, number, number]}
+ */

--- a/src/math/core/angles/angle.js
+++ b/src/math/core/angles/angle.js
@@ -38,4 +38,35 @@ export class Angle {
   static copy(angle) {
     this.value = angle.value
   }
+
+  /**
+   * @param {Angle} value
+   */
+  static serialize(value) {
+    return value.value
+  }
+
+  /**
+   * @param {AngleSerial} value
+   * @param {Angle} [out]
+   */
+  static deserialize(value, out = new Angle()) {
+    out.value = value
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is AngleSerial}
+   */
+  static validateSerial(value) {
+    return typeof value === 'number'
+  }
 }
+
+/**
+ * Serialized form of `Angle`.
+ *
+ * @typedef {number} AngleSerial
+ */

--- a/src/math/core/angles/quaternion.js
+++ b/src/math/core/angles/quaternion.js
@@ -180,10 +180,10 @@ export class Quaternion {
       return false
     }
 
-    return typeof value.x === 'number'
-      && typeof value.y === 'number'
-      && typeof value.z === 'number'
-      && typeof value.w === 'number'
+    return typeof value.x === 'number' &&
+      typeof value.y === 'number' &&
+      typeof value.z === 'number' &&
+      typeof value.w === 'number'
   }
 
   /**

--- a/src/math/core/angles/quaternion.js
+++ b/src/math/core/angles/quaternion.js
@@ -143,6 +143,50 @@ export class Quaternion {
   }
 
   /**
+   * @param {Quaternion} value
+   */
+  static serialize(value) {
+    return {
+      x: value.x,
+      y: value.y,
+      z: value.z,
+      w: value.w
+    }
+  }
+
+  /**
+   * @param {QuaternionSerial} value
+   * @param {Quaternion} [out]
+   */
+  static deserialize(value, out = new Quaternion()) {
+    out.x = value.x
+    out.y = value.y
+    out.z = value.z
+    out.w = value.w
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is QuaternionSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('x' in value) || !('y' in value) || !('z' in value) || !('w' in value)) {
+      return false
+    }
+
+    return typeof value.x === 'number'
+      && typeof value.y === 'number'
+      && typeof value.z === 'number'
+      && typeof value.w === 'number'
+  }
+
+  /**
    * @param {Quaternion} out
    */
   static identity(out = new Quaternion()) {
@@ -582,3 +626,13 @@ export class Quaternion {
    */
   static Zero = Quaternion.zero()
 }
+
+/**
+ * Serialized form of `Quaternion`.
+ *
+ * @typedef QuaternionSerial
+ * @property {number} x
+ * @property {number} y
+ * @property {number} z
+ * @property {number} w
+ */

--- a/src/math/core/angles/rotary.js
+++ b/src/math/core/angles/rotary.js
@@ -150,6 +150,43 @@ export class Rotary {
   }
 
   /**
+   * @param {Rotary} value
+   */
+  static serialize(value) {
+    return {
+      cos: value.cos,
+      sin: value.sin
+    }
+  }
+
+  /**
+   * @param {RotarySerial} value
+   * @param {Rotary} [out]
+   */
+  static deserialize(value, out = new Rotary()) {
+    out.cos = value.cos
+    out.sin = value.sin
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is RotarySerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('cos' in value) || !('sin' in value)) {
+      return false
+    }
+
+    return typeof value.cos === 'number' && typeof value.sin === 'number'
+  }
+
+  /**
    * @param {Rotary} out
    * @returns {Rotary}
    */
@@ -376,3 +413,11 @@ export class Rotary {
    */
   static Zero = Rotary.zero()
 }
+
+/**
+ * Serialized form of `Rotary`.
+ *
+ * @typedef RotarySerial
+ * @property {number} cos
+ * @property {number} sin
+ */

--- a/src/math/core/basis/basis2.js
+++ b/src/math/core/basis/basis2.js
@@ -55,8 +55,8 @@ export class Basis2 {
       return false
     }
 
-    return Vector2.validateSerial(value.x)
-      && Vector2.validateSerial(value.y)
+    return Vector2.validateSerial(value.x) &&
+      Vector2.validateSerial(value.y)
   }
 }
 

--- a/src/math/core/basis/basis2.js
+++ b/src/math/core/basis/basis2.js
@@ -20,4 +20,50 @@ export class Basis2 {
     this.x = x
     this.y = y
   }
+
+  /**
+   * @param {Basis2} value
+   */
+  static serialize(value) {
+    return {
+      x: Vector2.serialize(value.x),
+      y: Vector2.serialize(value.y)
+    }
+  }
+
+  /**
+   * @param {Basis2Serial} value
+   * @param {Basis2} [out]
+   */
+  static deserialize(value, out = new Basis2()) {
+    out.x = Vector2.deserialize(value.x, out.x)
+    out.y = Vector2.deserialize(value.y, out.y)
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Basis2Serial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('x' in value) || !('y' in value)) {
+      return false
+    }
+
+    return Vector2.validateSerial(value.x)
+      && Vector2.validateSerial(value.y)
+  }
 }
+
+/**
+ * Serialized form of `Basis2`.
+ *
+ * @typedef Basis2Serial
+ * @property {any} x
+ * @property {any} y
+ */

--- a/src/math/core/basis/basis3.js
+++ b/src/math/core/basis/basis3.js
@@ -62,9 +62,9 @@ export class Basis3 {
       return false
     }
 
-    return Vector3.validateSerial(value.x)
-      && Vector3.validateSerial(value.y)
-      && Vector3.validateSerial(value.z)
+    return Vector3.validateSerial(value.x) &&
+      Vector3.validateSerial(value.y) &&
+      Vector3.validateSerial(value.z)
   }
 }
 

--- a/src/math/core/basis/basis3.js
+++ b/src/math/core/basis/basis3.js
@@ -25,4 +25,54 @@ export class Basis3 {
     this.y = y
     this.z = z
   }
+
+  /**
+   * @param {Basis3} value
+   */
+  static serialize(value) {
+    return {
+      x: Vector3.serialize(value.x),
+      y: Vector3.serialize(value.y),
+      z: Vector3.serialize(value.z)
+    }
+  }
+
+  /**
+   * @param {Basis3Serial} value
+   * @param {Basis3} [out]
+   */
+  static deserialize(value, out = new Basis3()) {
+    out.x = Vector3.deserialize(value.x, out.x)
+    out.y = Vector3.deserialize(value.y, out.y)
+    out.z = Vector3.deserialize(value.z, out.z)
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Basis3Serial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('x' in value) || !('y' in value) || !('z' in value)) {
+      return false
+    }
+
+    return Vector3.validateSerial(value.x)
+      && Vector3.validateSerial(value.y)
+      && Vector3.validateSerial(value.z)
+  }
 }
+
+/**
+ * Serialized form of `Basis3`.
+ *
+ * @typedef Basis3Serial
+ * @property {any} x
+ * @property {any} y
+ * @property {any} z
+ */

--- a/src/math/core/matrices/matrix2.js
+++ b/src/math/core/matrices/matrix2.js
@@ -247,12 +247,12 @@ export class Matrix2 {
    * @returns {value is Matrix2Serial}
    */
   static validateSerial(value) {
-    return Array.isArray(value)
-      && value.length === 4
-      && typeof value[0] === 'number'
-      && typeof value[1] === 'number'
-      && typeof value[2] === 'number'
-      && typeof value[3] === 'number'
+    return Array.isArray(value) &&
+      value.length === 4 &&
+      typeof value[0] === 'number' &&
+      typeof value[1] === 'number' &&
+      typeof value[2] === 'number' &&
+      typeof value[3] === 'number'
   }
 
   /**

--- a/src/math/core/matrices/matrix2.js
+++ b/src/math/core/matrices/matrix2.js
@@ -222,6 +222,40 @@ export class Matrix2 {
   }
 
   /**
+   * @param {Matrix2} value
+   * @returns {Matrix2Serial}
+   */
+  static serialize(value) {
+    return [value.a, value.b, value.c, value.d]
+  }
+
+  /**
+   * @param {Matrix2Serial} value
+   * @param {Matrix2} [out]
+   */
+  static deserialize(value, out = new Matrix2()) {
+    out.a = value[0]
+    out.b = value[1]
+    out.c = value[2]
+    out.d = value[3]
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Matrix2Serial}
+   */
+  static validateSerial(value) {
+    return Array.isArray(value)
+      && value.length === 4
+      && typeof value[0] === 'number'
+      && typeof value[1] === 'number'
+      && typeof value[2] === 'number'
+      && typeof value[3] === 'number'
+  }
+
+  /**
    * @param {Matrix2} matrix
    * @param {Matrix2} out
    * @returns {Matrix2}
@@ -451,3 +485,10 @@ export class Matrix2 {
    */
   static Zero = Matrix2.zero()
 }
+
+/**
+ * Serialized form of `Matrix2`.
+ *
+ * @typedef Matrix2Serial
+ * @type {[number, number, number, number]}
+ */

--- a/src/math/core/matrices/matrix3.js
+++ b/src/math/core/matrices/matrix3.js
@@ -290,6 +290,52 @@ export class Matrix3 {
   }
 
   /**
+   * @param {Matrix3} value
+   * @returns {Matrix3Serial}
+   */
+  static serialize(value) {
+    return [value.a, value.b, value.c, value.d, value.e, value.f, value.g, value.h, value.i]
+  }
+
+  /**
+   * @param {Matrix3Serial} value
+   * @param {Matrix3} [out]
+   */
+  static deserialize(value, out = new Matrix3()) {
+    const serial = /** @type {Matrix3Serial} */ (value)
+
+    out.a = serial[0]
+    out.b = serial[1]
+    out.c = serial[2]
+    out.d = serial[3]
+    out.e = serial[4]
+    out.f = serial[5]
+    out.g = serial[6]
+    out.h = serial[7]
+    out.i = serial[8]
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Matrix3Serial}
+   */
+  static validateSerial(value) {
+    return Array.isArray(value)
+      && value.length === 9
+      && typeof value[0] === 'number'
+      && typeof value[1] === 'number'
+      && typeof value[2] === 'number'
+      && typeof value[3] === 'number'
+      && typeof value[4] === 'number'
+      && typeof value[5] === 'number'
+      && typeof value[6] === 'number'
+      && typeof value[7] === 'number'
+      && typeof value[8] === 'number'
+  }
+
+  /**
    * @param {Matrix3} matrix
    * @param {Matrix3} [out=new Matrix3()]
    */
@@ -618,3 +664,8 @@ export class Matrix3 {
    */
   static Zero = Matrix3.zero()
 }
+
+/**
+ * @typedef Matrix3Serial
+ * @type {[number, number, number, number, number, number, number, number, number]}
+ */

--- a/src/math/core/matrices/matrix3.js
+++ b/src/math/core/matrices/matrix3.js
@@ -322,17 +322,17 @@ export class Matrix3 {
    * @returns {value is Matrix3Serial}
    */
   static validateSerial(value) {
-    return Array.isArray(value)
-      && value.length === 9
-      && typeof value[0] === 'number'
-      && typeof value[1] === 'number'
-      && typeof value[2] === 'number'
-      && typeof value[3] === 'number'
-      && typeof value[4] === 'number'
-      && typeof value[5] === 'number'
-      && typeof value[6] === 'number'
-      && typeof value[7] === 'number'
-      && typeof value[8] === 'number'
+    return Array.isArray(value) &&
+      value.length === 9 &&
+      typeof value[0] === 'number' &&
+      typeof value[1] === 'number' &&
+      typeof value[2] === 'number' &&
+      typeof value[3] === 'number' &&
+      typeof value[4] === 'number' &&
+      typeof value[5] === 'number' &&
+      typeof value[6] === 'number' &&
+      typeof value[7] === 'number' &&
+      typeof value[8] === 'number'
   }
 
   /**

--- a/src/math/core/matrices/matrix4.js
+++ b/src/math/core/matrices/matrix4.js
@@ -452,24 +452,24 @@ export class Matrix4 {
    * @returns {value is Matrix4Serial}
    */
   static validateSerial(value) {
-    return Array.isArray(value)
-      && value.length === 16
-      && typeof value[0] === 'number'
-      && typeof value[1] === 'number'
-      && typeof value[2] === 'number'
-      && typeof value[3] === 'number'
-      && typeof value[4] === 'number'
-      && typeof value[5] === 'number'
-      && typeof value[6] === 'number'
-      && typeof value[7] === 'number'
-      && typeof value[8] === 'number'
-      && typeof value[9] === 'number'
-      && typeof value[10] === 'number'
-      && typeof value[11] === 'number'
-      && typeof value[12] === 'number'
-      && typeof value[13] === 'number'
-      && typeof value[14] === 'number'
-      && typeof value[15] === 'number'
+    return Array.isArray(value) &&
+      value.length === 16 &&
+      typeof value[0] === 'number' &&
+      typeof value[1] === 'number' &&
+      typeof value[2] === 'number' &&
+      typeof value[3] === 'number' &&
+      typeof value[4] === 'number' &&
+      typeof value[5] === 'number' &&
+      typeof value[6] === 'number' &&
+      typeof value[7] === 'number' &&
+      typeof value[8] === 'number' &&
+      typeof value[9] === 'number' &&
+      typeof value[10] === 'number' &&
+      typeof value[11] === 'number' &&
+      typeof value[12] === 'number' &&
+      typeof value[13] === 'number' &&
+      typeof value[14] === 'number' &&
+      typeof value[15] === 'number'
   }
 
   /**

--- a/src/math/core/matrices/matrix4.js
+++ b/src/math/core/matrices/matrix4.js
@@ -398,6 +398,81 @@ export class Matrix4 {
   }
 
   /**
+   * @param {Matrix4} value
+   * @returns {Matrix4Serial}
+   */
+  static serialize(value) {
+    return [
+      value.a,
+      value.b,
+      value.c,
+      value.d,
+      value.e,
+      value.f,
+      value.g,
+      value.h,
+      value.i,
+      value.j,
+      value.k,
+      value.l,
+      value.m,
+      value.n,
+      value.o,
+      value.p
+    ]
+  }
+
+  /**
+   * @param {Matrix4Serial} value
+   * @param {Matrix4} [out]
+   */
+  static deserialize(value, out = new Matrix4()) {
+    out.a = value[0]
+    out.b = value[1]
+    out.c = value[2]
+    out.d = value[3]
+    out.e = value[4]
+    out.f = value[5]
+    out.g = value[6]
+    out.h = value[7]
+    out.i = value[8]
+    out.j = value[9]
+    out.k = value[10]
+    out.l = value[11]
+    out.m = value[12]
+    out.n = value[13]
+    out.o = value[14]
+    out.p = value[15]
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Matrix4Serial}
+   */
+  static validateSerial(value) {
+    return Array.isArray(value)
+      && value.length === 16
+      && typeof value[0] === 'number'
+      && typeof value[1] === 'number'
+      && typeof value[2] === 'number'
+      && typeof value[3] === 'number'
+      && typeof value[4] === 'number'
+      && typeof value[5] === 'number'
+      && typeof value[6] === 'number'
+      && typeof value[7] === 'number'
+      && typeof value[8] === 'number'
+      && typeof value[9] === 'number'
+      && typeof value[10] === 'number'
+      && typeof value[11] === 'number'
+      && typeof value[12] === 'number'
+      && typeof value[13] === 'number'
+      && typeof value[14] === 'number'
+      && typeof value[15] === 'number'
+  }
+
+  /**
    * @param {Matrix4} matrix
    * @param {Matrix4} out
    * @returns {Matrix4}
@@ -903,3 +978,8 @@ export class Matrix4 {
    */
   static Zero = Matrix4.zero()
 }
+
+/**
+ * @typedef Matrix4Serial
+ * @type {[number, number, number, number, number, number, number, number, number, number, number, number, number, number, number, number]}
+ */

--- a/src/math/core/vectors/float/vector2.js
+++ b/src/math/core/vectors/float/vector2.js
@@ -281,6 +281,43 @@ export class Vector2 {
   }
 
   /**
+   * @param {Vector2} value
+   */
+  static serialize(value) {
+    return {
+      x: value.x,
+      y: value.y
+    }
+  }
+
+  /**
+   * @param {Vector2Serial} value
+   * @param {Vector2} [out]
+   */
+  static deserialize(value, out = new Vector2()) {
+    out.x = value.x
+    out.y = value.y
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Vector2Serial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('x' in value) || !('y' in value)) {
+      return false
+    }
+
+    return typeof value.x === 'number' && typeof value.y === 'number'
+  }
+
+  /**
    * @param {number} scalar
    * @param {Vector2} out
    * @returns {Vector2}
@@ -310,7 +347,7 @@ export class Vector2 {
    * @param {Vector2} v2
    */
   static distanceToSquared(v1, v2) {
-    const temp = new this(v1.x - v2.x, v1.y - v2.y)
+    const temp = new Vector2(v1.x - v2.x, v1.y - v2.y)
 
     return this.magnitudeSquared(temp)
   }
@@ -320,7 +357,7 @@ export class Vector2 {
    * @param {Vector2} v2
    */
   static distanceTo(v1, v2) {
-    const temp = new this(v1.x - v2.x, v1.y - v2.y)
+    const temp = new Vector2(v1.x - v2.x, v1.y - v2.y)
 
     return this.magnitude(temp)
   }
@@ -677,3 +714,11 @@ export class Vector2 {
    */
   static NegY = new Vector2(0, -1)
 }
+
+/**
+ * Serialized form of `Vector2`.
+ *
+* @typedef Vector2Serial
+* @property {number} x
+* @property {number} y
+*/

--- a/src/math/core/vectors/float/vector2.js
+++ b/src/math/core/vectors/float/vector2.js
@@ -718,7 +718,7 @@ export class Vector2 {
 /**
  * Serialized form of `Vector2`.
  *
-* @typedef Vector2Serial
-* @property {number} x
-* @property {number} y
-*/
+ * @typedef Vector2Serial
+ * @property {number} x
+ * @property {number} y
+ */

--- a/src/math/core/vectors/float/vector3.js
+++ b/src/math/core/vectors/float/vector3.js
@@ -313,9 +313,9 @@ export class Vector3 {
       return false
     }
 
-    return typeof value.x === 'number'
-      && typeof value.y === 'number'
-      && typeof value.z === 'number'
+    return typeof value.x === 'number' &&
+      typeof value.y === 'number' &&
+      typeof value.z === 'number'
   }
 
   /**
@@ -685,8 +685,8 @@ export class Vector3 {
 /**
  * Serialized form of `Vector3`.
  *
-* @typedef Vector3Serial
-* @property {number} x
-* @property {number} y
-* @property {number} z
-*/
+ * @typedef Vector3Serial
+ * @property {number} x
+ * @property {number} y
+ * @property {number} z
+ */

--- a/src/math/core/vectors/float/vector3.js
+++ b/src/math/core/vectors/float/vector3.js
@@ -278,6 +278,47 @@ export class Vector3 {
   }
 
   /**
+   * @param {Vector3} value
+   */
+  static serialize(value) {
+    return {
+      x: value.x,
+      y: value.y,
+      z: value.z
+    }
+  }
+
+  /**
+   * @param {Vector3Serial} value
+   * @param {Vector3} [out]
+   */
+  static deserialize(value, out = new Vector3()) {
+    out.x = value.x
+    out.y = value.y
+    out.z = value.z
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Vector3Serial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('x' in value) || !('y' in value) || !('z' in value)) {
+      return false
+    }
+
+    return typeof value.x === 'number'
+      && typeof value.y === 'number'
+      && typeof value.z === 'number'
+  }
+
+  /**
    * @param {number} scalar
    * @param {Vector3} out
    */
@@ -640,3 +681,12 @@ export class Vector3 {
    */
   static NegZ = new Vector3(0, 0, -1)
 }
+
+/**
+ * Serialized form of `Vector3`.
+ *
+* @typedef Vector3Serial
+* @property {number} x
+* @property {number} y
+* @property {number} z
+*/

--- a/src/math/core/vectors/float/vector4.js
+++ b/src/math/core/vectors/float/vector4.js
@@ -336,10 +336,10 @@ export class Vector4 {
       return false
     }
 
-    return typeof value.x === 'number'
-      && typeof value.y === 'number'
-      && typeof value.z === 'number'
-      && typeof value.w === 'number'
+    return typeof value.x === 'number' &&
+      typeof value.y === 'number' &&
+      typeof value.z === 'number' &&
+      typeof value.w === 'number'
   }
 
   /**
@@ -710,9 +710,9 @@ export class Vector4 {
 /**
  * Serialized form of `Vector4`.
  *
-* @typedef Vector4Serial
-* @property {number} x
-* @property {number} y
-* @property {number} z
-* @property {number} w
-*/
+ * @typedef Vector4Serial
+ * @property {number} x
+ * @property {number} y
+ * @property {number} z
+ * @property {number} w
+ */

--- a/src/math/core/vectors/float/vector4.js
+++ b/src/math/core/vectors/float/vector4.js
@@ -299,6 +299,50 @@ export class Vector4 {
   }
 
   /**
+   * @param {Vector4} value
+   */
+  static serialize(value) {
+    return {
+      x: value.x,
+      y: value.y,
+      z: value.z,
+      w: value.w
+    }
+  }
+
+  /**
+   * @param {Vector4Serial} value
+   * @param {Vector4} [out]
+   */
+  static deserialize(value, out = new Vector4()) {
+    out.x = value.x
+    out.y = value.y
+    out.z = value.z
+    out.w = value.w
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is Vector4Serial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('x' in value) || !('y' in value) || !('z' in value) || !('w' in value)) {
+      return false
+    }
+
+    return typeof value.x === 'number'
+      && typeof value.y === 'number'
+      && typeof value.z === 'number'
+      && typeof value.w === 'number'
+  }
+
+  /**
    * @param {number} scalar
    * @param {Vector4} out
    */
@@ -662,3 +706,13 @@ export class Vector4 {
    */
   static NegW = new Vector4(0, 0, 0, -1)
 }
+
+/**
+ * Serialized form of `Vector4`.
+ *
+* @typedef Vector4Serial
+* @property {number} x
+* @property {number} y
+* @property {number} z
+* @property {number} w
+*/

--- a/src/math/tests/affines/affine2.test.js
+++ b/src/math/tests/affines/affine2.test.js
@@ -36,6 +36,26 @@ describe("Testing `Affine2`", () => {
         deepStrictEqual(destination, source)
     })
 
+    test("`Affine2.serialize` returns an array serial", () => {
+        const affine = new Affine2(
+            1, 2, 5,
+            3, 4, 6
+        )
+
+        deepStrictEqual(Affine2.serialize(affine), [1, 3, 2, 4, 5, 6])
+        strictEqual(Affine2.validateSerial([1, 3, 2, 4, 5, 6]), true)
+    })
+
+    test("`Affine2.deserialize` reads an array serial", () => {
+        const actual = Affine2.deserialize([1, 3, 2, 4, 5, 6])
+        const expected = new Affine2(
+            1, 2, 5,
+            3, 4, 6
+        )
+
+        deepStrictEqual(actual, expected)
+    })
+
     test("`Affine2.set` sets values corrrectly", () => {
         const expected = new Affine2(
             1, 2, 5,

--- a/src/math/tests/affines/affine3.test.js
+++ b/src/math/tests/affines/affine3.test.js
@@ -45,6 +45,28 @@ describe("Testing `Affine3`", () => {
         deepStrictEqual(destination, source)
     })
 
+    test("`Affine3.serialize` returns an array serial", () => {
+        const affine = new Affine3(
+            1, 2, 3, 4,
+            5, 6, 7, 8,
+            9, 10, 11, 12
+        )
+
+        deepStrictEqual(Affine3.serialize(affine), [1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12])
+        strictEqual(Affine3.validateSerial([1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12]), true)
+    })
+
+    test("`Affine3.deserialize` reads an array serial", () => {
+        const actual = Affine3.deserialize([1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12])
+        const expected = new Affine3(
+            1, 2, 3, 4,
+            5, 6, 7, 8,
+            9, 10, 11, 12
+        )
+
+        deepStrictEqual(actual, expected)
+    })
+
     test("`Affine3.set` sets values corrrectly", () => {
         const expected = new Affine3(
             1, 2, 3, 4,

--- a/src/math/tests/matrices/matrix2.test.js
+++ b/src/math/tests/matrices/matrix2.test.js
@@ -22,6 +22,26 @@ describe("Testing `Matrix2`", () => {
         deepStrictEqual(destination, source)
     })
 
+    test("`Matrix2.serialize` returns an array serial", () => {
+        const matrix = new Matrix2(
+            1, 2,
+            3, 4
+        )
+
+        deepStrictEqual(Matrix2.serialize(matrix), [1, 3, 2, 4])
+        strictEqual(Matrix2.validateSerial([1, 3, 2, 4]), true)
+    })
+
+    test("`Matrix2.deserialize` reads an array serial", () => {
+        const actual = Matrix2.deserialize([1, 3, 2, 4])
+        const expected = new Matrix2(
+            1, 2,
+            3, 4
+        )
+
+        deepStrictEqual(actual, expected)
+    })
+
     test("`Matrix2.set` sets values corrrectly", () => {
         const expected = new Matrix2(
             1, 2,

--- a/src/math/tests/matrices/matrix3.test.js
+++ b/src/math/tests/matrices/matrix3.test.js
@@ -24,6 +24,28 @@ describe("Testing `Matrix3`", () => {
         deepStrictEqual(destination, source)
     })
 
+    test("`Matrix3.serialize` returns an array serial", () => {
+        const matrix = new Matrix3(
+            1, 2, 3,
+            4, 5, 6,
+            7, 8, 9
+        )
+
+        deepStrictEqual(Matrix3.serialize(matrix), [1, 4, 7, 2, 5, 8, 3, 6, 9])
+        strictEqual(Matrix3.validateSerial([1, 4, 7, 2, 5, 8, 3, 6, 9]), true)
+    })
+
+    test("`Matrix3.deserialize` reads an array serial", () => {
+        const actual = Matrix3.deserialize([1, 4, 7, 2, 5, 8, 3, 6, 9])
+        const expected = new Matrix3(
+            1, 2, 3,
+            4, 5, 6,
+            7, 8, 9
+        )
+
+        deepStrictEqual(actual, expected)
+    })
+
     test("`Matrix3.set` sets values corrrectly", () => {
         const expected = new Matrix3(
             1, 2, 3,

--- a/src/math/tests/matrices/matrix4.test.js
+++ b/src/math/tests/matrices/matrix4.test.js
@@ -26,6 +26,30 @@ describe("Testing `Matrix4`", () => {
         deepStrictEqual(destination, source)
     })
 
+    test("`Matrix4.serialize` returns an array serial", () => {
+        const matrix = new Matrix4(
+            1, 2, 3, 4,
+            5, 6, 7, 8,
+            9, 10, 11, 12,
+            13, 14, 15, 16
+        )
+
+        deepStrictEqual(Matrix4.serialize(matrix), [1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16])
+        strictEqual(Matrix4.validateSerial([1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16]), true)
+    })
+
+    test("`Matrix4.deserialize` reads an array serial", () => {
+        const actual = Matrix4.deserialize([1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16])
+        const expected = new Matrix4(
+            1, 2, 3, 4,
+            5, 6, 7, 8,
+            9, 10, 11, 12,
+            13, 14, 15, 16
+        )
+
+        deepStrictEqual(actual, expected)
+    })
+
     test("`Matrix4.set` sets values corrrectly", () => {
         const expected = new Matrix4(
             1, 2, 3, 4,

--- a/src/movable/components/2d/acceleration.js
+++ b/src/movable/components/2d/acceleration.js
@@ -16,4 +16,19 @@ export class Acceleration2D extends Vector2 {
   static clone(target) {
     return Acceleration2D.copy(target)
   }
+
+  /**
+   * @param {Acceleration2D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/core/vectors/float/vector2.js').Vector2Serial} value
+   * @param {Acceleration2D} [out]
+   */
+  static deserialize(value, out = new Acceleration2D()) {
+    return super.deserialize(/** @type {any} */ (value), out)
+  }
 }

--- a/src/movable/components/2d/rotation.js
+++ b/src/movable/components/2d/rotation.js
@@ -18,4 +18,19 @@ export class Rotation2D extends Angle {
   static clone(target) {
     return Rotation2D.copy(target)
   }
+
+  /**
+   * @param {Rotation2D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/core/angles/angle.js').AngleSerial} value
+   * @param {Rotation2D} [out]
+   */
+  static deserialize(value, out = new Rotation2D()) {
+    return super.deserialize(/** @type {any} */ (value), out)
+  }
 }

--- a/src/movable/components/2d/torque.js
+++ b/src/movable/components/2d/torque.js
@@ -18,4 +18,19 @@ export class Torque2D extends Angle {
   static clone(target) {
     return Torque2D.copy(target)
   }
+
+  /**
+   * @param {Torque2D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/core/angles/angle.js').AngleSerial} value
+   * @param {Torque2D} [out]
+   */
+  static deserialize(value, out = new Torque2D()) {
+    return super.deserialize(/** @type {any} */ (value), out)
+  }
 }

--- a/src/movable/components/2d/velocity.js
+++ b/src/movable/components/2d/velocity.js
@@ -16,4 +16,19 @@ export class Velocity2D extends Vector2 {
   static clone(target) {
     return Velocity2D.copy(target)
   }
+
+  /**
+   * @param {Velocity2D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/core/vectors/float/vector2.js').Vector2Serial} value
+   * @param {Velocity2D} [out]
+   */
+  static deserialize(value, out = new Velocity2D()) {
+    return super.deserialize(/** @type {any} */ (value), out)
+  }
 }

--- a/src/movable/components/3d/acceleration.js
+++ b/src/movable/components/3d/acceleration.js
@@ -16,4 +16,19 @@ export class Acceleration3D extends Vector3 {
   static clone(target) {
     return Acceleration3D.copy(target)
   }
+
+  /**
+   * @param {Acceleration3D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/core/vectors/float/vector3.js').Vector3Serial} value
+   * @param {Acceleration3D} [out]
+   */
+  static deserialize(value, out = new Acceleration3D()) {
+    return super.deserialize(/** @type {any} */ (value), out)
+  }
 }

--- a/src/movable/components/3d/rotation.js
+++ b/src/movable/components/3d/rotation.js
@@ -16,4 +16,19 @@ export class Rotation3D extends Vector3 {
   static clone(target) {
     return Rotation3D.copy(target)
   }
+
+  /**
+   * @param {Rotation3D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/core/vectors/float/vector3.js').Vector3Serial} value
+   * @param {Rotation3D} [out]
+   */
+  static deserialize(value, out = new Rotation3D()) {
+    return super.deserialize(/** @type {any} */ (value), out)
+  }
 }

--- a/src/movable/components/3d/torque.js
+++ b/src/movable/components/3d/torque.js
@@ -16,4 +16,19 @@ export class Torque3D extends Vector3 {
   static clone(target) {
     return Torque3D.copy(target)
   }
+
+  /**
+   * @param {Torque3D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/core/vectors/float/vector3.js').Vector3Serial} value
+   * @param {Torque3D} [out]
+   */
+  static deserialize(value, out = new Torque3D()) {
+    return super.deserialize(/** @type {any} */ (value), out)
+  }
 }

--- a/src/movable/components/3d/velocity.js
+++ b/src/movable/components/3d/velocity.js
@@ -16,4 +16,19 @@ export class Velocity3D extends Vector3 {
   static clone(target) {
     return Velocity3D.copy(target)
   }
+
+  /**
+   * @param {Velocity3D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/core/vectors/float/vector3.js').Vector3Serial} value
+   * @param {Velocity3D} [out]
+   */
+  static deserialize(value, out = new Velocity3D()) {
+    return super.deserialize(/** @type {any} */ (value), out)
+  }
 }

--- a/src/movable/systems/types.js
+++ b/src/movable/systems/types.js
@@ -16,22 +16,30 @@ export function registerMovable2DTypes(world) {
   }))
   registry.get(Velocity2D)?.setMethod(Velocity2D.copy)
   registry.get(Velocity2D)?.setMethod(Velocity2D.clone)
+  registry.get(Velocity2D)?.setMethod(Velocity2D.serialize)
+  registry.get(Velocity2D)?.setMethod(Velocity2D.deserialize)
   registry.register(Rotation2D, new StructInfo({
     value: new Field(typeid(Number))
   }))
   registry.get(Rotation2D)?.setMethod(Rotation2D.copy)
   registry.get(Rotation2D)?.setMethod(Rotation2D.clone)
+  registry.get(Rotation2D)?.setMethod(Rotation2D.serialize)
+  registry.get(Rotation2D)?.setMethod(Rotation2D.deserialize)
   registry.register(Acceleration2D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number))
   }))
   registry.get(Acceleration2D)?.setMethod(Acceleration2D.copy)
   registry.get(Acceleration2D)?.setMethod(Acceleration2D.clone)
+  registry.get(Acceleration2D)?.setMethod(Acceleration2D.serialize)
+  registry.get(Acceleration2D)?.setMethod(Acceleration2D.deserialize)
   registry.register(Torque2D, new StructInfo({
     value: new Field(typeid(Number))
   }))
   registry.get(Torque2D)?.setMethod(Torque2D.copy)
   registry.get(Torque2D)?.setMethod(Torque2D.clone)
+  registry.get(Torque2D)?.setMethod(Torque2D.serialize)
+  registry.get(Torque2D)?.setMethod(Torque2D.deserialize)
 }
 
 /**
@@ -47,6 +55,8 @@ export function registerMovable3DTypes(world) {
   }))
   registry.get(Velocity3D)?.setMethod(Velocity3D.copy)
   registry.get(Velocity3D)?.setMethod(Velocity3D.clone)
+  registry.get(Velocity3D)?.setMethod(Velocity3D.serialize)
+  registry.get(Velocity3D)?.setMethod(Velocity3D.deserialize)
   registry.register(Rotation3D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number)),
@@ -54,6 +64,8 @@ export function registerMovable3DTypes(world) {
   }))
   registry.get(Rotation3D)?.setMethod(Rotation3D.copy)
   registry.get(Rotation3D)?.setMethod(Rotation3D.clone)
+  registry.get(Rotation3D)?.setMethod(Rotation3D.serialize)
+  registry.get(Rotation3D)?.setMethod(Rotation3D.deserialize)
   registry.register(Acceleration3D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number)),
@@ -61,6 +73,8 @@ export function registerMovable3DTypes(world) {
   }))
   registry.get(Acceleration3D)?.setMethod(Acceleration3D.copy)
   registry.get(Acceleration3D)?.setMethod(Acceleration3D.clone)
+  registry.get(Acceleration3D)?.setMethod(Acceleration3D.serialize)
+  registry.get(Acceleration3D)?.setMethod(Acceleration3D.deserialize)
   registry.register(Torque3D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number)),
@@ -68,4 +82,6 @@ export function registerMovable3DTypes(world) {
   }))
   registry.get(Torque3D)?.setMethod(Torque3D.copy)
   registry.get(Torque3D)?.setMethod(Torque3D.clone)
+  registry.get(Torque3D)?.setMethod(Torque3D.serialize)
+  registry.get(Torque3D)?.setMethod(Torque3D.deserialize)
 }

--- a/src/name/components/name.js
+++ b/src/name/components/name.js
@@ -28,4 +28,35 @@ export class Name {
   static clone(target) {
     return Name.copy(target)
   }
+
+  /**
+   * @param {Name} value
+   * @returns {string}
+   */
+  static serialize(value) {
+    return value.value
+  }
+
+  /**
+   * @param {string} value
+   * @param {Name} [out]
+   */
+  static deserialize(value, out = new Name()) {
+    out.value = value
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is string}
+   */
+  static validateSerial(value) {
+    return  typeof value === 'string'
+  }
 }
+
+/**
+ * @typedef NameSerial
+ * @property {string} value
+ */

--- a/src/name/components/name.js
+++ b/src/name/components/name.js
@@ -52,7 +52,7 @@ export class Name {
    * @returns {value is string}
    */
   static validateSerial(value) {
-    return  typeof value === 'string'
+    return typeof value === 'string'
   }
 }
 

--- a/src/name/systems/types.js
+++ b/src/name/systems/types.js
@@ -15,4 +15,6 @@ export function registerNameTypes(world) {
   }))
   registry.get(Name)?.setMethod(Name.copy)
   registry.get(Name)?.setMethod(Name.clone)
+  registry.get(Name)?.setMethod(Name.serialize)
+  registry.get(Name)?.setMethod(Name.deserialize)
 }

--- a/src/physics/components/collider.js
+++ b/src/physics/components/collider.js
@@ -70,6 +70,56 @@ export class Collider2D {
   }
 
   /**
+   * @param {Collider2D} value
+   */
+  static serialize(value) {
+    return {
+      type: value.type,
+      angle: value.angle,
+      vertices: value.vertices.map((vertex) => Vector2.serialize(vertex)),
+      geometry: Geometry.serialize(value.geometry)
+    }
+  }
+
+  /**
+   * @param {Collider2DSerial} value
+   * @param {Collider2D} [out]
+   */
+  static deserialize(value, out = new Collider2D([])) {
+    const target = /** @type {any} */ (out)
+
+    target.type = value.type
+    target.angle = value.angle
+    target.vertices = value.vertices.map((vertex) => Vector2.deserialize(vertex))
+    target.geometry = Geometry.deserialize(value.geometry)
+
+    return out
+  }
+
+  /**
+   * @param {Collider2DSerial} value
+   * @returns {value is Collider2DSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('type' in value) || !('angle' in value) || !('vertices' in value) || !('geometry' in value)) {
+      return false
+    }
+
+    if (!Array.isArray(value.vertices)) {
+      return false
+    }
+
+    return typeof value.type === 'number'
+      && typeof value.angle === 'number'
+      && value.vertices.every((vertex) => Vector2.validateSerial(vertex))
+      && Geometry.validateSerial(value.geometry)
+  }
+
+  /**
    * @param {number} width
    * @param {number} height
    */
@@ -262,6 +312,14 @@ export class Collider2D {
 }
 
 /**
+ * @typedef Collider2DSerial
+ * @property {number} type
+ * @property {number} angle
+ * @property {import('../../math/core/vectors/float/vector2.js').Vector2Serial[]} vertices
+ * @property {import('../core/geometry.js').GeometrySerial} geometry
+ */
+
+/**
  * @param {Vector2} position
  * @param {Vector2[]} vertices
  */
@@ -275,8 +333,8 @@ function getNearVertex(position, vertices) {
     if (min > a) {
       vertex = i
       min = a
-    }
   }
+}
 
   return vertex
 }

--- a/src/physics/components/collider.js
+++ b/src/physics/components/collider.js
@@ -113,10 +113,10 @@ export class Collider2D {
       return false
     }
 
-    return typeof value.type === 'number'
-      && typeof value.angle === 'number'
-      && value.vertices.every((vertex) => Vector2.validateSerial(vertex))
-      && Geometry.validateSerial(value.geometry)
+    return typeof value.type === 'number' &&
+      typeof value.angle === 'number' &&
+      value.vertices.every((vertex) => Vector2.validateSerial(vertex)) &&
+      Geometry.validateSerial(value.geometry)
   }
 
   /**
@@ -333,8 +333,8 @@ function getNearVertex(position, vertices) {
     if (min > a) {
       vertex = i
       min = a
+    }
   }
-}
 
   return vertex
 }

--- a/src/physics/components/physicsproperties.js
+++ b/src/physics/components/physicsproperties.js
@@ -29,4 +29,75 @@ export class PhysicsProperties {
   static clone(target) {
     return PhysicsProperties.copy(target)
   }
+
+  /**
+   * @param {PhysicsProperties} value
+   */
+  static serialize(value) {
+    return {
+      invinertia: value.invinertia,
+      invmass: value.invmass,
+      mask: value.mask,
+      group: value.group,
+      sleep: value.sleep,
+      restitution: value.restitution,
+      kineticFriction: value.kineticFriction
+    }
+  }
+
+  /**
+   * @param {PhysicsPropertiesSerial} value
+   * @param {PhysicsProperties} [out]
+   */
+  static deserialize(value, out = new PhysicsProperties()) {
+    out.invinertia = value.invinertia
+    out.invmass = value.invmass
+    out.mask = value.mask
+    out.group = value.group
+    out.sleep = value.sleep
+    out.restitution = value.restitution
+    out.kineticFriction = value.kineticFriction
+
+    return out
+  }
+
+  /**
+   * @param {PhysicsPropertiesSerial} value
+   * @returns {value is PhysicsPropertiesSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('invinertia' in value)
+      || !('invmass' in value)
+      || !('mask' in value)
+      || !('group' in value)
+      || !('sleep' in value)
+      || !('restitution' in value)
+      || !('kineticFriction' in value)
+    ) {
+      return false
+    }
+
+    return typeof value.invinertia === 'number'
+      && typeof value.invmass === 'number'
+      && typeof value.mask === 'bigint'
+      && typeof value.group === 'bigint'
+      && typeof value.sleep === 'boolean'
+      && typeof value.restitution === 'number'
+      && typeof value.kineticFriction === 'number'
+  }
 }
+
+/**
+ * @typedef PhysicsPropertiesSerial
+ * @property {number} invinertia
+ * @property {number} invmass
+ * @property {bigint} mask
+ * @property {bigint} group
+ * @property {boolean} sleep
+ * @property {number} restitution
+ * @property {number} kineticFriction
+ */

--- a/src/physics/components/physicsproperties.js
+++ b/src/physics/components/physicsproperties.js
@@ -70,24 +70,24 @@ export class PhysicsProperties {
       return false
     }
 
-    if (!('invinertia' in value)
-      || !('invmass' in value)
-      || !('mask' in value)
-      || !('group' in value)
-      || !('sleep' in value)
-      || !('restitution' in value)
-      || !('kineticFriction' in value)
+    if (!('invinertia' in value) ||
+      !('invmass' in value) ||
+      !('mask' in value) ||
+      !('group' in value) ||
+      !('sleep' in value) ||
+      !('restitution' in value) ||
+      !('kineticFriction' in value)
     ) {
       return false
     }
 
-    return typeof value.invinertia === 'number'
-      && typeof value.invmass === 'number'
-      && typeof value.mask === 'bigint'
-      && typeof value.group === 'bigint'
-      && typeof value.sleep === 'boolean'
-      && typeof value.restitution === 'number'
-      && typeof value.kineticFriction === 'number'
+    return typeof value.invinertia === 'number' &&
+      typeof value.invmass === 'number' &&
+      typeof value.mask === 'bigint' &&
+      typeof value.group === 'bigint' &&
+      typeof value.sleep === 'boolean' &&
+      typeof value.restitution === 'number' &&
+      typeof value.kineticFriction === 'number'
   }
 }
 

--- a/src/physics/components/softbody.js
+++ b/src/physics/components/softbody.js
@@ -14,6 +14,21 @@ export class SoftBody2D {
   static clone(target) {
     return SoftBody2D.copy(target)
   }
+
+  /**
+   * @param {SoftBody2D} _value
+   */
+  static serialize(_value) {
+    return {}
+  }
+
+  /**
+   * @param {unknown} _value
+   * @param {SoftBody2D} [out]
+   */
+  static deserialize(_value, out = new SoftBody2D()) {
+    return out
+  }
 }
 
 export class SoftBody3D {
@@ -31,5 +46,20 @@ export class SoftBody3D {
    */
   static clone(target) {
     return SoftBody3D.copy(target)
+  }
+
+  /**
+   * @param {SoftBody3D} _value
+   */
+  static serialize(_value) {
+    return {}
+  }
+
+  /**
+   * @param {unknown} _value
+   * @param {SoftBody3D} [out]
+   */
+  static deserialize(_value, out = new SoftBody3D()) {
+    return out
   }
 }

--- a/src/physics/core/geometry.js
+++ b/src/physics/core/geometry.js
@@ -30,6 +30,47 @@ export class Geometry {
   }
 
   /**
+   * @param {Geometry} value
+   */
+  static serialize(value) {
+    return {
+      vertices: value.vertices.map((vertex) => Vector2.serialize(vertex))
+    }
+  }
+
+  /**
+   * @param {GeometrySerial} value
+   * @param {Geometry} [out]
+   */
+  static deserialize(value, out = new Geometry([])) {
+    out.vertices = value.vertices.map((vertex) => Vector2.deserialize(vertex))
+    out.normals = Geometry.calcFaceNormals(out.vertices)
+    out.dynNormals = out.normals.map((vertex) => Vector2.copy(vertex))
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is GeometrySerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('vertices' in value)) {
+      return false
+    }
+
+    if (!Array.isArray(value.vertices)) {
+      return false
+    }
+
+    return value.vertices.every((vertex) => Vector2.validateSerial(vertex))
+  }
+
+  /**
    * @param {Geometry} geometry
    * @param {number} angle
    * @param {Vector2[]} out
@@ -89,6 +130,11 @@ export class Geometry {
     }
   }
 }
+
+/**
+ * @typedef GeometrySerial
+ * @property {import('../../math/core/vectors/float/vector2.js').Vector2Serial[]} vertices
+ */
 
 /**
  * @param {Vector2} axis

--- a/src/physics/systems/types.js
+++ b/src/physics/systems/types.js
@@ -28,6 +28,8 @@ export function registerPhysicsTypes(world) {
   }))
   registry.get(Collider2D)?.setMethod(Collider2D.copy)
   registry.get(Collider2D)?.setMethod(Collider2D.clone)
+  registry.get(Collider2D)?.setMethod(Collider2D.serialize)
+  registry.get(Collider2D)?.setMethod(Collider2D.deserialize)
   registry.register(PhysicsProperties, new StructInfo({
     invinertia: new Field(typeid(Number)),
     invmass: new Field(typeid(Number)),
@@ -39,10 +41,16 @@ export function registerPhysicsTypes(world) {
   }))
   registry.get(PhysicsProperties)?.setMethod(PhysicsProperties.copy)
   registry.get(PhysicsProperties)?.setMethod(PhysicsProperties.clone)
+  registry.get(PhysicsProperties)?.setMethod(PhysicsProperties.serialize)
+  registry.get(PhysicsProperties)?.setMethod(PhysicsProperties.deserialize)
   registry.register(SoftBody2D, new StructInfo({}))
   registry.get(SoftBody2D)?.setMethod(SoftBody2D.copy)
   registry.get(SoftBody2D)?.setMethod(SoftBody2D.clone)
+  registry.get(SoftBody2D)?.setMethod(SoftBody2D.serialize)
+  registry.get(SoftBody2D)?.setMethod(SoftBody2D.deserialize)
   registry.register(SoftBody3D, new StructInfo({}))
   registry.get(SoftBody3D)?.setMethod(SoftBody3D.copy)
   registry.get(SoftBody3D)?.setMethod(SoftBody3D.clone)
+  registry.get(SoftBody3D)?.setMethod(SoftBody3D.serialize)
+  registry.get(SoftBody3D)?.setMethod(SoftBody3D.deserialize)
 }

--- a/src/profiler/resources/profiler.js
+++ b/src/profiler/resources/profiler.js
@@ -36,8 +36,8 @@ export class Profile {
       return false
     }
 
-    return typeof value.lastTick === 'number'
-      && typeof value.delta === 'number'
+    return typeof value.lastTick === 'number' &&
+      typeof value.delta === 'number'
   }
 }
 

--- a/src/profiler/resources/profiler.js
+++ b/src/profiler/resources/profiler.js
@@ -1,6 +1,44 @@
 export class Profile {
   lastTick = 0
   delta = 0
+
+  /**
+   * @param {Profile} value
+   */
+  static serialize(value) {
+    return {
+      lastTick: value.lastTick,
+      delta: value.delta
+    }
+  }
+
+  /**
+   * @param {ProfileSerial} value
+   * @param {Profile} [out]
+   */
+  static deserialize(value, out = new Profile()) {
+    out.lastTick = value.lastTick
+    out.delta = value.delta
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is ProfileSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('lastTick' in value) || !('delta' in value)) {
+      return false
+    }
+
+    return typeof value.lastTick === 'number'
+      && typeof value.delta === 'number'
+  }
 }
 
 export class Profiler {
@@ -49,4 +87,73 @@ export class Profiler {
 
     profile.delta = performance.now() - profile.lastTick
   }
+
+  /**
+   * @param {Profiler} value
+   */
+  static serialize(value) {
+    return {
+      profiles: Array.from(value.profiles.entries()).map(([label, profile]) => [
+        label,
+        Profile.serialize(profile)
+      ])
+    }
+  }
+
+  /**
+   * @param {ProfilerSerial} value
+   * @param {Profiler} [out]
+   */
+  static deserialize(value, out = new Profiler()) {
+    out.profiles = new Map(
+      value.profiles.map(([label, profile]) => [label, Profile.deserialize(profile)])
+    )
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is ProfilerSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('profiles' in value)) {
+      return false
+    }
+
+    if (!Array.isArray(value.profiles)) {
+      return false
+    }
+
+    for (let i = 0; i < value.profiles.length; i++) {
+      const entry = value.profiles[i]
+
+      if (!Array.isArray(entry) || entry.length !== 2) {
+        return false
+      }
+
+      const [label, profile] = entry
+
+      if (typeof label !== 'string' || !Profile.validateSerial(profile)) {
+        return false
+      }
+    }
+
+    return true
+  }
 }
+
+/**
+ * @typedef ProfileSerial
+ * @property {number} lastTick
+ * @property {number} delta
+ */
+
+/**
+ * @typedef ProfilerSerial
+ * @property {[string, ProfileSerial][]} profiles
+ */

--- a/src/profiler/systems/types.js
+++ b/src/profiler/systems/types.js
@@ -14,12 +14,16 @@ export function registerProfilerTypes(world) {
     lastTick: new Field(typeid(Number)),
     delta: new Field(typeid(Number))
   }))
+  registry.get(Profile)?.setMethod(Profile.serialize)
+  registry.get(Profile)?.setMethod(Profile.deserialize)
   const profileMapId = typeidGeneric(Map, [String, Profile])
 
   registry.registerTypeId(profileMapId, new MapInfo(typeid(String), typeid(Profile)))
   registry.register(Profiler, new StructInfo({
     profiles: new Field(profileMapId)
   }))
+  registry.get(Profiler)?.setMethod(Profiler.serialize)
+  registry.get(Profiler)?.setMethod(Profiler.deserialize)
   registry.register(ProfilerTimer, new StructInfo({
 
     // TODO: add a shared helper for enum type ids to avoid setTypeId string literals.
@@ -28,4 +32,6 @@ export function registerProfilerTypes(world) {
     speed: new Field(typeid(Number)),
     paused: new Field(typeid(Boolean))
   }))
+  registry.get(ProfilerTimer)?.setMethod(ProfilerTimer.serialize)
+  registry.get(ProfilerTimer)?.setMethod(ProfilerTimer.deserialize)
 }

--- a/src/render-core/assets/image.js
+++ b/src/render-core/assets/image.js
@@ -27,4 +27,48 @@ export class Image {
 
     return new Image(array, new Vector2(1, 1))
   }
+
+  /**
+   * @param {Image} value
+   */
+  static serialize(value) {
+    return {
+      raw: Array.from(value.raw),
+      dimensions: Vector2.serialize(value.dimensions)
+    }
+  }
+
+  /**
+   * @param {ImageSerial} value
+   * @param {Image} [out]
+   */
+  static deserialize(value, out = Image.default()) {
+    out.raw = new Uint8ClampedArray(value.raw)
+    out.dimensions = Vector2.deserialize(value.dimensions, out.dimensions)
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is ImageSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('raw' in value) || !('dimensions' in value)) {
+      return false
+    }
+
+    return Array.isArray(value.raw)
+      && Vector2.validateSerial(value.dimensions)
+  }
 }
+
+/**
+ * @typedef ImageSerial
+ * @property {number[]} raw
+ * @property {import('../../math/core/vectors/float/vector2.js').Vector2Serial} dimensions
+ */

--- a/src/render-core/assets/image.js
+++ b/src/render-core/assets/image.js
@@ -62,8 +62,8 @@ export class Image {
       return false
     }
 
-    return Array.isArray(value.raw)
-      && Vector2.validateSerial(value.dimensions)
+    return Array.isArray(value.raw) &&
+      Vector2.validateSerial(value.dimensions)
   }
 }
 

--- a/src/render-core/assets/material.js
+++ b/src/render-core/assets/material.js
@@ -17,6 +17,21 @@ export class Material {
   static default() {
     return new Material()
   }
+
+  /**
+   * @param {Material} _value
+   */
+  static serialize(_value) {
+    return {}
+  }
+
+  /**
+   * @param {unknown} _value
+   * @param {Material} [out]
+   */
+  static deserialize(_value, out = new Material()) {
+    return out
+  }
 }
 
 export default {}

--- a/src/render-core/assets/materials/basic.js
+++ b/src/render-core/assets/materials/basic.js
@@ -25,9 +25,49 @@ export class BasicMaterial extends Material {
   static default() {
     return new BasicMaterial()
   }
+
+  /**
+   * @param {BasicMaterial} value
+   */
+  static serialize(value) {
+    return {
+      color: Color.serialize(value.color)
+    }
+  }
+
+  /**
+   * @param {BasicMaterialSerial} value
+   * @param {BasicMaterial} [out]
+   */
+  static deserialize(value, out = new BasicMaterial()) {
+    out.color = Color.deserialize(value.color, out.color)
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is BasicMaterialSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('color' in value)) {
+      return false
+    }
+
+    return Color.validateSerial(value.color)
+  }
 }
 
 /**
  * @typedef BasicMaterialOptions
  * @property {Color} [color]
+ */
+
+/**
+ * @typedef BasicMaterialSerial
+ * @property {import('../../../color/core/color.js').ColorSerial} color
  */

--- a/src/render-core/assets/mesh.js
+++ b/src/render-core/assets/mesh.js
@@ -65,6 +65,32 @@ export class Mesh {
   }
 
   /**
+   * @param {Mesh} value
+   */
+  static serialize(value) {
+    return {
+      indices: value.indices ? Array.from(value.indices) : undefined,
+      attributes: Array.from(value.attributes.entries()).map(([name, attribute]) => [
+        name,
+        MeshAttributeData.serialize(attribute)
+      ])
+    }
+  }
+
+  /**
+   * @param {MeshSerial} value
+   * @param {Mesh} [out]
+   */
+  static deserialize(value, out = new Mesh()) {
+    out.indices = value.indices ? new Uint16Array(value.indices) : undefined
+    out.attributes = new Map(
+      value.attributes.map(([name, attribute]) => [name, MeshAttributeData.deserialize(attribute)])
+    )
+
+    return out
+  }
+
+  /**
    * @param {number} width
    * @param {number} height
    * @returns {Mesh}
@@ -820,3 +846,9 @@ export class Mesh {
     return new Mesh()
   }
 }
+
+/**
+ * @typedef MeshSerial
+ * @property {number[] | undefined} indices
+ * @property {[string, import('../core/attributedata.js').MeshAttributeDataSerial][]} attributes
+ */

--- a/src/render-core/assets/shader.js
+++ b/src/render-core/assets/shader.js
@@ -24,4 +24,50 @@ export class Shader {
   static default() {
     return new Shader(ShaderStage.Fragment, '')
   }
+
+  /**
+   * @param {Shader} value
+   */
+  static serialize(value) {
+    return {
+      stage: value.stage,
+      source: value.source
+    }
+  }
+
+  /**
+   * @param {ShaderSerial} value
+   * @param {Shader} [out]
+   */
+  static deserialize(value, out = Shader.default()) {
+    const target = /** @type {any} */ (out)
+
+    target.stage = value.stage
+    target.source = value.source
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is ShaderSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('stage' in value) || !('source' in value)) {
+      return false
+    }
+
+    return typeof value.stage === 'number'
+      && typeof value.source === 'string'
+  }
 }
+
+/**
+ * @typedef ShaderSerial
+ * @property {number} stage
+ * @property {string} source
+ */

--- a/src/render-core/assets/shader.js
+++ b/src/render-core/assets/shader.js
@@ -61,8 +61,8 @@ export class Shader {
       return false
     }
 
-    return typeof value.stage === 'number'
-      && typeof value.source === 'string'
+    return typeof value.stage === 'number' &&
+      typeof value.source === 'string'
   }
 }
 

--- a/src/render-core/components/camera.js
+++ b/src/render-core/components/camera.js
@@ -48,10 +48,11 @@ export class Camera {
    * @param {Camera} value
    */
   static serialize(value) {
-    const projection = value.projection instanceof OrthographicProjection?
-    OrthographicProjection.serialize(value.projection):
+    const projection = value.projection instanceof OrthographicProjection ?
+      OrthographicProjection.serialize(value.projection) :
+
     // @ts-ignore
-    PerspectiveProjection.serialize(value.projection)
+      PerspectiveProjection.serialize(value.projection)
 
     return {
       projection,

--- a/src/render-core/components/camera.js
+++ b/src/render-core/components/camera.js
@@ -43,7 +43,50 @@ export class Camera {
   static clone(target) {
     return Camera.copy(target)
   }
+
+  /**
+   * @param {Camera} value
+   */
+  static serialize(value) {
+    const projection = value.projection instanceof OrthographicProjection?
+    OrthographicProjection.serialize(value.projection):
+    // @ts-ignore
+    PerspectiveProjection.serialize(value.projection)
+
+    return {
+      projection,
+      near: value.near,
+      far: value.far
+    }
+  }
+
+  /**
+   * @param {CameraSerial} value
+   * @param {Camera} [out]
+   */
+  static deserialize(value, out = new Camera()) {
+    if (value.projection.type === 'perspective') {
+      out.projection = PerspectiveProjection.deserialize(value.projection)
+    } else if (value.projection.type === 'orthographic') {
+      out.projection = OrthographicProjection.deserialize(value.projection)
+    } else {
+      out.projection = new PerspectiveProjection()
+    }
+
+    out.near = value.near
+    out.far = value.far
+
+    return out
+  }
   projectionMatrix() {
     return this.projection.asProjectionMatrix(this.near, this.far)
   }
 }
+
+/**
+ * @typedef CameraSerial
+ * @property {import('../core/projection.js').ProjectionSerial} projection
+ * @property {number} near
+ * @property {number} far
+ * @property {string} projectionType
+ */

--- a/src/render-core/components/materials/index.js
+++ b/src/render-core/components/materials/index.js
@@ -1,6 +1,7 @@
 import { BasicMaterial } from '../../assets/index.js'
 import { Material2D, Material3D } from '../material.js'
-import { HandleSnapshot } from '../../../asset/index.js'
+import { Handle, HandleSnapshot } from '../../../asset/index.js'
+import { typeid } from '../../../type/index.js'
 
 /**
  * @augments Material2D<BasicMaterial>
@@ -70,12 +71,12 @@ export class BasicMaterial3D extends Material3D {
 export class BasicMaterial2DSnapshot {
 
   /**
-   * @type {HandleSnapshot<BasicMaterial>}
+   * @type {HandleSnapshot}
    */
   handle
 
   /**
-   * @param {HandleSnapshot<BasicMaterial>} handle
+   * @param {HandleSnapshot} handle
    */
   constructor(handle) {
     this.handle = handle
@@ -86,7 +87,26 @@ export class BasicMaterial2DSnapshot {
    * @returns {BasicMaterial2D}
    */
   fromSnapshot(world) {
-    return new BasicMaterial2D(this.handle.fromSnapshot(world))
+    return new BasicMaterial2D(/**@type {Handle<BasicMaterial>} */(this.handle.fromSnapshot(world)))
+  }
+
+  /**
+   * @param {BasicMaterial2DSnapshot} value
+   */
+  static serialize(value) {
+    return {
+      handle: HandleSnapshot.serialize(value.handle)
+    }
+  }
+
+  /**
+   * @param {BasicMaterial2DSnapshotSerial} value
+   * @param {BasicMaterial2DSnapshot} [out]
+   */
+  static deserialize(value, out = new BasicMaterial2DSnapshot(new HandleSnapshot(typeid(Object),''))) {
+    out.handle = HandleSnapshot.deserialize(value.handle, out.handle)
+
+    return out
   }
 }
 
@@ -96,12 +116,12 @@ export class BasicMaterial2DSnapshot {
 export class BasicMaterial3DSnapshot {
 
   /**
-   * @type {HandleSnapshot<BasicMaterial>}
+   * @type {HandleSnapshot}
    */
   handle
 
   /**
-   * @param {HandleSnapshot<BasicMaterial>} handle
+   * @param {HandleSnapshot} handle
    */
   constructor(handle) {
     this.handle = handle
@@ -112,6 +132,35 @@ export class BasicMaterial3DSnapshot {
    * @returns {BasicMaterial3D}
    */
   fromSnapshot(world) {
-    return new BasicMaterial3D(this.handle.fromSnapshot(world))
+    return new BasicMaterial3D(/**@type {Handle<BasicMaterial>} */(this.handle.fromSnapshot(world)))
+  }
+
+  /**
+   * @param {BasicMaterial3DSnapshot} value
+   */
+  static serialize(value) {
+    return {
+      handle: HandleSnapshot.serialize(value.handle)
+    }
+  }
+
+  /**
+   * @param {BasicMaterial3DSnapshotSerial} value
+   * @param {BasicMaterial3DSnapshot} [out]
+   */
+  static deserialize(value, out = new BasicMaterial3DSnapshot(new HandleSnapshot(typeid(Object),''))) {
+    out.handle = HandleSnapshot.deserialize(value.handle, out.handle)
+
+    return out
   }
 }
+
+/**
+ * @typedef BasicMaterial2DSnapshotSerial
+ * @property {import('../../../asset/core/handle.js').HandleSnapshotSerial} handle
+ */
+
+/**
+ * @typedef BasicMaterial3DSnapshotSerial
+ * @property {import('../../../asset/core/handle.js').HandleSnapshotSerial} handle
+ */

--- a/src/render-core/components/materials/index.js
+++ b/src/render-core/components/materials/index.js
@@ -87,7 +87,7 @@ export class BasicMaterial2DSnapshot {
    * @returns {BasicMaterial2D}
    */
   fromSnapshot(world) {
-    return new BasicMaterial2D(/**@type {Handle<BasicMaterial>} */(this.handle.fromSnapshot(world)))
+    return new BasicMaterial2D(/** @type {Handle<BasicMaterial>} */(this.handle.fromSnapshot(world)))
   }
 
   /**
@@ -103,7 +103,7 @@ export class BasicMaterial2DSnapshot {
    * @param {BasicMaterial2DSnapshotSerial} value
    * @param {BasicMaterial2DSnapshot} [out]
    */
-  static deserialize(value, out = new BasicMaterial2DSnapshot(new HandleSnapshot(typeid(Object),''))) {
+  static deserialize(value, out = new BasicMaterial2DSnapshot(new HandleSnapshot(typeid(Object), ''))) {
     out.handle = HandleSnapshot.deserialize(value.handle, out.handle)
 
     return out
@@ -132,7 +132,7 @@ export class BasicMaterial3DSnapshot {
    * @returns {BasicMaterial3D}
    */
   fromSnapshot(world) {
-    return new BasicMaterial3D(/**@type {Handle<BasicMaterial>} */(this.handle.fromSnapshot(world)))
+    return new BasicMaterial3D(/** @type {Handle<BasicMaterial>} */(this.handle.fromSnapshot(world)))
   }
 
   /**
@@ -148,7 +148,7 @@ export class BasicMaterial3DSnapshot {
    * @param {BasicMaterial3DSnapshotSerial} value
    * @param {BasicMaterial3DSnapshot} [out]
    */
-  static deserialize(value, out = new BasicMaterial3DSnapshot(new HandleSnapshot(typeid(Object),''))) {
+  static deserialize(value, out = new BasicMaterial3DSnapshot(new HandleSnapshot(typeid(Object), ''))) {
     out.handle = HandleSnapshot.deserialize(value.handle, out.handle)
 
     return out

--- a/src/render-core/components/mesh.js
+++ b/src/render-core/components/mesh.js
@@ -1,4 +1,5 @@
 import { Handle, HandleSnapshot } from '../../asset/index.js'
+import { typeid } from '../../type/index.js'
 import { Mesh } from '../assets/index.js'
 
 export class Meshed {
@@ -47,12 +48,12 @@ export class Meshed {
 export class MeshedSnapshot {
 
   /**
-   * @type {HandleSnapshot<Mesh>}
+   * @type {HandleSnapshot}
    */
   handle
 
   /**
-   * @param {HandleSnapshot<Mesh>} handle
+   * @param {HandleSnapshot} handle
    */
   constructor(handle) {
     this.handle = handle
@@ -63,6 +64,30 @@ export class MeshedSnapshot {
    * @returns {Meshed}
    */
   fromSnapshot(world) {
-    return new Meshed(this.handle.fromSnapshot(world))
+    return new Meshed(/**@type {Handle<Mesh>} */(this.handle.fromSnapshot(world)))
+  }
+
+  /**
+   * @param {MeshedSnapshot} value
+   */
+  static serialize(value) {
+    return {
+      handle: HandleSnapshot.serialize(value.handle)
+    }
+  }
+
+  /**
+   * @param {MeshedSnapshotSerial} value
+   * @param {MeshedSnapshot} [out]
+   */
+  static deserialize(value, out = new MeshedSnapshot(new HandleSnapshot(typeid(Object),''))) {
+    out.handle = HandleSnapshot.deserialize(value.handle, out.handle)
+
+    return out
   }
 }
+
+/**
+ * @typedef MeshedSnapshotSerial
+ * @property {import('../../asset/core/handle.js').HandleSnapshotSerial} handle
+ */

--- a/src/render-core/components/mesh.js
+++ b/src/render-core/components/mesh.js
@@ -64,7 +64,7 @@ export class MeshedSnapshot {
    * @returns {Meshed}
    */
   fromSnapshot(world) {
-    return new Meshed(/**@type {Handle<Mesh>} */(this.handle.fromSnapshot(world)))
+    return new Meshed(/** @type {Handle<Mesh>} */(this.handle.fromSnapshot(world)))
   }
 
   /**
@@ -80,7 +80,7 @@ export class MeshedSnapshot {
    * @param {MeshedSnapshotSerial} value
    * @param {MeshedSnapshot} [out]
    */
-  static deserialize(value, out = new MeshedSnapshot(new HandleSnapshot(typeid(Object),''))) {
+  static deserialize(value, out = new MeshedSnapshot(new HandleSnapshot(typeid(Object), ''))) {
     out.handle = HandleSnapshot.deserialize(value.handle, out.handle)
 
     return out

--- a/src/render-core/components/renderlists.js
+++ b/src/render-core/components/renderlists.js
@@ -91,6 +91,21 @@ export class RenderLists2D extends RenderLists {
   static clone(target) {
     return RenderLists2D.copy(target)
   }
+
+  /**
+   * @param {RenderLists2D} _value
+   */
+  static serialize(_value) {
+    return {}
+  }
+
+  /**
+   * @param {unknown} _value
+   * @param {RenderLists2D} [out]
+   */
+  static deserialize(_value, out = new RenderLists2D()) {
+    return out
+  }
 }
 
 /**
@@ -113,5 +128,20 @@ export class RenderLists3D extends RenderLists {
    */
   static clone(target) {
     return RenderLists3D.copy(target)
+  }
+
+  /**
+   * @param {RenderLists3D} _value
+   */
+  static serialize(_value) {
+    return {}
+  }
+
+  /**
+   * @param {unknown} _value
+   * @param {RenderLists3D} [out]
+   */
+  static deserialize(_value, out = new RenderLists3D()) {
+    return out
   }
 }

--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -79,10 +79,10 @@ export class MeshAttribute {
       return false
     }
 
-    return typeof value.name === 'string'
-      && typeof value.id === 'number'
-      && typeof value.type === 'number'
-      && typeof value.size === 'number'
+    return typeof value.name === 'string' &&
+      typeof value.id === 'number' &&
+      typeof value.type === 'number' &&
+      typeof value.size === 'number'
   }
 
   static Position2D = new MeshAttribute(

--- a/src/render-core/core/attribute.js
+++ b/src/render-core/core/attribute.js
@@ -39,6 +39,52 @@ export class MeshAttribute {
     this.size = size
   }
 
+  /**
+   * @param {MeshAttribute} value
+   */
+  static serialize(value) {
+    return {
+      name: value.name,
+      id: value.id,
+      type: value.type,
+      size: value.size
+    }
+  }
+
+  /**
+   * @param {MeshAttributeSerial} value
+   * @param {MeshAttribute} [out]
+   */
+  static deserialize(value, out = new MeshAttribute('', 0, 0, 0)) {
+    const target = /** @type {any} */ (out)
+
+    target.name = value.name
+    target.id = value.id
+    target.type = value.type
+    target.size = value.size
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is MeshAttributeSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('name' in value) || !('id' in value) || !('type' in value) || !('size' in value)) {
+      return false
+    }
+
+    return typeof value.name === 'string'
+      && typeof value.id === 'number'
+      && typeof value.type === 'number'
+      && typeof value.size === 'number'
+  }
+
   static Position2D = new MeshAttribute(
     'position2d',
     0,
@@ -102,3 +148,11 @@ export class MeshAttribute {
     4
   )
 }
+
+/**
+ * @typedef MeshAttributeSerial
+ * @property {string} name
+ * @property {number} id
+ * @property {number} type
+ * @property {number} size
+ */

--- a/src/render-core/core/attributedata.js
+++ b/src/render-core/core/attributedata.js
@@ -11,4 +11,44 @@ export class MeshAttributeData {
   constructor(data) {
     this.data = data
   }
+
+  /**
+   * @param {MeshAttributeData} value
+   */
+  static serialize(value) {
+    return {
+      data: Array.from(value.data)
+    }
+  }
+
+  /**
+   * @param {MeshAttributeDataSerial} value
+   * @param {MeshAttributeData} [out]
+   */
+  static deserialize(value, out = new MeshAttributeData(new Float32Array())) {
+    out.data = new Float32Array(value.data)
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is MeshAttributeDataSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('data' in value)) {
+      return false
+    }
+
+    return Array.isArray(value.data)
+  }
 }
+
+/**
+ * @typedef MeshAttributeDataSerial
+ * @property {number[]} data
+ */

--- a/src/render-core/core/projection.js
+++ b/src/render-core/core/projection.js
@@ -161,9 +161,9 @@ export class PerspectiveProjection extends Projection {
       return false
     }
 
-    return value.type === 'perspective'
-      && typeof value.fov === 'number'
-      && typeof value.aspect === 'number'
+    return value.type === 'perspective' &&
+      typeof value.fov === 'number' &&
+      typeof value.aspect === 'number'
   }
 }
 
@@ -278,11 +278,11 @@ export class OrthographicProjection extends Projection {
       return false
     }
 
-    return value.type === 'orthographic'
-      && typeof value.left === 'number'
-      && typeof value.right === 'number'
-      && typeof value.top === 'number'
-      && typeof value.bottom === 'number'
+    return value.type === 'orthographic' &&
+      typeof value.left === 'number' &&
+      typeof value.right === 'number' &&
+      typeof value.top === 'number' &&
+      typeof value.bottom === 'number'
   }
 }
 

--- a/src/render-core/core/projection.js
+++ b/src/render-core/core/projection.js
@@ -24,6 +24,21 @@ export class Projection {
   isOrthographic() {
     return false
   }
+
+  /**
+   * @param {unknown} _value
+   */
+  static serialize(_value) {
+    return {}
+  }
+
+  /**
+   * @param {unknown} _value
+   * @param {Projection} [out]
+   */
+  static deserialize(_value, out = new Projection()) {
+    return out
+  }
 }
 
 export class PerspectiveProjection extends Projection {
@@ -110,6 +125,46 @@ export class PerspectiveProjection extends Projection {
 
     return out
   }
+
+  /**
+   * @param {PerspectiveProjection} value
+   */
+  static serialize(value) {
+    return {
+      type: 'perspective',
+      fov: value.fov,
+      aspect: value.aspect
+    }
+  }
+
+  /**
+   * @param {PerspectiveProjectionSerial} value
+   * @param {PerspectiveProjection} [out]
+   */
+  static deserialize(value, out = new PerspectiveProjection()) {
+    out.fov = value.fov
+    out.aspect = value.aspect
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is PerspectiveProjectionSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('type' in value) || !('fov' in value) || !('aspect' in value)) {
+      return false
+    }
+
+    return value.type === 'perspective'
+      && typeof value.fov === 'number'
+      && typeof value.aspect === 'number'
+  }
 }
 
 export class OrthographicProjection extends Projection {
@@ -183,7 +238,69 @@ export class OrthographicProjection extends Projection {
 
     return out
   }
+
+  /**
+   * @param {OrthographicProjection} value
+   */
+  static serialize(value) {
+    return {
+      type: 'orthographic',
+      left: value.left,
+      right: value.right,
+      top: value.top,
+      bottom: value.bottom
+    }
+  }
+
+  /**
+   * @param {OrthographicProjectionSerial} value
+   * @param {OrthographicProjection} [out]
+   */
+  static deserialize(value, out = new OrthographicProjection()) {
+    out.left = value.left
+    out.right = value.right
+    out.top = value.top
+    out.bottom = value.bottom
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is OrthographicProjectionSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('type' in value) || !('left' in value) || !('right' in value) || !('top' in value) || !('bottom' in value)) {
+      return false
+    }
+
+    return value.type === 'orthographic'
+      && typeof value.left === 'number'
+      && typeof value.right === 'number'
+      && typeof value.top === 'number'
+      && typeof value.bottom === 'number'
+  }
 }
+
+/**
+ * @typedef PerspectiveProjectionSerial
+ * @property {'perspective'} type
+ * @property {number} fov
+ * @property {number} aspect
+ */
+
+/**
+ * @typedef OrthographicProjectionSerial
+ * @property {'orthographic'} type
+ * @property {number} left
+ * @property {number} right
+ * @property {number} top
+ * @property {number} bottom
+ */
 
 /**
  * @readonly
@@ -193,3 +310,7 @@ export const ProjectionType = {
   Perspective: 0,
   Orthographic: 1
 }
+
+/**
+ * @typedef {PerspectiveProjectionSerial | OrthographicProjectionSerial} ProjectionSerial
+ */

--- a/src/render-core/systems/types.js
+++ b/src/render-core/systems/types.js
@@ -29,21 +29,31 @@ export function registerRenderCoreTypes(world) {
   registry.register(MeshAttributeData, new StructInfo({
     data: new Field(typeid(Float32Array))
   }))
+  registry.get(MeshAttributeData)?.setMethod(MeshAttributeData.serialize)
+  registry.get(MeshAttributeData)?.setMethod(MeshAttributeData.deserialize)
   registry.register(Image, new StructInfo({
     raw: new Field(typeid(Uint8ClampedArray)),
     dimensions: new Field(typeid(Vector2))
   }))
+  registry.get(Image)?.setMethod(Image.serialize)
+  registry.get(Image)?.setMethod(Image.deserialize)
   registry.register(Mesh, new StructInfo({
     indices: new Field(typeid(Uint16Array), true),
     attributes: new Field(meshAttributeMapId)
   }))
+  registry.get(Mesh)?.setMethod(Mesh.serialize)
+  registry.get(Mesh)?.setMethod(Mesh.deserialize)
   registry.register(Shader, new StructInfo({
     stage: new Field(shaderStageId),
     source: new Field(typeid(String))
   }))
+  registry.get(Shader)?.setMethod(Shader.serialize)
+  registry.get(Shader)?.setMethod(Shader.deserialize)
   registry.register(BasicMaterial, new StructInfo({
     color: new Field(typeid(Color))
   }))
+  registry.get(BasicMaterial)?.setMethod(BasicMaterial.serialize)
+  registry.get(BasicMaterial)?.setMethod(BasicMaterial.deserialize)
   registry.register(Meshed, new StructInfo({
     handle: new Field(typeidGeneric(Handle, [Mesh]))
   }))
@@ -53,6 +63,8 @@ export function registerRenderCoreTypes(world) {
   registry.register(MeshedSnapshot, new StructInfo({
     handle: new Field(typeid(HandleSnapshot))
   }))
+  registry.get(MeshedSnapshot)?.setMethod(MeshedSnapshot.serialize)
+  registry.get(MeshedSnapshot)?.setMethod(MeshedSnapshot.deserialize)
   registry.get(MeshedSnapshot)?.setMethod(MeshedSnapshot.prototype.fromSnapshot)
   registry.register(BasicMaterial2D, new StructInfo({
     handle: new Field(basicMaterialHandleId)
@@ -63,6 +75,8 @@ export function registerRenderCoreTypes(world) {
   registry.register(BasicMaterial2DSnapshot, new StructInfo({
     handle: new Field(typeid(HandleSnapshot))
   }))
+  registry.get(BasicMaterial2DSnapshot)?.setMethod(BasicMaterial2DSnapshot.serialize)
+  registry.get(BasicMaterial2DSnapshot)?.setMethod(BasicMaterial2DSnapshot.deserialize)
   registry.get(BasicMaterial2DSnapshot)?.setMethod(BasicMaterial2DSnapshot.prototype.fromSnapshot)
   registry.register(BasicMaterial3D, new StructInfo({
     handle: new Field(basicMaterialHandleId)
@@ -73,6 +87,8 @@ export function registerRenderCoreTypes(world) {
   registry.register(BasicMaterial3DSnapshot, new StructInfo({
     handle: new Field(typeid(HandleSnapshot))
   }))
+  registry.get(BasicMaterial3DSnapshot)?.setMethod(BasicMaterial3DSnapshot.serialize)
+  registry.get(BasicMaterial3DSnapshot)?.setMethod(BasicMaterial3DSnapshot.deserialize)
   registry.get(BasicMaterial3DSnapshot)?.setMethod(BasicMaterial3DSnapshot.prototype.fromSnapshot)
   registry.register(Camera, new StructInfo({
     projection: new Field(typeid(Projection)),
@@ -81,14 +97,20 @@ export function registerRenderCoreTypes(world) {
   }))
   registry.get(Camera)?.setMethod(Camera.copy)
   registry.get(Camera)?.setMethod(Camera.clone)
+  registry.get(Camera)?.setMethod(Camera.serialize)
+  registry.get(Camera)?.setMethod(Camera.deserialize)
 
   registry.register(RenderLists2D, new OpaqueInfo())
   registry.get(RenderLists2D)?.setMethod(RenderLists2D.copy)
   registry.get(RenderLists2D)?.setMethod(RenderLists2D.clone)
+  registry.get(RenderLists2D)?.setMethod(RenderLists2D.serialize)
+  registry.get(RenderLists2D)?.setMethod(RenderLists2D.deserialize)
 
   registry.register(RenderLists3D, new OpaqueInfo())
   registry.get(RenderLists3D)?.setMethod(RenderLists3D.copy)
   registry.get(RenderLists3D)?.setMethod(RenderLists3D.clone)
+  registry.get(RenderLists3D)?.setMethod(RenderLists3D.serialize)
+  registry.get(RenderLists3D)?.setMethod(RenderLists3D.deserialize)
 }
 
 /**
@@ -118,6 +140,12 @@ export function registerMaterialTypes(component, material) {
     }
     if ('clone' in component && typeof component.clone === 'function') {
       registry.get(component)?.setMethod(component.clone)
+    }
+    if ('serialize' in component && typeof component.serialize === 'function') {
+      registry.get(component)?.setMethod(component.serialize)
+    }
+    if ('deserialize' in component && typeof component.deserialize === 'function') {
+      registry.get(component)?.setMethod(component.deserialize)
     }
   }
 }

--- a/src/render-webgl/resources/clearcolor.js
+++ b/src/render-webgl/resources/clearcolor.js
@@ -4,4 +4,19 @@ export class ClearColor extends Color {
   constructor() {
     super(0, 0, 0)
   }
+
+  /**
+   * @param {ClearColor} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../color/index.js').ColorSerial} value
+   * @param {ClearColor} [out]
+   */
+  static deserialize(value, out = new ClearColor()) {
+    return super.deserialize(value, out)
+  }
 }

--- a/src/render-webgl/systems/types.js
+++ b/src/render-webgl/systems/types.js
@@ -24,6 +24,8 @@ export function registerWebglTypes(world) {
     type: new Field(typeid(Number)),
     size: new Field(typeid(Number))
   }))
+  registry.get(MeshAttribute)?.setMethod(MeshAttribute.serialize)
+  registry.get(MeshAttribute)?.setMethod(MeshAttribute.deserialize)
   registry.register(WebglRenderPipeline, new StructInfo({
     program: new Field(webglProgramId)
   }))
@@ -37,6 +39,8 @@ export function registerWebglTypes(world) {
     b: new Field(typeid(Number)),
     a: new Field(typeid(Number))
   }))
+  registry.get(ClearColor)?.setMethod(ClearColor.serialize)
+  registry.get(ClearColor)?.setMethod(ClearColor.deserialize)
   registry.register(AttributeMap, new MapInfo(typeid(String), typeid(MeshAttribute)))
   registry.register(WebglProgramCache, new MapInfo(typeid(String), typeid(WebglRenderPipeline)))
 }

--- a/src/scene/components/instance.js
+++ b/src/scene/components/instance.js
@@ -70,7 +70,7 @@ export class SceneInstanceSnapshot {
    * @returns {SceneInstance}
    */
   fromSnapshot(world) {
-    return new SceneInstance(/**@type {Handle<Scene>} */(this.handle.fromSnapshot(world)))
+    return new SceneInstance(/** @type {Handle<Scene>} */(this.handle.fromSnapshot(world)))
   }
 
   /**
@@ -86,7 +86,7 @@ export class SceneInstanceSnapshot {
    * @param {SceneInstanceSnapshotSerial} value
    * @param {SceneInstanceSnapshot} [out]
    */
-  static deserialize(value, out = new SceneInstanceSnapshot(new HandleSnapshot(typeid(Object),''))) {
+  static deserialize(value, out = new SceneInstanceSnapshot(new HandleSnapshot(typeid(Object), ''))) {
     out.handle = HandleSnapshot.deserialize(value.handle, out.handle)
 
     return out

--- a/src/scene/components/instance.js
+++ b/src/scene/components/instance.js
@@ -1,6 +1,7 @@
 /** @import { EntityId } from '../../ecs/index.js' */
 /** @import { Scene } from "../assets/scene.js" */
 import { Handle, HandleSnapshot } from '../../asset/index.js'
+import { typeid } from '../../type/index.js'
 
 export class SceneInstance {
 
@@ -53,12 +54,12 @@ export class SceneInstance {
 export class SceneInstanceSnapshot {
 
   /**
-   * @type {HandleSnapshot<Scene>}
+   * @type {HandleSnapshot}
    */
   handle
 
   /**
-   * @param {HandleSnapshot<Scene>} handle
+   * @param {HandleSnapshot} handle
    */
   constructor(handle) {
     this.handle = handle
@@ -69,6 +70,46 @@ export class SceneInstanceSnapshot {
    * @returns {SceneInstance}
    */
   fromSnapshot(world) {
-    return new SceneInstance(this.handle.fromSnapshot(world))
+    return new SceneInstance(/**@type {Handle<Scene>} */(this.handle.fromSnapshot(world)))
+  }
+
+  /**
+   * @param {SceneInstanceSnapshot} value
+   */
+  static serialize(value) {
+    return {
+      handle: HandleSnapshot.serialize(value.handle)
+    }
+  }
+
+  /**
+   * @param {SceneInstanceSnapshotSerial} value
+   * @param {SceneInstanceSnapshot} [out]
+   */
+  static deserialize(value, out = new SceneInstanceSnapshot(new HandleSnapshot(typeid(Object),''))) {
+    out.handle = HandleSnapshot.deserialize(value.handle, out.handle)
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is SceneInstanceSnapshotSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('handle' in value)) {
+      return false
+    }
+
+    return HandleSnapshot.validateSerial(value.handle)
   }
 }
+
+/**
+ * @typedef SceneInstanceSnapshotSerial
+ * @property {import('../../asset/core/handle.js').HandleSnapshotSerial} handle
+ */

--- a/src/scene/systems/types.js
+++ b/src/scene/systems/types.js
@@ -20,5 +20,7 @@ export function registerSceneTypes(world) {
   registry.register(SceneInstanceSnapshot, new StructInfo({
     handle: new Field(typeid(HandleSnapshot))
   }))
+  registry.get(SceneInstanceSnapshot)?.setMethod(SceneInstanceSnapshot.serialize)
+  registry.get(SceneInstanceSnapshot)?.setMethod(SceneInstanceSnapshot.deserialize)
   registry.get(SceneInstanceSnapshot)?.setMethod(SceneInstanceSnapshot.prototype.fromSnapshot)
 }

--- a/src/time/clock.js
+++ b/src/time/clock.js
@@ -108,4 +108,34 @@ export class Clock {
 
     return clock.delta
   }
+
+  /**
+   * @param {Clock} value
+   */
+  static serialize(value) {
+    return {
+      elapsed: value.elapsed,
+      lastTick: value.lastTick,
+      delta: value.delta
+    }
+  }
+
+  /**
+   * @param {ClockSerial} value
+   * @param {Clock} [out]
+   */
+  static deserialize(value, out = new Clock()) {
+    out.elapsed = value.elapsed
+    out.lastTick = value.lastTick
+    out.delta = value.delta
+
+    return out
+  }
 }
+
+/**
+ * @typedef ClockSerial
+ * @property {number} elapsed
+ * @property {number} lastTick
+ * @property {number} delta
+ */

--- a/src/time/components/timer.js
+++ b/src/time/components/timer.js
@@ -108,6 +108,82 @@ export class Timer {
     return Timer.copy(target)
   }
 
+  /**
+   * @param {Timer} value
+   */
+  static serialize(value) {
+    return {
+      mode: value.mode,
+      duration: value.duration,
+      speed: value.speed,
+      paused: value.paused,
+      elapsedCount: value.elapsedCount,
+      elapsedTime: value.elapsedTime,
+      finished: value.finished,
+      startTicks: value.startTicks,
+      endTicks: value.endTicks,
+      playbackRequested: value.playbackRequested,
+      playbackResolved: value.playbackResolved
+    }
+  }
+
+  /**
+   * @param {TimerSerial} value
+   * @param {Timer} [out]
+   */
+  static deserialize(value, out = new Timer()) {
+    out.mode = value.mode
+    out.duration = value.duration
+    out.speed = value.speed
+    out.paused = value.paused
+    out.elapsedCount = value.elapsedCount
+    out.elapsedTime = value.elapsedTime
+    out.finished = value.finished
+    out.startTicks = value.startTicks
+    out.endTicks = value.endTicks
+    out.playbackRequested = value.playbackRequested
+    out.playbackResolved = value.playbackResolved
+
+    return out
+  }
+
+  /**
+   * @param {TimerSerial} value
+   * @returns {value is TimerSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('mode' in value)
+      || !('duration' in value)
+      || !('speed' in value)
+      || !('paused' in value)
+      || !('elapsedCount' in value)
+      || !('elapsedTime' in value)
+      || !('finished' in value)
+      || !('startTicks' in value)
+      || !('endTicks' in value)
+      || !('playbackRequested' in value)
+      || !('playbackResolved' in value)
+    ) {
+      return false
+    }
+
+    return typeof value.mode === 'number'
+      && typeof value.duration === 'number'
+      && typeof value.speed === 'number'
+      && typeof value.paused === 'boolean'
+      && typeof value.elapsedCount === 'number'
+      && typeof value.elapsedTime === 'number'
+      && typeof value.finished === 'boolean'
+      && typeof value.startTicks === 'number'
+      && typeof value.endTicks === 'number'
+      && typeof value.playbackRequested === 'boolean'
+      && typeof value.playbackResolved === 'boolean'
+  }
+
   elapsed() {
     return this.elapsedTime
   }
@@ -233,6 +309,21 @@ export class Timer {
     return this.finished
   }
 }
+
+/**
+ * @typedef TimerSerial
+ * @property {TimerMode} mode
+ * @property {number} duration
+ * @property {number} speed
+ * @property {boolean} paused
+ * @property {number} elapsedCount
+ * @property {number} elapsedTime
+ * @property {boolean} finished
+ * @property {number} startTicks
+ * @property {number} endTicks
+ * @property {boolean} playbackRequested
+ * @property {boolean} playbackResolved
+ */
 
 /**
  * @readonly

--- a/src/time/components/timer.js
+++ b/src/time/components/timer.js
@@ -156,32 +156,32 @@ export class Timer {
       return false
     }
 
-    if (!('mode' in value)
-      || !('duration' in value)
-      || !('speed' in value)
-      || !('paused' in value)
-      || !('elapsedCount' in value)
-      || !('elapsedTime' in value)
-      || !('finished' in value)
-      || !('startTicks' in value)
-      || !('endTicks' in value)
-      || !('playbackRequested' in value)
-      || !('playbackResolved' in value)
+    if (!('mode' in value) ||
+      !('duration' in value) ||
+      !('speed' in value) ||
+      !('paused' in value) ||
+      !('elapsedCount' in value) ||
+      !('elapsedTime' in value) ||
+      !('finished' in value) ||
+      !('startTicks' in value) ||
+      !('endTicks' in value) ||
+      !('playbackRequested' in value) ||
+      !('playbackResolved' in value)
     ) {
       return false
     }
 
-    return typeof value.mode === 'number'
-      && typeof value.duration === 'number'
-      && typeof value.speed === 'number'
-      && typeof value.paused === 'boolean'
-      && typeof value.elapsedCount === 'number'
-      && typeof value.elapsedTime === 'number'
-      && typeof value.finished === 'boolean'
-      && typeof value.startTicks === 'number'
-      && typeof value.endTicks === 'number'
-      && typeof value.playbackRequested === 'boolean'
-      && typeof value.playbackResolved === 'boolean'
+    return typeof value.mode === 'number' &&
+      typeof value.duration === 'number' &&
+      typeof value.speed === 'number' &&
+      typeof value.paused === 'boolean' &&
+      typeof value.elapsedCount === 'number' &&
+      typeof value.elapsedTime === 'number' &&
+      typeof value.finished === 'boolean' &&
+      typeof value.startTicks === 'number' &&
+      typeof value.endTicks === 'number' &&
+      typeof value.playbackRequested === 'boolean' &&
+      typeof value.playbackResolved === 'boolean'
   }
 
   elapsed() {

--- a/src/time/resource/virtualclock.js
+++ b/src/time/resource/virtualclock.js
@@ -1,3 +1,18 @@
 import { Clock } from '../clock.js'
 
-export class VirtualClock extends Clock { }
+export class VirtualClock extends Clock {
+  /**
+   * @param {Clock} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../clock.js').ClockSerial} value
+   * @param {VirtualClock} [out]
+   */
+  static deserialize(value, out = new VirtualClock()) {
+    return super.deserialize(value, out)
+  }
+}

--- a/src/time/resource/virtualclock.js
+++ b/src/time/resource/virtualclock.js
@@ -1,6 +1,7 @@
 import { Clock } from '../clock.js'
 
 export class VirtualClock extends Clock {
+
   /**
    * @param {Clock} value
    */

--- a/src/time/systems/types.js
+++ b/src/time/systems/types.js
@@ -25,14 +25,20 @@ export function registerTimeTypes(world) {
   }))
   registry.get(Timer)?.setMethod(Timer.copy)
   registry.get(Timer)?.setMethod(Timer.clone)
+  registry.get(Timer)?.setMethod(Timer.serialize)
+  registry.get(Timer)?.setMethod(Timer.deserialize)
   registry.register(Clock, new StructInfo({
     elapsed: new Field(typeid(Number)),
     lastTick: new Field(typeid(Number)),
     delta: new Field(typeid(Number))
   }))
+  registry.get(Clock)?.setMethod(Clock.serialize)
+  registry.get(Clock)?.setMethod(Clock.deserialize)
   registry.register(VirtualClock, new StructInfo({
     elapsed: new Field(typeid(Number)),
     lastTick: new Field(typeid(Number)),
     delta: new Field(typeid(Number))
   }))
+  registry.get(VirtualClock)?.setMethod(VirtualClock.serialize)
+  registry.get(VirtualClock)?.setMethod(VirtualClock.deserialize)
 }

--- a/src/transform/components/2d/globaltransform.js
+++ b/src/transform/components/2d/globaltransform.js
@@ -16,4 +16,19 @@ export class GlobalTransform2D extends Affine2 {
   static clone(target) {
     return GlobalTransform2D.copy(target)
   }
+
+  /**
+   * @param {GlobalTransform2D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/index.js').Affine2Serial} value
+   * @param {GlobalTransform2D} [out]
+   */
+  static deserialize(value, out = new GlobalTransform2D()) {
+    return super.deserialize(value, out)
+  }
 }

--- a/src/transform/components/2d/orientation.js
+++ b/src/transform/components/2d/orientation.js
@@ -16,4 +16,19 @@ export class Orientation2D extends Rotary {
   static clone(target) {
     return Orientation2D.copy(target)
   }
+
+  /**
+   * @param {Orientation2D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/index.js').RotarySerial} value
+   * @param {Orientation2D} [out]
+   */
+  static deserialize(value, out = new Orientation2D()) {
+    return super.deserialize(value, out)
+  }
 }

--- a/src/transform/components/2d/position.js
+++ b/src/transform/components/2d/position.js
@@ -16,4 +16,19 @@ export class Position2D extends Vector2 {
   static clone(target) {
     return Position2D.copy(target)
   }
+
+  /**
+   * @param {Position2D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/index.js').Vector2Serial} value
+   * @param {Position2D} [out]
+   */
+  static deserialize(value, out = new Position2D()) {
+    return super.deserialize(value, out)
+  }
 }

--- a/src/transform/components/2d/remote.js
+++ b/src/transform/components/2d/remote.js
@@ -78,27 +78,27 @@ export class RemoteTransform2D {
       return false
     }
 
-    if (!('copyTranslation' in value)
-      || !('copyOrientation' in value)
-      || !('copyScale' in value)
-      || !('entity' in value)
-      || !('offsetTransform' in value)
+    if (!('copyTranslation' in value) ||
+      !('copyOrientation' in value) ||
+      !('copyScale' in value) ||
+      !('entity' in value) ||
+      !('offsetTransform' in value)
     ) {
       return false
     }
 
-    return typeof value.copyTranslation === 'boolean'
-      && typeof value.copyOrientation === 'boolean'
-      && typeof value.copyScale === 'boolean'
-      && Entity.validateSerial(value.entity)
-      && Affine2.validateSerial(value.offsetTransform)
+    return typeof value.copyTranslation === 'boolean' &&
+      typeof value.copyOrientation === 'boolean' &&
+      typeof value.copyScale === 'boolean' &&
+      Entity.validateSerial(value.entity) &&
+      Affine2.validateSerial(value.offsetTransform)
   }
 
   /**
    * @param {RemoteTransform2DSerial} value
    * @param {RemoteTransform2D} [out]
    */
-  static deserialize(value, out = new RemoteTransform2D(new Entity(0,0))) {
+  static deserialize(value, out = new RemoteTransform2D(new Entity(0, 0))) {
     out.copyTranslation = value.copyTranslation
     out.copyOrientation = value.copyOrientation
     out.copyScale = value.copyScale

--- a/src/transform/components/2d/remote.js
+++ b/src/transform/components/2d/remote.js
@@ -55,4 +55,67 @@ export class RemoteTransform2D {
   static clone(target) {
     return RemoteTransform2D.copy(target)
   }
+
+  /**
+   * @param {RemoteTransform2D} value
+   */
+  static serialize(value) {
+    return {
+      copyTranslation: value.copyTranslation,
+      copyOrientation: value.copyOrientation,
+      copyScale: value.copyScale,
+      entity: Entity.serialize(value.entity),
+      offsetTransform: Affine2.serialize(value.offsetTransform)
+    }
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is RemoteTransform2DSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('copyTranslation' in value)
+      || !('copyOrientation' in value)
+      || !('copyScale' in value)
+      || !('entity' in value)
+      || !('offsetTransform' in value)
+    ) {
+      return false
+    }
+
+    return typeof value.copyTranslation === 'boolean'
+      && typeof value.copyOrientation === 'boolean'
+      && typeof value.copyScale === 'boolean'
+      && Entity.validateSerial(value.entity)
+      && Affine2.validateSerial(value.offsetTransform)
+  }
+
+  /**
+   * @param {RemoteTransform2DSerial} value
+   * @param {RemoteTransform2D} [out]
+   */
+  static deserialize(value, out = new RemoteTransform2D(new Entity(0,0))) {
+    out.copyTranslation = value.copyTranslation
+    out.copyOrientation = value.copyOrientation
+    out.copyScale = value.copyScale
+    out.entity = Entity.deserialize(value.entity, out.entity)
+    out.offsetTransform = Affine2.deserialize(value.offsetTransform, out.offsetTransform)
+
+    return out
+  }
 }
+
+/**
+ * Serialized form of `RemoteTransform2D`.
+ *
+ * @typedef RemoteTransform2DSerial
+ * @property {boolean} copyTranslation
+ * @property {boolean} copyOrientation
+ * @property {boolean} copyScale
+ * @property {any} entity
+ * @property {any} offsetTransform
+ */

--- a/src/transform/components/2d/scale.js
+++ b/src/transform/components/2d/scale.js
@@ -19,4 +19,19 @@ export class Scale2D extends Vector2 {
   static clone(target) {
     return Scale2D.copy(target)
   }
+
+  /**
+   * @param {Scale2D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/index.js').Vector2Serial} value
+   * @param {Scale2D} [out]
+   */
+  static deserialize(value, out = new Scale2D()) {
+    return super.deserialize(value, out)
+  }
 }

--- a/src/transform/components/3d/globaltransform.js
+++ b/src/transform/components/3d/globaltransform.js
@@ -16,4 +16,19 @@ export class GlobalTransform3D extends Affine3 {
   static clone(target) {
     return GlobalTransform3D.copy(target)
   }
+
+  /**
+   * @param {GlobalTransform3D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/index.js').Affine3Serial} value
+   * @param {GlobalTransform3D} [out]
+   */
+  static deserialize(value, out = new GlobalTransform3D()) {
+    return super.deserialize(value, out)
+  }
 }

--- a/src/transform/components/3d/orientation.js
+++ b/src/transform/components/3d/orientation.js
@@ -16,4 +16,19 @@ export class Orientation3D extends Quaternion {
   static clone(target) {
     return Orientation3D.copy(target)
   }
+
+  /**
+   * @param {Orientation3D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/index.js').QuaternionSerial} value
+   * @param {Orientation3D} [out]
+   */
+  static deserialize(value, out = new Orientation3D()) {
+    return super.deserialize(value, out)
+  }
 }

--- a/src/transform/components/3d/position.js
+++ b/src/transform/components/3d/position.js
@@ -16,4 +16,19 @@ export class Position3D extends Vector3 {
   static clone(target) {
     return Position3D.copy(target)
   }
+
+  /**
+   * @param {Position3D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/index.js').Vector3Serial} value
+   * @param {Position3D} [out]
+   */
+  static deserialize(value, out = new Position3D()) {
+    return super.deserialize(value, out)
+  }
 }

--- a/src/transform/components/3d/remote.js
+++ b/src/transform/components/3d/remote.js
@@ -55,4 +55,67 @@ export class RemoteTransform3D {
   static clone(target) {
     return RemoteTransform3D.copy(target)
   }
+
+  /**
+   * @param {RemoteTransform3D} value
+   */
+  static serialize(value) {
+    return {
+      copyTranslation: value.copyTranslation,
+      copyOrientation: value.copyOrientation,
+      copyScale: value.copyScale,
+      entity: Entity.serialize(value.entity),
+      offsetTransform: Affine3.serialize(value.offsetTransform)
+    }
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is RemoteTransform3DSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('copyTranslation' in value)
+      || !('copyOrientation' in value)
+      || !('copyScale' in value)
+      || !('entity' in value)
+      || !('offsetTransform' in value)
+    ) {
+      return false
+    }
+
+    return typeof value.copyTranslation === 'boolean'
+      && typeof value.copyOrientation === 'boolean'
+      && typeof value.copyScale === 'boolean'
+      && Entity.validateSerial(value.entity)
+      && Affine3.validateSerial(value.offsetTransform)
+  }
+
+  /**
+   * @param {RemoteTransform3DSerial} value
+   * @param {RemoteTransform3D} [out]
+   */
+  static deserialize(value, out = new RemoteTransform3D(new Entity(0,0))) {
+    out.copyTranslation = value.copyTranslation
+    out.copyOrientation = value.copyOrientation
+    out.copyScale = value.copyScale
+    out.entity = Entity.deserialize(value.entity, out.entity)
+    out.offsetTransform = Affine3.deserialize(value.offsetTransform, out.offsetTransform)
+
+    return out
+  }
 }
+
+/**
+ * Serialized form of `RemoteTransform3D`.
+ *
+ * @typedef RemoteTransform3DSerial
+ * @property {boolean} copyTranslation
+ * @property {boolean} copyOrientation
+ * @property {boolean} copyScale
+ * @property {any} entity
+ * @property {any} offsetTransform
+ */

--- a/src/transform/components/3d/remote.js
+++ b/src/transform/components/3d/remote.js
@@ -78,27 +78,27 @@ export class RemoteTransform3D {
       return false
     }
 
-    if (!('copyTranslation' in value)
-      || !('copyOrientation' in value)
-      || !('copyScale' in value)
-      || !('entity' in value)
-      || !('offsetTransform' in value)
+    if (!('copyTranslation' in value) ||
+      !('copyOrientation' in value) ||
+      !('copyScale' in value) ||
+      !('entity' in value) ||
+      !('offsetTransform' in value)
     ) {
       return false
     }
 
-    return typeof value.copyTranslation === 'boolean'
-      && typeof value.copyOrientation === 'boolean'
-      && typeof value.copyScale === 'boolean'
-      && Entity.validateSerial(value.entity)
-      && Affine3.validateSerial(value.offsetTransform)
+    return typeof value.copyTranslation === 'boolean' &&
+      typeof value.copyOrientation === 'boolean' &&
+      typeof value.copyScale === 'boolean' &&
+      Entity.validateSerial(value.entity) &&
+      Affine3.validateSerial(value.offsetTransform)
   }
 
   /**
    * @param {RemoteTransform3DSerial} value
    * @param {RemoteTransform3D} [out]
    */
-  static deserialize(value, out = new RemoteTransform3D(new Entity(0,0))) {
+  static deserialize(value, out = new RemoteTransform3D(new Entity(0, 0))) {
     out.copyTranslation = value.copyTranslation
     out.copyOrientation = value.copyOrientation
     out.copyScale = value.copyScale

--- a/src/transform/components/3d/scale.js
+++ b/src/transform/components/3d/scale.js
@@ -20,4 +20,19 @@ export class Scale3D extends Vector3 {
   static clone(target) {
     return Scale3D.copy(target)
   }
+
+  /**
+   * @param {Scale3D} value
+   */
+  static serialize(value) {
+    return super.serialize(value)
+  }
+
+  /**
+   * @param {import('../../../math/index.js').Vector3Serial} value
+   * @param {Scale3D} [out]
+   */
+  static deserialize(value, out = new Scale3D()) {
+    return super.deserialize(value, out)
+  }
 }

--- a/src/transform/systems/types.js
+++ b/src/transform/systems/types.js
@@ -28,18 +28,24 @@ export function registerTransform2DTypes(world) {
   }))
   registry.get(Position2D)?.setMethod(Position2D.copy)
   registry.get(Position2D)?.setMethod(Position2D.clone)
+  registry.get(Position2D)?.setMethod(Position2D.serialize)
+  registry.get(Position2D)?.setMethod(Position2D.deserialize)
   registry.register(Orientation2D, new StructInfo({
     cos: new Field(typeid(Number)),
     sin: new Field(typeid(Number))
   }))
   registry.get(Orientation2D)?.setMethod(Orientation2D.copy)
   registry.get(Orientation2D)?.setMethod(Orientation2D.clone)
+  registry.get(Orientation2D)?.setMethod(Orientation2D.serialize)
+  registry.get(Orientation2D)?.setMethod(Orientation2D.deserialize)
   registry.register(Scale2D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number))
   }))
   registry.get(Scale2D)?.setMethod(Scale2D.copy)
   registry.get(Scale2D)?.setMethod(Scale2D.clone)
+  registry.get(Scale2D)?.setMethod(Scale2D.serialize)
+  registry.get(Scale2D)?.setMethod(Scale2D.deserialize)
   registry.register(GlobalTransform2D, new StructInfo({
     a: new Field(typeid(Number)),
     b: new Field(typeid(Number)),
@@ -50,6 +56,8 @@ export function registerTransform2DTypes(world) {
   }))
   registry.get(GlobalTransform2D)?.setMethod(GlobalTransform2D.copy)
   registry.get(GlobalTransform2D)?.setMethod(GlobalTransform2D.clone)
+  registry.get(GlobalTransform2D)?.setMethod(GlobalTransform2D.serialize)
+  registry.get(GlobalTransform2D)?.setMethod(GlobalTransform2D.deserialize)
 }
 
 /**
@@ -65,6 +73,8 @@ export function registerTransform3DTypes(world) {
   }))
   registry.get(Position3D)?.setMethod(Position3D.copy)
   registry.get(Position3D)?.setMethod(Position3D.clone)
+  registry.get(Position3D)?.setMethod(Position3D.serialize)
+  registry.get(Position3D)?.setMethod(Position3D.deserialize)
   registry.register(Orientation3D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number)),
@@ -73,6 +83,8 @@ export function registerTransform3DTypes(world) {
   }))
   registry.get(Orientation3D)?.setMethod(Orientation3D.copy)
   registry.get(Orientation3D)?.setMethod(Orientation3D.clone)
+  registry.get(Orientation3D)?.setMethod(Orientation3D.serialize)
+  registry.get(Orientation3D)?.setMethod(Orientation3D.deserialize)
   registry.register(Scale3D, new StructInfo({
     x: new Field(typeid(Number)),
     y: new Field(typeid(Number)),
@@ -80,6 +92,8 @@ export function registerTransform3DTypes(world) {
   }))
   registry.get(Scale3D)?.setMethod(Scale3D.copy)
   registry.get(Scale3D)?.setMethod(Scale3D.clone)
+  registry.get(Scale3D)?.setMethod(Scale3D.serialize)
+  registry.get(Scale3D)?.setMethod(Scale3D.deserialize)
   registry.register(GlobalTransform3D, new StructInfo({
     a: new Field(typeid(Number)),
     b: new Field(typeid(Number)),
@@ -96,6 +110,8 @@ export function registerTransform3DTypes(world) {
   }))
   registry.get(GlobalTransform3D)?.setMethod(GlobalTransform3D.copy)
   registry.get(GlobalTransform3D)?.setMethod(GlobalTransform3D.clone)
+  registry.get(GlobalTransform3D)?.setMethod(GlobalTransform3D.serialize)
+  registry.get(GlobalTransform3D)?.setMethod(GlobalTransform3D.deserialize)
 }
 
 /**
@@ -113,6 +129,8 @@ export function registerRemoteTransform2DTypes(world) {
   }))
   registry.get(RemoteTransform2D)?.setMethod(RemoteTransform2D.copy)
   registry.get(RemoteTransform2D)?.setMethod(RemoteTransform2D.clone)
+  registry.get(RemoteTransform2D)?.setMethod(RemoteTransform2D.serialize)
+  registry.get(RemoteTransform2D)?.setMethod(RemoteTransform2D.deserialize)
 }
 
 /**
@@ -130,4 +148,6 @@ export function registerRemoteTransform3DTypes(world) {
   }))
   registry.get(RemoteTransform3D)?.setMethod(RemoteTransform3D.copy)
   registry.get(RemoteTransform3D)?.setMethod(RemoteTransform3D.clone)
+  registry.get(RemoteTransform3D)?.setMethod(RemoteTransform3D.serialize)
+  registry.get(RemoteTransform3D)?.setMethod(RemoteTransform3D.deserialize)
 }

--- a/src/tween/components/tween.js
+++ b/src/tween/components/tween.js
@@ -60,7 +60,7 @@ export class Tween {
    * @param {Tween<U>} source
    * @param {Tween<U>} target
    */
-  static copy(source, target = new this(source.to, source.from, source.duration, source.repeat, source.flip, source.easing)) {
+  static copy(source, target = new Tween(source.to, source.from, source.duration, source.repeat, source.flip, source.easing)) {
     const cloneValue = (/** @type {U} */ value) => {
       if (!value || typeof value !== 'object') {
         return value

--- a/src/window/components/main.js
+++ b/src/window/components/main.js
@@ -14,4 +14,19 @@ export class MainWindow {
   static clone(target) {
     return MainWindow.copy(target)
   }
+
+  /**
+   * @param {MainWindow} _value
+   */
+  static serialize(_value) {
+    return {}
+  }
+
+  /**
+   * @param {unknown} _value
+   * @param {MainWindow} [out]
+   */
+  static deserialize(_value, out = new MainWindow()) {
+    return out
+  }
 }

--- a/src/window/components/window.js
+++ b/src/window/components/window.js
@@ -46,6 +46,31 @@ export class Window {
   }
 
   /**
+   * @param {Window} value
+   */
+  static serialize(value) {
+    return {
+      width: value.width,
+      height: value.height,
+      selector: value.selector
+    }
+  }
+
+  /**
+   * @param {WindowSerial} value
+   * @param {Window} [out]
+   */
+  static deserialize(value, out = new Window()) {
+    const target = /** @type {any} */ (out)
+
+    target.width = value.width
+    target.height = value.height
+    target.selector = value.selector
+
+    return out
+  }
+
+  /**
    * Returns width of the window.
    *
    * @returns {number}
@@ -72,6 +97,13 @@ export class Window {
     this.height = height
   }
 }
+
+/**
+ * @typedef WindowSerial
+ * @property {number} width
+ * @property {number} height
+ * @property {string | undefined} selector
+ */
 
 /**
  * @typedef WindowOptions

--- a/src/window/systems/types.js
+++ b/src/window/systems/types.js
@@ -27,9 +27,13 @@ export function registerWindowTypes(world) {
   }))
   registry.get(Window)?.setMethod(Window.copy)
   registry.get(Window)?.setMethod(Window.clone)
+  registry.get(Window)?.setMethod(Window.serialize)
+  registry.get(Window)?.setMethod(Window.deserialize)
   registry.register(MainWindow, new StructInfo({}))
   registry.get(MainWindow)?.setMethod(MainWindow.copy)
   registry.get(MainWindow)?.setMethod(MainWindow.clone)
+  registry.get(MainWindow)?.setMethod(MainWindow.serialize)
+  registry.get(MainWindow)?.setMethod(MainWindow.deserialize)
   registry.register(Windows, new StructInfo({
     entities: new Field(entityWindowMapId)
   }))


### PR DESCRIPTION
# PR Description

## Objective

Introduces a standardized serialization/deserialization system across the engine, enabling persistence, snapshotting and future scene/state saving support.

## Solution

This expands the engine type system by implementing serialization support for a large number of engine primitives and registering those methods inside the runtime type registry.

### Root Cause

The engine previously lacked a unified mechanism for converting runtime objects into serializable formats and reconstructing them later.

This prevented:

* Scene persistence
* Runtime snapshotting
* State restoration
* Asset handle reconstruction after serialization
* Generic object transfer/storage across systems

### Changes Made

The following changes were introduced:

* Added `serialize()` methods to core engine structures
* Added `deserialize()` methods for reconstructing objects from serialized state
* Added `validateSerial()` methods for runtime type validation
* Registered serialization/deserialization methods in the type registry system
* Refactored asset snapshot handling for safer untyped asset restoration
* Updated dependency `vifaa` to support serialization efforts

### Why This Approach

This solution was chosen because:

* It provides a consistent serialization contract across all engine types
* It integrates directly with the existing runtime type registry
* It allows generic serialization without requiring per-system special handling
* It prepares the engine for scene saving/loading and state persistence systems

Alternative approaches such as external serializers or reflection-based serialization were avoided because they reduce control over engine-specific reconstruction logic.

### Notes

* Serialization format differs per type depending on storage efficiency requirements
* Runtime type registry now supports serialize/deserialize method dispatch dynamically

## Showcase

Demonstrate how objects can now be persisted and reconstructed.

### Before

```js
const player = new AnimationPlayer()

// No standardized way to save runtime state
```

### After

```js
const player = new AnimationPlayer()

const data = AnimationPlayer.serialize(player)

// Persist to storage / transfer over network

const restored = AnimationPlayer.deserialize(data)
```

## Migration Guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
