### PR TITLE
Unify 2d/3d material components into one

### DIFF
--- a/assets/scene/basic.json
+++ b/assets/scene/basic.json
@@ -11,7 +11,7 @@
           "asset": 4294967296
         }
       },
-      "BasicMaterial2DSnapshot": {
+      "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
           "asset": 4294967296
@@ -29,7 +29,7 @@
           "asset": 4294967296
         }
       },
-      "BasicMaterial2DSnapshot": {
+      "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
           "asset": 4294967296
@@ -47,7 +47,7 @@
           "asset": 4294967296
         }
       },
-      "BasicMaterial2DSnapshot": {
+      "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
           "asset": 4294967296
@@ -65,7 +65,7 @@
           "asset": 4294967296
         }
       },
-      "BasicMaterial2DSnapshot": {
+      "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
           "asset": 4294967296
@@ -83,7 +83,7 @@
           "asset": 4294967296
         }
       },
-      "BasicMaterial2DSnapshot": {
+      "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
           "asset": 4294967296
@@ -101,7 +101,7 @@
           "asset": 4294967296
         }
       },
-      "BasicMaterial2DSnapshot": {
+      "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
           "asset": 4294967296
@@ -119,7 +119,7 @@
           "asset": 4294967296
         }
       },
-      "BasicMaterial2DSnapshot": {
+      "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
           "asset": 4294967296
@@ -137,7 +137,7 @@
           "asset": 4294967296
         }
       },
-      "BasicMaterial2DSnapshot": {
+      "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
           "asset": 4294967296

--- a/examples/samples/animation/2d/basic.js
+++ b/examples/samples/animation/2d/basic.js
@@ -1,6 +1,6 @@
 import {
   Mesh,
-  createTransform2D,
+  createBasicMesh2D,
   World,
   AnimationClip,
   AnimationTrack,
@@ -14,8 +14,6 @@ import {
   MeshAssets,
   BasicMaterialAssets,
   BasicMaterial,
-  Meshed,
-  BasicMaterial2D,
   HALF_PI,
   PI,
   TAU,
@@ -72,9 +70,7 @@ function init(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(0.3, 0.3),
-      new Meshed(mesh),
-      new BasicMaterial2D(material),
+      ...createBasicMesh2D(mesh, material, 0.3, 0.3),
       new AnimationTarget(player, targetname)])
     .build()
 }

--- a/examples/samples/animation/3d/basic.js
+++ b/examples/samples/animation/3d/basic.js
@@ -10,12 +10,10 @@ import {
   MeshAssets,
   BasicMaterialAssets,
   BasicMaterial,
-  Meshed,
   HALF_PI,
   PI,
   TAU,
-  BasicMaterial3D,
-  createTransform3D,
+  createBasicMesh3D,
   Orientation3DAnimationEffector,
   Position3DAnimationEffector,
   Scale3DAnimationEffector,
@@ -74,9 +72,7 @@ export function init(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(1, 1),
-      new Meshed(mesh),
-      new BasicMaterial3D(material),
+      ...createBasicMesh3D(mesh, material, 1, 1),
       new AnimationTarget(player, targetname)])
     .build()
 }

--- a/examples/samples/ecs/despawn.js
+++ b/examples/samples/ecs/despawn.js
@@ -1,13 +1,11 @@
 import {
   Mesh,
-  createTransform2D,
+  createBasicMesh2D,
   World,
   Query,
   EntityCommands,
   Entity,
   BasicMaterial,
-  Meshed,
-  BasicMaterial2D,
   BasicMaterialAssets,
   MeshAssets,
   App,
@@ -62,9 +60,7 @@ function init(world) {
       commands
         .spawn()
         .insertPrefab([
-          ...createTransform2D(x, y),
-          new Meshed(mesh),
-          new BasicMaterial2D(material),
+          ...createBasicMesh2D(mesh, material, x, y),
           new Marker()])
         .build()
     }

--- a/examples/samples/ecs/spawn.js
+++ b/examples/samples/ecs/spawn.js
@@ -1,13 +1,11 @@
 import {
   Mesh,
-  createTransform2D,
+  createBasicMesh2D,
   World,
   Query,
   EntityCommands,
   Entity,
   BasicMaterial,
-  Meshed,
-  BasicMaterial2D,
   BasicMaterialAssets,
   MeshAssets,
   Canvas2DRendererPlugin,
@@ -61,9 +59,7 @@ function update(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(x, y),
-      new Meshed(mesh),
-      new BasicMaterial2D(material),
+      ...createBasicMesh2D(mesh, material, x, y),
       new Marker()])
     .build()
 }

