### PR TITLE
Drop asset handles on component removal

### DIFF
--- a/src/animation/components/player.js
+++ b/src/animation/components/player.js
@@ -1,5 +1,6 @@
 /** @import { PlaybackSettings } from '../core/index.js'*/
 /** @import { AssetId } from '../../asset/index.js'*/
+/** @import { ComponentHook } from '../../ecs/index.js' */
 import { Handle } from '../../asset/index.js'
 import { Playback } from '../core/index.js'
 import { AnimationClip } from '../assets/index.js'
@@ -245,3 +246,20 @@ export class AnimationPlayer {
  * @property {[AssetId, any][]} animations
  * @property {number | null} current
  */
+
+/**
+ * @type {ComponentHook}
+ */
+export function dropAnimationPlayer(entity, world) {
+  const player = world.get(entity, AnimationPlayer)
+
+  if (!player) {
+    return
+  }
+
+  player.handles.forEach((handle) => {
+    handle.drop()
+  })
+  player.handles.clear()
+  player.animations.clear()
+}

--- a/src/animation/components/player.js
+++ b/src/animation/components/player.js
@@ -12,6 +12,11 @@ export class AnimationPlayer {
   animations = new Map()
 
   /**
+   * @type {Map<AssetId,Handle<AnimationClip>>}
+   */
+  handles = new Map()
+
+  /**
    * @type {number | null}
    */
   current = null
@@ -21,13 +26,17 @@ export class AnimationPlayer {
    * @param {AnimationPlayer} target
    */
   static copy(source, target = new AnimationPlayer()) {
-    const animations = new Map()
+    const { animations, handles } = target
 
+    animations.clear()
+    handles.clear()
     source.animations.forEach((playback, id) => {
       animations.set(id, Playback.copy(playback))
     })
+    source.handles.forEach((handle, id) => {
+      handles.set(id, handle.clone())
+    })
 
-    target.animations = animations
     target.current = source.current
 
     return target
@@ -110,8 +119,15 @@ export class AnimationPlayer {
    */
   set(handle, settings) {
     const playback = new Playback(settings)
+    const id = handle.id()
+    const existing = this.handles.get(id)
 
-    this.animations.set(handle.id(), playback)
+    if (existing && existing !== handle) {
+      existing.drop()
+    }
+
+    this.animations.set(id, playback)
+    this.handles.set(id, handle)
 
     return this
   }
@@ -127,7 +143,12 @@ export class AnimationPlayer {
    * @param {Handle<AnimationClip>} handle
    */
   delete(handle) {
-    this.animations.delete(handle.id())
+    const id = handle.id()
+    const existing = this.handles.get(id)
+
+    this.animations.delete(id)
+    this.handles.delete(id)
+    existing?.drop()
 
     return this
   }

--- a/src/animation/plugin.js
+++ b/src/animation/plugin.js
@@ -1,9 +1,10 @@
 import { App, Plugin } from '../app/index.js'
 import { AssetPlugin, Assets } from '../asset/index.js'
 import { AppSchedule } from '../core/index.js'
+import { ComponentHooks } from '../ecs/index.js'
 import { typeidGeneric } from '../type/index.js'
 import { AnimationClip } from './assets/index.js'
-import { AnimationPlayer, AnimationTarget } from './components/index.js'
+import { AnimationPlayer, AnimationTarget, dropAnimationPlayer } from './components/index.js'
 import { AnimationClipAssets } from './resources/index.js'
 import { advanceAnimationPlayers, applyAnimations, registerAnimationTypes } from './systems/index.js'
 
@@ -17,6 +18,10 @@ export class AnimationPlugin extends Plugin {
 
     app
       .registerType(AnimationPlayer)
+      .setComponentHooks(AnimationPlayer, new ComponentHooks(
+        null,
+        dropAnimationPlayer
+      ))
       .registerType(AnimationTarget)
       .registerSystem({ schedule: AppSchedule.Startup, system: registerAnimationTypes })
       .registerPlugin(new AssetPlugin({

--- a/src/render-core/components/material.js
+++ b/src/render-core/components/material.js
@@ -37,3 +37,41 @@ export class Material3D {
     this.handle = handle
   }
 }
+
+
+
+/**
+ * @template {Material} T
+ * @template {Material3D<T>} U
+ * @param {import("../../index.js").Constructor<U>} type
+ * @returns {import('../../ecs/index.js').ComponentHook}
+ */
+export function dropMaterial2D(type) {
+  return function dropMaterial2D(entity, world) {
+    const material = world.get(entity, type)
+
+    if (!material) {
+      return
+    }
+
+    material.handle.drop()
+  }
+}
+
+/**
+ * @template {Material} T
+ * @template {Material3D<T>} U
+ * @param {import("../../index.js").Constructor<U>} type
+ * @returns {import('../../ecs/index.js').ComponentHook}
+ */
+export function dropMaterial3D(type) {
+  return function dropMaterial3D(entity, world) {
+    const material = world.get(entity, type)
+
+    if (!material) {
+      return
+    }
+
+    material.handle.drop()
+  }
+}

--- a/src/render-core/components/material.js
+++ b/src/render-core/components/material.js
@@ -38,8 +38,6 @@ export class Material3D {
   }
 }
 
-
-
 /**
  * @template {Material} T
  * @template {Material3D<T>} U

--- a/src/render-core/components/mesh.js
+++ b/src/render-core/components/mesh.js
@@ -1,3 +1,4 @@
+/** @import { ComponentHook } from '../../ecs/index.js' */
 import { Handle, HandleSnapshot } from '../../asset/index.js'
 import { typeid } from '../../type/index.js'
 import { Mesh } from '../assets/index.js'
@@ -91,3 +92,16 @@ export class MeshedSnapshot {
  * @typedef MeshedSnapshotSerial
  * @property {import('../../asset/core/handle.js').HandleSnapshotSerial} handle
  */
+
+/**
+ * @type {ComponentHook}
+ */
+export function removeMeshedHandle(entity, world) {
+  const meshed = world.get(entity, Meshed)
+
+  if (!meshed) {
+    return
+  }
+
+  meshed.handle.drop()
+}

--- a/src/render-core/plugin.js
+++ b/src/render-core/plugin.js
@@ -1,7 +1,14 @@
 import { App, Plugin } from '../app/index.js'
 import { AppSchedule, CoreSystems } from '../core/index.js'
 import { AssetImporterPlugin, AssetPlugin, Assets } from '../asset/index.js'
-import { BasicMaterial2D, BasicMaterial3D, Camera, Meshed } from './components/index.js'
+import { ComponentHooks } from '../ecs/index.js'
+import {
+  BasicMaterial2D,
+  BasicMaterial3D,
+  Camera,
+  Meshed,
+  removeMeshedHandle
+} from './components/index.js'
 import { Mesh, Shader, Image, BasicMaterial } from './assets/index.js'
 import { BasicMaterialAssets, ImageAssets, ImageImporter, MeshAssets } from './resources/index.js'
 import { Material2DPlugin, Material3DPlugin } from './plugins/index.js'
@@ -32,6 +39,10 @@ export class RenderCorePlugin extends Plugin {
 
     app
       .registerType(Meshed)
+      .setComponentHooks(Meshed, new ComponentHooks(
+        null,
+        removeMeshedHandle
+      ))
       .registerType(Camera)
       .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerRenderCoreTypes })
       .registerPlugin(new AssetPlugin({
@@ -78,7 +89,6 @@ export class RenderCorePlugin extends Plugin {
         asset: BasicMaterial,
         component: BasicMaterial3D
       }))
-
     world.setResourceAlias(typeidGeneric(Assets, [Image]), ImageAssets)
     world.setResourceAlias(typeidGeneric(Assets, [Mesh]), MeshAssets)
     world.setResourceAlias(typeidGeneric(Assets, [BasicMaterial]), BasicMaterialAssets)

--- a/src/render-core/plugins/material.js
+++ b/src/render-core/plugins/material.js
@@ -1,10 +1,10 @@
 /** @import { Constructor, TypeId } from '../../type/index.js' */
-
 import { App, Plugin } from '../../app/index.js'
 import { AppSchedule, CoreSystems } from '../../core/index.js'
+import { ComponentHooks } from '../../ecs/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
 import { Material } from '../assets/index.js'
-import { Material2D, Material3D } from '../components/index.js'
+import { dropMaterial2D, dropMaterial3D, Material2D, Material3D } from '../components/index.js'
 import { genBinRenderables2D, genBinRenderables3D, registerMaterialTypes } from '../systems/index.js'
 
 /**
@@ -41,6 +41,10 @@ export class Material2DPlugin extends Plugin {
 
     app
       .registerType(component)
+      .setComponentHooks(component, new ComponentHooks(
+        null,
+        dropMaterial2D(component)
+      ))
       .registerSystem({
         schedule: AppSchedule.Startup,
         systemGroup: CoreSystems.Start,
@@ -97,6 +101,10 @@ export class Material3DPlugin extends Plugin {
 
     app
       .registerType(component)
+      .setComponentHooks(component, new ComponentHooks(
+        null,
+        dropMaterial3D(component)
+      ))
       .registerSystem({
         schedule: AppSchedule.Startup,
         systemGroup: CoreSystems.Start,

--- a/src/scene/hooks/instance.js
+++ b/src/scene/hooks/instance.js
@@ -12,3 +12,18 @@ export function initSceneInstance(entity, world) {
   // the scene may actually not be loaded so we will defer the actual spawning of the scene entities to when the scene asset is actually loaded.
   spawner.add(sceneHandle.handle.id(), entity)
 }
+
+/**
+ * @type {ComponentHook}
+ */
+export function dropSceneInstance(entity, world) {
+  const spawner = world.getResource(SceneSpawner)
+  const sceneInstance = world.get(entity, SceneInstance)
+
+  if (!sceneInstance) {
+    return
+  }
+
+  spawner.remove(sceneInstance.handle.id(), entity)
+  sceneInstance.handle.drop()
+}

--- a/src/scene/plugin.js
+++ b/src/scene/plugin.js
@@ -3,7 +3,7 @@ import { ComponentHooks } from '../ecs/index.js'
 import { Scene } from './assets/index.js'
 import { SceneInstance } from './components/index.js'
 import { JSONSceneExporter, JSONSceneImporter, SceneAssets, SceneSpawner } from './resources/index.js'
-import { initSceneInstance } from './hooks/index.js'
+import { initSceneInstance, dropSceneInstance } from './hooks/index.js'
 import { AssetExporterPlugin, AssetImporterPlugin, AssetPlugin, Assets } from '../asset/index.js'
 import { SceneAdded, SceneDropped, SceneModified } from './events/index.js'
 import { typeidGeneric } from '../type/index.js'
@@ -36,7 +36,8 @@ export class ScenePlugin extends Plugin {
       .registerType(SceneInstance)
       .setResource(new SceneSpawner())
       .setComponentHooks(SceneInstance, new ComponentHooks(
-        initSceneInstance
+        initSceneInstance,
+        dropSceneInstance
       ))
       .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerSceneTypes })
       .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.End, system: spawnScenes })

--- a/src/scene/resources/scenespawner.js
+++ b/src/scene/resources/scenespawner.js
@@ -35,7 +35,11 @@ export class SceneSpawner {
 
     if (!list) return
 
-    list.splice(list.indexOf(entity.id()), 1)
+    const index = list.indexOf(entity.id())
+
+    if (index === -1) return
+
+    list.splice(index, 1)
   }
 
   /**


### PR DESCRIPTION
## Objective

Introduces automatic cleanup hooks for components that own asset handles, ensuring reference-counted assets are released correctly when components are removed or entities are destroyed.

## Solution

This improves memory and resource management by registering component destruction hooks that automatically drop owned asset handles when their parent components leave the ECS world.

### Root Cause

Several components internally owned asset handles but did not release them when removed. This caused multiple issues:

* Asset reference leaks
* Incorrect asset lifetime tracking
* Resources remaining alive after entities were destroyed
* Duplicate handles accumulating during repeated creation/removal cycles

Because handles are reference-counted, failing to release them prevented assets from being properly garbage collected.

### Changes Made

* Adds component removal hooks for asset-backed components
* Automatically releases asset handles when components/entities are destroyed
* Prevents stale asset references and handle leaks across animation, rendering, and scene systems

### Why This Approach

This solution was chosen because:

* Cleanup happens automatically at ECS lifecycle boundaries
* Asset ownership is released deterministically
* Reference-counted assets remain accurate
* Systems do not need manual cleanup logic

### Notes

* Components that own handles should now define removal hooks
* Asset reference counting now better reflects real runtime ownership
* Replacing animation handles now properly drops previous references

> [!Note]
> This cleans up asset handles in engine defined components. For components a user defined, you will need to create your own component hook to drop asset handles held by those.

## Showcase

N/A

## Migration Guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
