### PR TITLE
Fix scene relationship mapping

### DIFF
--- a/examples/samples/scene/2d/load_json.js
+++ b/examples/samples/scene/2d/load_json.js
@@ -6,6 +6,7 @@ import {
   BasicMaterialAssets,
   Canvas2DRendererPlugin,
   Color,
+  createTransform2D,
   DefaultPlugin,
   DOMWindowPlugin,
   EntityCommands,
@@ -65,6 +66,7 @@ function init(world) {
   commands
     .spawn()
     .insertPrefab([
+      ...createTransform2D(),
       new SceneInstance(sceneHandle)
     ])
     .build()

--- a/src/hierarchy/systems/types.js
+++ b/src/hierarchy/systems/types.js
@@ -21,6 +21,8 @@ export function registerHierarchyTypes(world) {
   registry.get(Children)?.setMethod(Children.clone)
   registry.get(Children)?.setMethod(Children.serialize)
   registry.get(Children)?.setMethod(Children.deserialize)
+  registry.get(Children)?.setMethod(Children.prototype.visit)
+  registry.get(Children)?.setMethod(Children.prototype.map)
   registry.register(Parent, new StructInfo({
     entity: new Field(typeid(Entity))
   }))
@@ -28,4 +30,6 @@ export function registerHierarchyTypes(world) {
   registry.get(Parent)?.setMethod(Parent.clone)
   registry.get(Parent)?.setMethod(Parent.serialize)
   registry.get(Parent)?.setMethod(Parent.deserialize)
+  registry.get(Parent)?.setMethod(Parent.prototype.visit)
+  registry.get(Parent)?.setMethod(Parent.prototype.map)
 }

--- a/src/scene/assets/scene.js
+++ b/src/scene/assets/scene.js
@@ -69,25 +69,41 @@ export class Scene {
    * @param {Entity} [instanceEntity]
    */
   toWorld(world, instance, typeRegistry, instanceEntity) {
-    const { entityMap } = instance
+    const { entityMap: worldToSceneMap } = instance
+    const sceneToWorldMap = new Map()
+
+    for (const entity of this.entities.keys()) {
+      const worldEntity = world.spawn([])
+
+      worldToSceneMap.set(worldEntity.id(), entity)
+      sceneToWorldMap.set(entity, worldEntity.id())
+    }
 
     for (const [entity, components] of this.entities) {
-
+      const worldEntity = sceneToWorldMap.get(entity)
       const clonedComponents = components.map((component) => {
         const { constructor } = component
         const type = /** @type {import('../../type/index.js').Constructor} */ (constructor)
         const entry = typeRegistry.get(type)
+        const clonedComponent = fromSnapshot(component, world, entry)
 
-        return fromSnapshot(component, world, entry)
+        if (!clonedComponent) {
+          return undefined
+        }
+
+        entry
+          .getMethod('map')
+          ?.method
+          ?.call(clonedComponent, sceneToWorldMap)
+
+        return clonedComponent
       }).filter((e) => e !== undefined)
 
       if (!clonedComponents.some((c) => c.constructor === Parent)) {
         clonedComponents.push(new Parent(instanceEntity))
       }
 
-      const worldEntity = world.spawn(clonedComponents)
-
-      entityMap.set(worldEntity.id(), entity)
+      world.insert(Entity.from(worldEntity), clonedComponents)
     }
   }
 
@@ -111,7 +127,7 @@ export class Scene {
         const snapshot = toSnapshot(component, world, entry)
 
         if (snapshot) {
-          components.push(/** @type {object} */ (snapshot))
+          components.push(/** @type {object} */(snapshot))
         }
       }
 


### PR DESCRIPTION
## Objective

This fixes relationship remapping during scene instantiation so cloned scene entities preserve valid entity references in the runtime world.

## Solution

### Root Cause

Scene entities were previously cloned and spawned one at a time. This meant relationship components such as `Parent` and `Children` could not reliably remap references to newly spawned world entities, because the full scene-to-world entity map did not exist yet. As a result, relationship components could keep references to serialized scene entity IDs instead of the runtime entities created during instancing.

### Changes Made

* Adds two-pass scene spawning for stable entity remapping
* Registers relationship traversal methods with the type registry
* Ensures relationships point to spawned world entities instead of scene entity IDs
* Updates the JSON scene loading example to include a transform on the scene instance root

### Why This Approach

This approach ensures every scene entity has a corresponding world entity before relationship components are remapped. That avoids order-dependent spawning bugs and allows relationship components to remap generically through the type registry instead of hardcoding relationship-specific logic into scene spawning.

### Notes

* This depends on relationship components registering their `map()` method in the type registry.
* Scene entity IDs are still tracked through `worldToSceneMap`.
* Scene-to-world mapping is local to the instancing process and used to rewrite cloned relationship references.

## Showcase

N/A

## Migration Guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