--- a/examples/samples/emitter/2d/basic.js
+++ b/examples/samples/emitter/2d/basic.js
@@ -12,10 +12,11 @@ import {
   MouseButton,
   BasicMaterial,
   Meshed,
-  BasicMaterial2D,
+  BasicMaterialInstance,
   MeshAssets,
   BasicMaterialAssets,
-  createMovable2D,
+  createBasicMesh2D,
+  createRawMovable2D,
   Position2D,
   Orientation2D,
   Acceleration2D,
@@ -66,13 +67,12 @@ function init(world) {
   const material = materials.add(new BasicMaterial())
 
   /**
-   *@returns {[Position2D, Orientation2D, Scale2D, GlobalTransform2D, Velocity2D, Rotation2D, Acceleration2D, Torque2D, Meshed, BasicMaterial2D]}
+   *@returns {[Position2D, Orientation2D, Scale2D, GlobalTransform2D, Meshed, BasicMaterialInstance, Velocity2D, Rotation2D, Acceleration2D, Torque2D]}
    */
   function particle() {
     return [
-      ...createMovable2D(),
-      new Meshed(mesh.clone()),
-      new BasicMaterial2D(material.clone())]
+      ...createBasicMesh2D(mesh.clone(), material.clone()),
+      ...createRawMovable2D()]
   }
 
   /**

--- a/examples/samples/emitter/2d/duration.js
+++ b/examples/samples/emitter/2d/duration.js
@@ -10,10 +10,11 @@ import {
   MeshAssets,
   BasicMaterialAssets,
   Meshed,
-  BasicMaterial2D,
+  BasicMaterialInstance,
   BasicMaterial,
   Acceleration2D,
-  createMovable2D,
+  createBasicMesh2D,
+  createRawMovable2D,
   GlobalTransform2D,
   Orientation2D,
   Rotation2D,
@@ -60,13 +61,12 @@ function init(world) {
   const material = materials.add(new BasicMaterial())
 
   /**
-   *@returns {[Position2D, Orientation2D, Scale2D, GlobalTransform2D, Velocity2D, Rotation2D, Acceleration2D, Torque2D, Meshed, BasicMaterial2D]}
+   *@returns {[Position2D, Orientation2D, Scale2D, GlobalTransform2D, Meshed, BasicMaterialInstance, Velocity2D, Rotation2D, Acceleration2D, Torque2D]}
    */
   function particle() {
     return [
-      ...createMovable2D(),
-      new Meshed(mesh),
-      new BasicMaterial2D(material)]
+      ...createBasicMesh2D(mesh, material),
+      ...createRawMovable2D()]
   }
 
   /**

--- a/examples/samples/emitter/3d/basic.js
+++ b/examples/samples/emitter/3d/basic.js
@@ -13,8 +13,9 @@ import {
   Meshed,
   MeshAssets,
   BasicMaterialAssets,
-  createMovable3D,
-  BasicMaterial3D,
+  createBasicMesh3D,
+  createRawMovable3D,
+  BasicMaterialInstance,
   Entity,
   Rotation3D,
   Velocity3D,
@@ -65,13 +66,12 @@ function init(world) {
   const material = materials.add(new BasicMaterial())
 
   /**
-   *@returns {[Position3D, Orientation3D, Scale3D, GlobalTransform3D, Velocity3D, Rotation3D, Acceleration3D, Torque3D, Meshed, BasicMaterial3D]}
+   *@returns {[Position3D, Orientation3D, Scale3D, GlobalTransform3D, Meshed, BasicMaterialInstance, Velocity3D, Rotation3D, Acceleration3D, Torque3D]}
    */
   function particle() {
     return [
-      ...createMovable3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material)]
+      ...createBasicMesh3D(mesh, material),
+      ...createRawMovable3D()]
   }
 
   /**

--- a/examples/samples/emitter/3d/duration.js
+++ b/examples/samples/emitter/3d/duration.js
@@ -12,8 +12,9 @@ import {
   createEmitter3D,
   Position3D,
   Acceleration3D,
-  BasicMaterial3D,
-  createMovable3D,
+  BasicMaterialInstance,
+  createBasicMesh3D,
+  createRawMovable3D,
   Entity,
   GlobalTransform3D,
   Orientation3D,
@@ -63,13 +64,12 @@ function init(world) {
   const offset = -((width + padding) * number) / 2
 
   /**
-   *@returns {[Position3D, Orientation3D, Scale3D, GlobalTransform3D, Velocity3D, Rotation3D, Acceleration3D, Torque3D, Meshed, BasicMaterial3D]}
+   *@returns {[Position3D, Orientation3D, Scale3D, GlobalTransform3D, Meshed, BasicMaterialInstance, Velocity3D, Rotation3D, Acceleration3D, Torque3D]}
    */
   function particle() {
     return [
-      ...createMovable3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material)]
+      ...createBasicMesh3D(mesh, material),
+      ...createRawMovable3D()]
   }
 
   /**

--- a/examples/samples/input/keyboard.js
+++ b/examples/samples/input/keyboard.js
@@ -1,6 +1,6 @@
 import {
   Mesh,
-  createTransform2D,
+  createBasicMesh2D,
   World,
   Color,
   Query,
@@ -9,8 +9,7 @@ import {
   KeyCode,
   Entity,
   BasicMaterial,
-  Meshed,
-  BasicMaterial2D,
+  BasicMaterialInstance,
   BasicMaterialAssets,
   MeshAssets,
   App,
@@ -54,7 +53,7 @@ function update(world) {
   const materials = world.getResource(BasicMaterialAssets)
   const keyboard = world.getResource(Keyboard)
   const map = world.getResource(KeytoEntityMap)
-  const entities = new Query(world, [Entity, BasicMaterial2D])
+  const entities = new Query(world, [Entity, BasicMaterialInstance])
 
   map.forEach((id, key) => {
     const entity = entities.get(id)
@@ -103,9 +102,7 @@ function spawnDigits(world) {
     const entity = commands
       .spawn()
       .insertPrefab([
-        ...createTransform2D(x, y),
-        new Meshed(mesh),
-        new BasicMaterial2D(materials.add(new BasicMaterial()))])
+        ...createBasicMesh2D(mesh, materials.add(new BasicMaterial()), x, y)])
       .build()
 
     map.set(digit, entity)
@@ -167,9 +164,7 @@ function spawnAlphabet(world) {
     const entity = commands
       .spawn()
       .insertPrefab([
-        ...createTransform2D(x, y),
-        new Meshed(mesh),
-        new BasicMaterial2D(materials.add(new BasicMaterial()))])
+        ...createBasicMesh2D(mesh, materials.add(new BasicMaterial()), x, y)])
       .build()
 
     map.set(digit, entity)

--- a/examples/samples/input/mouse.js
+++ b/examples/samples/input/mouse.js
@@ -1,6 +1,6 @@
 import {
   Mesh,
-  createTransform2D,
+  createBasicMesh2D,
   World,
   Color,
   Query,
@@ -11,9 +11,8 @@ import {
   Entity,
   Mouse,
   MouseButtons,
-  Meshed,
   BasicMaterial,
-  BasicMaterial2D,
+  BasicMaterialInstance,
   BasicMaterialAssets,
   MeshAssets,
   App,
@@ -63,9 +62,7 @@ function spawnMouseFollower(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(),
-      new Meshed(mesh),
-      new BasicMaterial2D(materials.add(new BasicMaterial({
+      ...createBasicMesh2D(mesh, materials.add(new BasicMaterial({
         color: Color.WHITE.clone()
       }))),
       new MouseEntity()
@@ -99,11 +96,9 @@ function spawnButtons(world) {
     const entity = commands
       .spawn()
       .insertPrefab([
-        ...createTransform2D(x, y),
-        new Meshed(mesh),
-        new BasicMaterial2D(materials.add(new BasicMaterial({
+        ...createBasicMesh2D(mesh, materials.add(new BasicMaterial({
           color: Color.WHITE.clone()
-        })))])
+        })), x, y)])
       .build()
 
     map.set(digit, entity)
@@ -132,7 +127,7 @@ function updateButtons(world) {
   const materials = world.getResource(BasicMaterialAssets)
   const mousebuttons = world.getResource(MouseButtons)
   const map = world.getResource(KeytoEntityMap)
-  const entities = new Query(world, [Entity, BasicMaterial2D])
+  const entities = new Query(world, [Entity, BasicMaterialInstance])
 
   map.forEach((id, key) => {
     const entity = entities.get(id)

--- a/examples/samples/input/touch.js
+++ b/examples/samples/input/touch.js
@@ -1,6 +1,6 @@
 import {
   Mesh,
-  createTransform2D,
+  createBasicMesh2D,
   World,
   Color,
   Query,
@@ -10,8 +10,7 @@ import {
   Entity,
   Position2D,
   BasicMaterial,
-  BasicMaterial2D,
-  Meshed,
+  BasicMaterialInstance,
   BasicMaterialAssets,
   MeshAssets,
   App,
@@ -58,9 +57,7 @@ function init(world) {
     const entity = commands
       .spawn()
       .insertPrefab([
-        ...createTransform2D(0, 0),
-        new Meshed(mesh),
-        new BasicMaterial2D(materials.add(new BasicMaterial({
+        ...createBasicMesh2D(mesh, materials.add(new BasicMaterial({
           color: Color.WHITE.clone()
         })))])
       .build()
@@ -77,7 +74,7 @@ function update(world) {
   const materials = world.getResource(BasicMaterialAssets)
   const touches = world.getResource(Touches)
   const map = world.getResource(TouchtoEntityMap)
-  const entities = new Query(world, [Position2D, BasicMaterial2D])
+  const entities = new Query(world, [Position2D, BasicMaterialInstance])
 
   map.forEach((id, key) => {
     const touch = touches.get(key)

--- a/examples/samples/render/canvas-2d/material.js
+++ b/examples/samples/render/canvas-2d/material.js
@@ -1,11 +1,9 @@
 import {
   Mesh,
-  createTransform2D,
+  createBasicMesh2D,
   World,
   EntityCommands,
   BasicMaterial,
-  Meshed,
-  BasicMaterial2D,
   BasicMaterialAssets,
   MeshAssets,
   App,
@@ -44,8 +42,6 @@ function init(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(-0.5, 0),
-      new Meshed(mesh),
-      new BasicMaterial2D(material)])
+      ...createBasicMesh2D(mesh, material, -0.5, 0)])
     .build()
 }

--- a/examples/samples/render/webgl/basictriangle.js
+++ b/examples/samples/render/webgl/basictriangle.js
@@ -2,10 +2,8 @@ import {
   Mesh,
   World,
   EntityCommands,
-  createTransform3D,
+  createBasicMesh3D,
   BasicMaterial,
-  Meshed,
-  BasicMaterial3D,
   BasicMaterialAssets,
   MeshAssets,
   App,
@@ -44,8 +42,6 @@ function spawnMesh(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material)])
+      ...createBasicMesh3D(mesh, material)])
     .build()
 }

--- a/examples/samples/render/webgl/cameraorthographic.js
+++ b/examples/samples/render/webgl/cameraorthographic.js
@@ -7,9 +7,8 @@ import {
   createCamera3D,
   EntityCommands,
   BasicMaterial,
-  Meshed,
-  BasicMaterial3D,
-  createMovable3D,
+  createBasicMesh3D,
+  createRawMovable3D,
   Query,
   BasicMaterialAssets,
   MeshAssets,
@@ -64,9 +63,8 @@ function spawnMesh(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createMovable3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material)])
+      ...createBasicMesh3D(mesh, material),
+      ...createRawMovable3D()])
     .insert(new Rotation3D(0, Math.PI / 10, 0))
     .build()
 }

--- a/examples/samples/render/webgl/cameraperspective.js
+++ b/examples/samples/render/webgl/cameraperspective.js
@@ -6,9 +6,8 @@ import {
   createCamera3D,
   EntityCommands,
   BasicMaterial,
-  BasicMaterial3D,
-  Meshed,
-  createMovable3D,
+  createBasicMesh3D,
+  createRawMovable3D,
   Query,
   Rotation3D,
   BasicMaterialAssets,
@@ -64,9 +63,8 @@ function spawnMesh(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createMovable3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material)])
+      ...createBasicMesh3D(mesh, material),
+      ...createRawMovable3D()])
     .build()
 }
 

--- a/examples/samples/render/webgl/camerarotate.js
+++ b/examples/samples/render/webgl/camerarotate.js
@@ -5,9 +5,7 @@ import {
   createCamera3D,
   EntityCommands,
   BasicMaterial,
-  createTransform3D,
-  Meshed,
-  BasicMaterial3D,
+  createBasicMesh3D,
   createRawMovable3D,
   Query,
   BasicMaterialAssets,
@@ -64,9 +62,7 @@ function spawnMesh(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material)])
+      ...createBasicMesh3D(mesh, material)])
     .build()
 }
 

--- a/examples/samples/render/webgl/colorchangetriangle.js
+++ b/examples/samples/render/webgl/colorchangetriangle.js
@@ -4,9 +4,7 @@ import {
   World,
   EntityCommands,
   BasicMaterial,
-  createTransform3D,
-  BasicMaterial3D,
-  Meshed,
+  createBasicMesh3D,
   BasicMaterialAssets,
   MeshAssets,
   App,
@@ -54,9 +52,7 @@ function spawnMesh(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material)])
+      ...createBasicMesh3D(mesh, material)])
     .build()
 }
 

--- a/examples/samples/render/webgl/geometries.js
+++ b/examples/samples/render/webgl/geometries.js
@@ -5,9 +5,8 @@ import {
   World,
   EntityCommands,
   BasicMaterial,
-  Meshed,
-  BasicMaterial3D,
-  createMovable3D,
+  createBasicMesh3D,
+  createRawMovable3D,
   Query,
   BasicMaterialAssets,
   MeshAssets,
@@ -65,9 +64,8 @@ function spawnMeshes(world) {
     commands
       .spawn()
       .insertPrefab([
-        ...createMovable3D(),
-        new Meshed(geometries[i]),
-        new BasicMaterial3D(material)])
+        ...createBasicMesh3D(geometries[i], material),
+        ...createRawMovable3D()])
       .insert(new Position3D(
         offsetX + width * (i % numX),
         offsetY - Math.floor(i / numX) * height,

--- a/examples/samples/scene/2d/basic.js
+++ b/examples/samples/scene/2d/basic.js
@@ -1,11 +1,9 @@
 import {
   Mesh,
-  createTransform2D,
+  createBasicMesh2D,
   World,
   EntityCommands,
   BasicMaterial,
-  Meshed,
-  BasicMaterial2D,
   Scene,
   SceneInstance,
   SceneAssets,
@@ -84,9 +82,7 @@ function createScene(meshes, materials) {
   for (let y = -halfHeight; y <= halfHeight; y += itemHeight) {
     for (let x = -halfWidth; x < halfWidth; x += itemWidth) {
       scene.set(new Entity(index, 1), [
-        ...createTransform2D(x, y),
-        new Meshed(mesh.clone()),
-        new BasicMaterial2D(material.clone())])
+        ...createBasicMesh2D(mesh.clone(), material.clone(), x, y)])
       index += 1
     }
   }

--- a/examples/samples/scene/2d/multiple_instances.js
+++ b/examples/samples/scene/2d/multiple_instances.js
@@ -1,10 +1,10 @@
 import {
   Mesh,
+  createBasicMesh2D,
   createMovable2D,
   World,
   EntityCommands,
   BasicMaterial,
-  Meshed,
   Scene,
   SceneInstance,
   SceneAssets,
@@ -14,7 +14,6 @@ import {
   MeshAssets,
   BasicMaterialAssets,
   Color,
-  BasicMaterial2D,
   AppSchedule,
   Rotation2D,
   rand,
@@ -27,8 +26,7 @@ import {
   FPSDebugger,
   App,
   Angular2DDamping,
-  Torque2D,
-  createTransform2D
+  Torque2D
 } from 'wima'
 import { addDefaultCamera2D, HackPlugin, setupViewport } from '../../utils.js'
 
@@ -108,9 +106,7 @@ function createScene(meshes, materials) {
 
   for (let i = 0; i < offsets.length; i++) {
     scene.set(new Entity(i, 1), [
-      ...createTransform2D(offsets[i].x, offsets[i].y),
-      new Meshed(mesh.clone()),
-      new BasicMaterial2D(material.clone()),
+      ...createBasicMesh2D(mesh.clone(), material.clone(), offsets[i].x, offsets[i].y),
       new Rotation2D(),
       new Torque2D()
     ])

--- a/examples/samples/scene/3d/basic.js
+++ b/examples/samples/scene/3d/basic.js
@@ -3,13 +3,11 @@ import {
   World,
   EntityCommands,
   BasicMaterial,
-  Meshed,
   Scene,
   SceneInstance,
   SceneAssets,
   Assets,
-  BasicMaterial3D,
-  createTransform3D,
+  createBasicMesh3D,
   Entity,
   createCamera3D,
   MeshAssets,
@@ -90,9 +88,7 @@ function createScene(meshes, materials) {
     for (let y = -halfHeight; y <= halfHeight; y += itemHeight) {
       for (let z = -halfDepth; z <= halfDepth; z += itemDepth) {
         scene.set(new Entity(index, 1), [
-          ...createTransform3D(x, y, z),
-          new Meshed(mesh.clone()),
-          new BasicMaterial3D(material.clone())])
+          ...createBasicMesh3D(mesh.clone(), material.clone(), x, y, z)])
         index += 1
       }
     }

--- a/examples/samples/scene/3d/multiple_instances.js
+++ b/examples/samples/scene/3d/multiple_instances.js
@@ -1,16 +1,15 @@
 import {
   Mesh,
   createRawMovable3D,
+  createBasicMesh3D,
   createTransform3D,
   World,
   EntityCommands,
   BasicMaterial,
-  Meshed,
   Scene,
   SceneInstance,
   SceneAssets,
   Assets,
-  BasicMaterial3D,
   Entity,
   Query,
   MeshAssets,
@@ -115,9 +114,7 @@ function createScene(meshes, materials) {
 
   for (let i = 0; i < offsets.length; i++) {
     scene.set(new Entity(i, 1), [
-      ...createTransform3D(offsets[i].x, offsets[i].y, offsets[i].z),
-      new Meshed(mesh.clone()),
-      new BasicMaterial3D(material.clone()),
+      ...createBasicMesh3D(mesh.clone(), material.clone(), offsets[i].x, offsets[i].y, offsets[i].z),
       new Rotation3D(),
       new Torque3D()
     ])

--- a/examples/samples/transform/2d/lookat.js
+++ b/examples/samples/transform/2d/lookat.js
@@ -5,9 +5,7 @@ import {
   Query,
   EntityCommands,
   VirtualClock,
-  BasicMaterial2D,
-  Meshed,
-  createTransform2D,
+  createBasicMesh2D,
   Orientation2D,
   GlobalTransform2D,
   Vector2,
@@ -62,9 +60,7 @@ function spawnLookers(world) {
       commands
         .spawn()
         .insertPrefab([
-          ...createTransform2D(x, y),
-          new Meshed(mesh),
-          new BasicMaterial2D(material),
+          ...createBasicMesh2D(mesh, material, x, y),
           new Looker()])
         .build()
     }
@@ -88,9 +84,7 @@ function spawnTarget(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(),
-      new Meshed(mesh),
-      new BasicMaterial2D(material),
+      ...createBasicMesh2D(mesh, material),
       new Target()])
     .build()
 }

--- a/examples/samples/transform/2d/propagate.js
+++ b/examples/samples/transform/2d/propagate.js
@@ -2,11 +2,9 @@ import {
   World,
   VirtualClock,
   BasicMaterial,
-  BasicMaterial2D,
-  createTransform2D,
+  createBasicMesh2D,
   EntityCommands,
   Mesh,
-  Meshed,
   Parent,
   Query,
   Children,
@@ -55,26 +53,20 @@ function addMeshes(world) {
   const parent = commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(),
-      new Meshed(mesh),
-      new BasicMaterial2D(material)])
+      ...createBasicMesh2D(mesh, material)])
     .build()
 
   const child = commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(0.4, 0, 0, 0.5, 0.5),
-      new Meshed(mesh),
-      new BasicMaterial2D(material),
+      ...createBasicMesh2D(mesh, material, 0.4, 0, 0, 0.5, 0.5),
       new Parent(parent)])
     .build()
 
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(0.4, 0, 0, 0.5, 0.5),
-      new Meshed(mesh),
-      new BasicMaterial2D(material),
+      ...createBasicMesh2D(mesh, material, 0.4, 0, 0, 0.5, 0.5),
       new Parent(child)
     ])
     .build()

--- a/examples/samples/transform/2d/rotate.js
+++ b/examples/samples/transform/2d/rotate.js
@@ -3,10 +3,10 @@ import {
   Mesh,
   World,
   EntityCommands,
-  createMovable2D,
+  createBasicMesh2D,
+  createRawMovable2D,
   Rotation2D,
   Meshed,
-  BasicMaterial2D,
   PI,
   Query,
   BasicMaterialAssets,
@@ -48,9 +48,8 @@ function addmesh(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createMovable2D(),
-      new Meshed(mesh),
-      new BasicMaterial2D(material)])
+      ...createBasicMesh2D(mesh, material),
+      ...createRawMovable2D()])
     .insert(new Rotation2D(PI))
     .build()
 }

--- a/examples/samples/transform/2d/scale.js
+++ b/examples/samples/transform/2d/scale.js
@@ -7,8 +7,7 @@ import {
   EntityCommands,
   VirtualClock,
   Meshed,
-  BasicMaterial2D,
-  createTransform2D,
+  createBasicMesh2D,
   BasicMaterialAssets,
   MeshAssets,
   App,
@@ -48,9 +47,7 @@ function addmesh(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(),
-      new Meshed(mesh),
-      new BasicMaterial2D(material)])
+      ...createBasicMesh2D(mesh, material)])
     .build()
 }
 

--- a/examples/samples/transform/2d/translate.js
+++ b/examples/samples/transform/2d/translate.js
@@ -6,9 +6,8 @@ import {
   Query,
   EntityCommands,
   VirtualClock,
-  BasicMaterial2D,
   Meshed,
-  createTransform2D,
+  createBasicMesh2D,
   BasicMaterialAssets,
   MeshAssets,
   App,
@@ -48,9 +47,7 @@ function addmesh(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform2D(),
-      new Meshed(mesh),
-      new BasicMaterial2D(material)])
+      ...createBasicMesh2D(mesh, material)])
     .build()
 }
 

--- a/examples/samples/transform/3d/lookat.js
+++ b/examples/samples/transform/3d/lookat.js
@@ -5,9 +5,7 @@ import {
   Query,
   EntityCommands,
   VirtualClock,
-  BasicMaterial3D,
-  Meshed,
-  createTransform3D,
+  createBasicMesh3D,
   Orientation3D,
   GlobalTransform3D,
   Vector3,
@@ -60,9 +58,7 @@ function spawnLookers(world) {
       commands
         .spawn()
         .insertPrefab([
-          ...createTransform3D(x, y),
-          new Meshed(mesh),
-          new BasicMaterial3D(material),
+          ...createBasicMesh3D(mesh, material, x, y),
           new Looker()])
         .build()
     }
@@ -86,9 +82,7 @@ function spawnTarget(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material),
+      ...createBasicMesh3D(mesh, material),
       new Target()])
     .build()
 }

--- a/examples/samples/transform/3d/propagate.js
+++ b/examples/samples/transform/3d/propagate.js
@@ -2,11 +2,9 @@ import {
   World,
   VirtualClock,
   BasicMaterial,
-  BasicMaterial3D,
-  createTransform3D,
+  createBasicMesh3D,
   EntityCommands,
   Mesh,
-  Meshed,
   Quaternion,
   Parent,
   Query,
@@ -54,26 +52,20 @@ function spawnMeshes(world) {
   const parent = commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material)])
+      ...createBasicMesh3D(mesh, material)])
     .build()
 
   const child = commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(1, 0, 0, 0, 0, 0, 0.5, 0.5, 0.5),
-      new Meshed(mesh),
-      new BasicMaterial3D(material),
+      ...createBasicMesh3D(mesh, material, 1, 0, 0, 0, 0, 0, 0.5, 0.5, 0.5),
       new Parent(parent)])
     .build()
 
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(0.5, 0, 0, 0, 0, 0, 0.5, 0.5, 0.5),
-      new Meshed(mesh),
-      new BasicMaterial3D(material),
+      ...createBasicMesh3D(mesh, material, 0.5, 0, 0, 0, 0, 0, 0.5, 0.5, 0.5),
       new Parent(child)
     ])
     .build()

--- a/examples/samples/transform/3d/rotate.js
+++ b/examples/samples/transform/3d/rotate.js
@@ -3,10 +3,10 @@ import {
   Mesh,
   World,
   EntityCommands,
-  createMovable3D,
+  createBasicMesh3D,
+  createRawMovable3D,
   Rotation3D,
   Meshed,
-  BasicMaterial3D,
   PI,
   Query,
   BasicMaterialAssets,
@@ -48,9 +48,8 @@ function spawnMesh(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createMovable3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material)])
+      ...createBasicMesh3D(mesh, material),
+      ...createRawMovable3D()])
     .insert(new Rotation3D(0, PI, 0))
     .build()
 }

--- a/examples/samples/transform/3d/scale.js
+++ b/examples/samples/transform/3d/scale.js
@@ -7,8 +7,7 @@ import {
   EntityCommands,
   VirtualClock,
   Meshed,
-  BasicMaterial3D,
-  createTransform3D,
+  createBasicMesh3D,
   BasicMaterialAssets,
   MeshAssets,
   App,
@@ -48,9 +47,7 @@ function spawnMesh(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material)])
+      ...createBasicMesh3D(mesh, material)])
     .build()
 }
 

--- a/examples/samples/transform/3d/translate.js
+++ b/examples/samples/transform/3d/translate.js
@@ -6,9 +6,8 @@ import {
   Query,
   EntityCommands,
   VirtualClock,
-  BasicMaterial3D,
   Meshed,
-  createTransform3D,
+  createBasicMesh3D,
   BasicMaterialAssets,
   MeshAssets,
   App,
@@ -48,9 +47,7 @@ function spawnMesh(world) {
   commands
     .spawn()
     .insertPrefab([
-      ...createTransform3D(),
-      new Meshed(mesh),
-      new BasicMaterial3D(material)])
+      ...createBasicMesh3D(mesh, material)])
     .build()
 }
 

--- a/examples/samples/tween/easing.js
+++ b/examples/samples/tween/easing.js
@@ -5,14 +5,12 @@ import {
   Easing,
   TweenRepeat,
   TweenFlip,
-  createTransform2D,
+  createBasicMesh2D,
   World,
   EntityCommands,
   Assets,
   typeidGeneric,
   BasicMaterial,
-  Meshed,
-  BasicMaterial2D,
   App,
   AppSchedule,
   Canvas2DRendererPlugin,
@@ -65,9 +63,7 @@ function init(world) {
     commands
       .spawn()
       .insertPrefab([
-        ...createTransform2D(x, y),
-        new Meshed(mesh),
-        new BasicMaterial2D(material),
+        ...createBasicMesh2D(mesh, material, x, y),
         new Position2DTween(
           new Vector2(x, y),
           new Vector2(x, endY),

--- a/src/render-core/components/material.js
+++ b/src/render-core/components/material.js
@@ -36,4 +36,3 @@ export function dropMaterialInstance(type) {
     material.handle.drop()
   }
 }
-

--- a/src/render-core/components/material.js
+++ b/src/render-core/components/material.js
@@ -5,7 +5,7 @@ import { Handle } from '../../asset/index.js'
  * @abstract
  * @template {Material} T
  */
-export class Material2D {
+export class MaterialInstance {
 
   /**
    * @type {Handle<T>}
@@ -22,30 +22,11 @@ export class Material2D {
 
 /**
  * @template {Material} T
- */
-export class Material3D {
-
-  /**
-   * @type {Handle<T>}
-   */
-  handle
-
-  /**
-   * @param {Handle<T>} handle
-   */
-  constructor(handle) {
-    this.handle = handle
-  }
-}
-
-/**
- * @template {Material} T
- * @template {Material3D<T>} U
- * @param {import("../../index.js").Constructor<U>} type
+ * @param {import("../../index.js").Constructor<MaterialInstance<T>>} type
  * @returns {import('../../ecs/index.js').ComponentHook}
  */
-export function dropMaterial2D(type) {
-  return function dropMaterial2D(entity, world) {
+export function dropMaterialInstance(type) {
+  return function dropMaterialInstance(entity, world) {
     const material = world.get(entity, type)
 
     if (!material) {
@@ -56,20 +37,3 @@ export function dropMaterial2D(type) {
   }
 }
 
-/**
- * @template {Material} T
- * @template {Material3D<T>} U
- * @param {import("../../index.js").Constructor<U>} type
- * @returns {import('../../ecs/index.js').ComponentHook}
- */
-export function dropMaterial3D(type) {
-  return function dropMaterial3D(entity, world) {
-    const material = world.get(entity, type)
-
-    if (!material) {
-      return
-    }
-
-    material.handle.drop()
-  }
-}

--- a/src/render-core/components/materials/index.js
+++ b/src/render-core/components/materials/index.js
@@ -1,74 +1,43 @@
 import { BasicMaterial } from '../../assets/index.js'
-import { Material2D, Material3D } from '../material.js'
+import { MaterialInstance } from '../material.js'
 import { Handle, HandleSnapshot } from '../../../asset/index.js'
 import { typeid } from '../../../type/index.js'
 
 /**
- * @augments Material2D<BasicMaterial>
+ * @augments MaterialInstance<BasicMaterial>
  */
-export class BasicMaterial2D extends Material2D {
+export class BasicMaterialInstance extends MaterialInstance {
 
   /**
-   * @param {BasicMaterial2D} source
-   * @param {BasicMaterial2D} target
+   * @param {BasicMaterialInstance} source
+   * @param {BasicMaterialInstance} target
    */
-  static copy(source, target = new BasicMaterial2D(source.handle)) {
+  static copy(source, target = new BasicMaterialInstance(source.handle)) {
     target.handle = source.handle.clone()
 
     return target
   }
 
   /**
-   * @param {BasicMaterial2D} target
+   * @param {BasicMaterialInstance} target
    */
   static clone(target) {
-    return BasicMaterial2D.copy(target)
+    return BasicMaterialInstance.copy(target)
   }
 
   /**
    * @param {import('../../../ecs/index.js').World} world
-   * @returns {BasicMaterial2DSnapshot}
+   * @returns {BasicMaterialInstanceSnapshot}
    */
   toSnapshot(world) {
-    return new BasicMaterial2DSnapshot(this.handle.toSnapshot(world))
+    return new BasicMaterialInstanceSnapshot(this.handle.toSnapshot(world))
   }
 }
 
 /**
- * @augments Material3D<BasicMaterial>
+ * Snapshot of a basic material instance component.
  */
-export class BasicMaterial3D extends Material3D {
-
-  /**
-   * @param {BasicMaterial3D} source
-   * @param {BasicMaterial3D} target
-   */
-  static copy(source, target = new BasicMaterial3D(source.handle)) {
-    target.handle = source.handle.clone()
-
-    return target
-  }
-
-  /**
-   * @param {BasicMaterial3D} target
-   */
-  static clone(target) {
-    return BasicMaterial3D.copy(target)
-  }
-
-  /**
-   * @param {import('../../../ecs/index.js').World} world
-   * @returns {BasicMaterial3DSnapshot}
-   */
-  toSnapshot(world) {
-    return new BasicMaterial3DSnapshot(this.handle.toSnapshot(world))
-  }
-}
-
-/**
- * Snapshot of a 2D basic material component.
- */
-export class BasicMaterial2DSnapshot {
+export class BasicMaterialInstanceSnapshot {
 
   /**
    * @type {HandleSnapshot}
@@ -84,14 +53,14 @@ export class BasicMaterial2DSnapshot {
 
   /**
    * @param {import('../../../ecs/index.js').World} world
-   * @returns {BasicMaterial2D}
+   * @returns {BasicMaterialInstance}
    */
   fromSnapshot(world) {
-    return new BasicMaterial2D(/** @type {Handle<BasicMaterial>} */(this.handle.fromSnapshot(world)))
+    return new BasicMaterialInstance(/** @type {Handle<BasicMaterial>} */(this.handle.fromSnapshot(world)))
   }
 
   /**
-   * @param {BasicMaterial2DSnapshot} value
+   * @param {BasicMaterialInstanceSnapshot} value
    */
   static serialize(value) {
     return {
@@ -100,10 +69,10 @@ export class BasicMaterial2DSnapshot {
   }
 
   /**
-   * @param {BasicMaterial2DSnapshotSerial} value
-   * @param {BasicMaterial2DSnapshot} [out]
+   * @param {BasicMaterialInstanceSnapshotSerial} value
+   * @param {BasicMaterialInstanceSnapshot} [out]
    */
-  static deserialize(value, out = new BasicMaterial2DSnapshot(new HandleSnapshot(typeid(Object), ''))) {
+  static deserialize(value, out = new BasicMaterialInstanceSnapshot(new HandleSnapshot(typeid(Object), ''))) {
     out.handle = HandleSnapshot.deserialize(value.handle, out.handle)
 
     return out
@@ -111,56 +80,6 @@ export class BasicMaterial2DSnapshot {
 }
 
 /**
- * Snapshot of a 3D basic material component.
- */
-export class BasicMaterial3DSnapshot {
-
-  /**
-   * @type {HandleSnapshot}
-   */
-  handle
-
-  /**
-   * @param {HandleSnapshot} handle
-   */
-  constructor(handle) {
-    this.handle = handle
-  }
-
-  /**
-   * @param {import('../../../ecs/index.js').World} world
-   * @returns {BasicMaterial3D}
-   */
-  fromSnapshot(world) {
-    return new BasicMaterial3D(/** @type {Handle<BasicMaterial>} */(this.handle.fromSnapshot(world)))
-  }
-
-  /**
-   * @param {BasicMaterial3DSnapshot} value
-   */
-  static serialize(value) {
-    return {
-      handle: HandleSnapshot.serialize(value.handle)
-    }
-  }
-
-  /**
-   * @param {BasicMaterial3DSnapshotSerial} value
-   * @param {BasicMaterial3DSnapshot} [out]
-   */
-  static deserialize(value, out = new BasicMaterial3DSnapshot(new HandleSnapshot(typeid(Object), ''))) {
-    out.handle = HandleSnapshot.deserialize(value.handle, out.handle)
-
-    return out
-  }
-}
-
-/**
- * @typedef BasicMaterial2DSnapshotSerial
- * @property {import('../../../asset/core/handle.js').HandleSnapshotSerial} handle
- */
-
-/**
- * @typedef BasicMaterial3DSnapshotSerial
+ * @typedef BasicMaterialInstanceSnapshotSerial
  * @property {import('../../../asset/core/handle.js').HandleSnapshotSerial} handle
  */

--- a/src/render-core/plugin.js
+++ b/src/render-core/plugin.js
@@ -3,15 +3,14 @@ import { AppSchedule, CoreSystems } from '../core/index.js'
 import { AssetImporterPlugin, AssetPlugin, Assets } from '../asset/index.js'
 import { ComponentHooks } from '../ecs/index.js'
 import {
-  BasicMaterial2D,
-  BasicMaterial3D,
+  BasicMaterialInstance,
   Camera,
   Meshed,
   removeMeshedHandle
 } from './components/index.js'
 import { Mesh, Shader, Image, BasicMaterial } from './assets/index.js'
 import { BasicMaterialAssets, ImageAssets, ImageImporter, MeshAssets } from './resources/index.js'
-import { Material2DPlugin, Material3DPlugin } from './plugins/index.js'
+import { MaterialInstancePlugin } from './plugins/index.js'
 import {
   ImageAdded,
   ImageDropped,
@@ -81,13 +80,9 @@ export class RenderCorePlugin extends Plugin {
           dropped: BasicMaterialDropped
         }
       }))
-      .registerPlugin(new Material2DPlugin({
+      .registerPlugin(new MaterialInstancePlugin({
         asset: BasicMaterial,
-        component: BasicMaterial2D
-      }))
-      .registerPlugin(new Material3DPlugin({
-        asset: BasicMaterial,
-        component: BasicMaterial3D
+        component: BasicMaterialInstance
       }))
     world.setResourceAlias(typeidGeneric(Assets, [Image]), ImageAssets)
     world.setResourceAlias(typeidGeneric(Assets, [Mesh]), MeshAssets)

--- a/src/render-core/plugins/material.js
+++ b/src/render-core/plugins/material.js
@@ -4,17 +4,17 @@ import { AppSchedule, CoreSystems } from '../../core/index.js'
 import { ComponentHooks } from '../../ecs/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
 import { Material } from '../assets/index.js'
-import { dropMaterial2D, dropMaterial3D, Material2D, Material3D } from '../components/index.js'
+import { dropMaterialInstance, MaterialInstance } from '../components/index.js'
 import { genBinRenderables2D, genBinRenderables3D, registerMaterialTypes } from '../systems/index.js'
 
 /**
  * @template {Material} T
  */
-export class Material2DPlugin extends Plugin {
+export class MaterialInstancePlugin extends Plugin {
 
   /**
    * @readonly
-   * @type {Constructor<Material2D<T>>}
+   * @type {Constructor<MaterialInstance<T>>}
    */
   component
 
@@ -25,7 +25,7 @@ export class Material2DPlugin extends Plugin {
   asset
 
   /**
-   * @param {Material2DPluginOptions<T>} param0
+   * @param {MaterialPluginOptions<T>} param0
    */
   constructor({ component, asset }) {
     super()
@@ -43,7 +43,7 @@ export class Material2DPlugin extends Plugin {
       .registerType(component)
       .setComponentHooks(component, new ComponentHooks(
         null,
-        dropMaterial2D(component)
+        dropMaterialInstance(component)
       ))
       .registerSystem({
         schedule: AppSchedule.Startup,
@@ -54,62 +54,8 @@ export class Material2DPlugin extends Plugin {
       .registerSystem({
         schedule: AppSchedule.Update,
         systemGroup: CoreSystems.PostMain,
-        label: `registerMaterialTypes<${typeid(asset)}>`,
+        label: `binRenders2D<${typeid(asset)}>`,
         system: genBinRenderables2D(asset, component)
-      })
-  }
-
-  /**
-   * @returns {TypeId}
-   */
-  name() {
-    return typeidGeneric(Material2DPlugin, [this.asset])
-  }
-}
-
-/**
- * @template {Material} T
- */
-export class Material3DPlugin extends Plugin {
-
-  /**
-   * @readonly
-   * @type {Constructor<Material3D<T>>}
-   */
-  component
-
-  /**
-   * @readonly
-   * @type {Constructor<T>}
-   */
-  asset
-
-  /**
-   * @param {Material3DPluginOptions<T>} param0
-   */
-  constructor({ component, asset }) {
-    super()
-    this.asset = asset
-    this.component = component
-  }
-
-  /**
-   * @param {App} app
-   */
-  register(app) {
-    const { asset, component } = this
-
-    app
-      .registerType(component)
-      .setComponentHooks(component, new ComponentHooks(
-        null,
-        dropMaterial3D(component)
-      ))
-      .registerSystem({
-        schedule: AppSchedule.Startup,
-        systemGroup: CoreSystems.Start,
-        label: `initRenderPipeline<${typeid(asset)}>`,
-        system: registerMaterialTypes(component, asset)
       })
       .registerSystem({
         schedule: AppSchedule.Update,
@@ -123,20 +69,13 @@ export class Material3DPlugin extends Plugin {
    * @returns {TypeId}
    */
   name() {
-    return typeidGeneric(Material3DPlugin, [this.asset])
+    return typeidGeneric(MaterialInstancePlugin, [this.asset])
   }
 }
 
 /**
  * @template {Material} T
- * @typedef Material2DPluginOptions
- * @property {Constructor<Material2D<T>>} component
- * @property {Constructor<T>} asset
- */
-
-/**
- * @template {Material} T
- * @typedef Material3DPluginOptions
- * @property {Constructor<Material3D<T>>} component
+ * @typedef MaterialPluginOptions
+ * @property {Constructor<MaterialInstance<T>>} component
  * @property {Constructor<T>} asset
  */

--- a/src/render-core/prefabs/basicmesh.js
+++ b/src/render-core/prefabs/basicmesh.js
@@ -1,0 +1,67 @@
+import { Handle } from '../../asset/index.js'
+import {
+  createTransform2D,
+  createTransform3D,
+  GlobalTransform2D,
+  GlobalTransform3D,
+  Orientation2D,
+  Orientation3D,
+  Position2D,
+  Position3D,
+  Scale2D,
+  Scale3D
+} from '../../transform/index.js'
+import { BasicMaterial, Mesh } from '../assets/index.js'
+import { BasicMaterialInstance, Meshed } from '../components/index.js'
+
+/**
+ * @param {Handle<Mesh>} [mesh]
+ * @param {Handle<BasicMaterial>} [material]
+ * @param {number} [x=0]
+ * @param {number} [y=0]
+ * @param {number} [a=0]
+ * @param {number} [sx=1]
+ * @param {number} [sy=1]
+ * @returns {[Position2D, Orientation2D, Scale2D, GlobalTransform2D, Meshed, BasicMaterialInstance]}
+ */
+export function createBasicMesh2D(mesh, material, x = 0, y = 0, a = 0, sx = 1, sy = 1) {
+  return [
+    ...createTransform2D(x, y, a, sx, sy),
+    new Meshed(mesh),
+    new BasicMaterialInstance(material)
+  ]
+}
+
+/**
+ * @param {Handle<Mesh>} [mesh]
+ * @param {Handle<BasicMaterial>} [material]
+ * @param {number} [x=0]
+ * @param {number} [y=0]
+ * @param {number} [z=0]
+ * @param {number} [ox=0]
+ * @param {number} [oy=0]
+ * @param {number} [oz=0]
+ * @param {number} [sx=1]
+ * @param {number} [sy=1]
+ * @param {number} [sz=1]
+ * @returns {[Position3D, Orientation3D, Scale3D, GlobalTransform3D, Meshed, BasicMaterialInstance]}
+ */
+export function createBasicMesh3D(
+  mesh,
+  material,
+  x = 0,
+  y = 0,
+  z = 0,
+  ox = 0,
+  oy = 0,
+  oz = 0,
+  sx = 1,
+  sy = 1,
+  sz = 1
+) {
+  return [
+    ...createTransform3D(x, y, z, ox, oy, oz, sx, sy, sz),
+    new Meshed(mesh),
+    new BasicMaterialInstance(material)
+  ]
+}

--- a/src/render-core/prefabs/index.js
+++ b/src/render-core/prefabs/index.js
@@ -1,2 +1,3 @@
 export * from './camera2d.js'
 export * from './camera3d.js'
+export * from './basicmesh.js'

--- a/src/render-core/systems/bin.js
+++ b/src/render-core/systems/bin.js
@@ -5,14 +5,14 @@ import { typeid } from '../../type/index.js'
 import { GlobalTransform2D, GlobalTransform3D } from '../../transform/index.js'
 import { Material } from '../assets/material.js'
 import { Camera } from '../components/camera.js'
-import { Material2D } from '../components/material.js'
+import { MaterialInstance } from '../components/material.js'
 import { Meshed } from '../components/mesh.js'
 import { RenderLists2D, RenderType, RenderLists3D } from '../components/index.js'
 
 /**
  * @template {Material} T
  * @param {Constructor<T>} assettype
- * @param {Constructor<Material2D<T>>} componenttype
+ * @param {Constructor<MaterialInstance<T>>} componenttype
  * @returns {SystemFunc}
  */
 export function genBinRenderables2D(assettype, componenttype) {
@@ -36,7 +36,7 @@ export function genBinRenderables2D(assettype, componenttype) {
 /**
  * @template {Material} T
  * @param {Constructor<T>} assettype
- * @param {Constructor<Material2D<T>>} componenttype
+ * @param {Constructor<MaterialInstance<T>>} componenttype
  * @returns {SystemFunc}
  */
 export function genBinRenderables3D(assettype, componenttype) {

--- a/src/render-core/systems/types.js
+++ b/src/render-core/systems/types.js
@@ -7,8 +7,7 @@ import { setTypeId, typeid, typeidGeneric } from '../../type/index.js'
 import { Handle, HandleSnapshot } from '../../asset/index.js'
 import { Color } from '../../color/index.js'
 import { Vector2 } from '../../math/index.js'
-import { Camera, Meshed, MeshedSnapshot, RenderLists2D, RenderLists3D } from '../components/index.js'
-import { BasicMaterial2D, BasicMaterial2DSnapshot, BasicMaterial3D, BasicMaterial3DSnapshot } from '../components/materials/index.js'
+import { BasicMaterialInstance, BasicMaterialInstanceSnapshot, Camera, Meshed, MeshedSnapshot, RenderLists2D, RenderLists3D } from '../components/index.js'
 import { MeshAttributeData } from '../core/attributedata.js'
 import { Projection, ShaderStage } from '../core/index.js'
 import { BasicMaterial, Image, Material, Mesh, Shader } from '../assets/index.js'
@@ -66,30 +65,18 @@ export function registerRenderCoreTypes(world) {
   registry.get(MeshedSnapshot)?.setMethod(MeshedSnapshot.serialize)
   registry.get(MeshedSnapshot)?.setMethod(MeshedSnapshot.deserialize)
   registry.get(MeshedSnapshot)?.setMethod(MeshedSnapshot.prototype.fromSnapshot)
-  registry.register(BasicMaterial2D, new StructInfo({
+  registry.register(BasicMaterialInstance, new StructInfo({
     handle: new Field(basicMaterialHandleId)
   }))
-  registry.get(BasicMaterial2D)?.setMethod(BasicMaterial2D.copy)
-  registry.get(BasicMaterial2D)?.setMethod(BasicMaterial2D.clone)
-  registry.get(BasicMaterial2D)?.setMethod(BasicMaterial2D.prototype.toSnapshot)
-  registry.register(BasicMaterial2DSnapshot, new StructInfo({
+  registry.get(BasicMaterialInstance)?.setMethod(BasicMaterialInstance.copy)
+  registry.get(BasicMaterialInstance)?.setMethod(BasicMaterialInstance.clone)
+  registry.get(BasicMaterialInstance)?.setMethod(BasicMaterialInstance.prototype.toSnapshot)
+  registry.register(BasicMaterialInstanceSnapshot, new StructInfo({
     handle: new Field(typeid(HandleSnapshot))
   }))
-  registry.get(BasicMaterial2DSnapshot)?.setMethod(BasicMaterial2DSnapshot.serialize)
-  registry.get(BasicMaterial2DSnapshot)?.setMethod(BasicMaterial2DSnapshot.deserialize)
-  registry.get(BasicMaterial2DSnapshot)?.setMethod(BasicMaterial2DSnapshot.prototype.fromSnapshot)
-  registry.register(BasicMaterial3D, new StructInfo({
-    handle: new Field(basicMaterialHandleId)
-  }))
-  registry.get(BasicMaterial3D)?.setMethod(BasicMaterial3D.copy)
-  registry.get(BasicMaterial3D)?.setMethod(BasicMaterial3D.clone)
-  registry.get(BasicMaterial3D)?.setMethod(BasicMaterial3D.prototype.toSnapshot)
-  registry.register(BasicMaterial3DSnapshot, new StructInfo({
-    handle: new Field(typeid(HandleSnapshot))
-  }))
-  registry.get(BasicMaterial3DSnapshot)?.setMethod(BasicMaterial3DSnapshot.serialize)
-  registry.get(BasicMaterial3DSnapshot)?.setMethod(BasicMaterial3DSnapshot.deserialize)
-  registry.get(BasicMaterial3DSnapshot)?.setMethod(BasicMaterial3DSnapshot.prototype.fromSnapshot)
+  registry.get(BasicMaterialInstanceSnapshot)?.setMethod(BasicMaterialInstanceSnapshot.serialize)
+  registry.get(BasicMaterialInstanceSnapshot)?.setMethod(BasicMaterialInstanceSnapshot.deserialize)
+  registry.get(BasicMaterialInstanceSnapshot)?.setMethod(BasicMaterialInstanceSnapshot.prototype.fromSnapshot)
   registry.register(Camera, new StructInfo({
     projection: new Field(typeid(Projection)),
     near: new Field(typeid(Number)),


### PR DESCRIPTION
## Objective

This consolidates duplicated rendering abstractions by replacing separate `Material2D`/`Material3D` components with a single `MaterialInstance` model and introduces prefab helpers for standardized mesh creation.

* Merges separate 2D/3D material components into a unified material abstraction
* Introduces reusable mesh prefab helpers for common render entity construction
* Removes duplicated material plugin infrastructure
* Simplifies entity creation across examples and scene serialization

## Solution

Reduces architectural duplication in the rendering pipeline by unifying material components and standardizing mesh entity creation patterns.

### Root Cause

The rendering system previously maintained separate but functionally identical abstractions for 2D and 3D materials:

```js
BasicMaterial2D
BasicMaterial3D
Material2DPlugin
Material3DPlugin
BasicMaterial2DSnapshot
BasicMaterial3DSnapshot
```

This created several issues:

* Duplicate serialization logic
* Duplicate plugin registration code
* Separate lifecycle management for identical behavior
* Boilerplate-heavy entity creation across examples
* Increased maintenance cost for render pipeline updates

Since both systems only wrapped a material handle, the distinction was unnecessary at the component level.

### Changes Made

The following changes were introduced:

* Replaced `Material2D` and `Material3D` with unified `MaterialInstance`
* Removed separate 2D/3D material plugins
* Introduced reusable mesh prefabs:

  * `createBasicMesh2D()`
  * `createBasicMesh3D()`
* Updated all engine examples to use new prefab API
* Updated scene serialization format to use unified snapshot names

### Why This Approach

This solution was chosen because:

* 2D and 3D material components had identical responsibilities
* Reduces duplicated serialization and plugin logic
* Makes render entity creation significantly simpler
* Improves API consistency across examples
* Lowers maintenance burden for future rendering changes

Alternative approaches such as keeping separate 2D/3D material abstractions were avoided because they provided no functional distinction while increasing complexity.

## Showcase

### Before

```js
// registering the material components
.registerPlugin(new Material2DPlugin(...))
.registerPlugin(new Material3DPlugin(...))

// Inserting an entity with basic material mesh
commands.spawn().insertPrefab([
  ...createTransform2D(),
  new Meshed(mesh),
  new BasicMaterial2D(material)
])
```

### After

```js
// registering the material components
.registerPlugin(new MaterialInstancePlugin(...))

// Inserting an entity with basic material mesh
commands.spawn().insertPrefab([
  ...createTransform2D(),
  new Meshed(mesh),
  new BasicMaterialInstance(material)
])

// Inserting an entity with basic material mesh (using prefab)
commands.spawn().insertPrefab(
  createBasicMesh2D(mesh, material)
)
```

## Migration Guide

### Replace Material Components

Replace:

```js
new BasicMaterial2D(handle)
new BasicMaterial3D(handle)
```

with:

```js
new BasicMaterialInstance(handle)
```

### Replace Material Types

Replace queries:

```js
Query(world, [BasicMaterial2D])
Query(world, [BasicMaterial3D])
```

with:

```js
Query(world, [BasicMaterialInstance])
```

### Replace Manual Mesh Construction

Replace:

```js
[
  ...createTransform2D(),
  new Meshed(mesh),
  new BasicMaterial2D(material)
]
```

with:

```js
[
  ...createBasicMesh2D(mesh, material)
]
```

or

```js
[
  ...createBasicMesh3D(mesh, material)
]
```

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
