### PR TITLE
Add `PluginGroup.replace`

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -232,7 +232,6 @@ export class PluginGroup extends Plugin {
     this.plugins.set(plugin.name(), plugin)
 
     return this
-
   }
 
   /**
@@ -240,6 +239,20 @@ export class PluginGroup extends Plugin {
    */
   remove(id) {
     this.plugins.delete(id)
+
+    return this
+  }
+
+  /**
+   * @template {Plugin} T
+   * @param {T} plugin
+   */
+  replace(plugin) {
+    const typeId = plugin.name()
+
+    this
+      .remove(typeId)
+      .add(plugin)
 
     return this
   }


### PR DESCRIPTION
## Objective

Adds a convenience API for replacing plugins inside a plugin group.

## Solution

### Root Cause

`PluginGroup` supported adding and removing plugins, but replacing a plugin required manually calling:

```js
group.remove(plugin.name())
group.add(plugin)
```

This made plugin customization more verbose than necessary.

### Changes Made

* Introduces `PluginGroup.replace()` allowing an existing plugin to be removed and replaced by another plugin with the same type ID

### Why This Approach

The implementation reuses the existing `remove()` and `add()` methods, keeping behavior consistent with the current plugin group lifecycle.

## Showcase

### Before

```js
group
  .remove(plugin.name())
  .add(plugin)
```

### After

```js
group.replace(plugin)
```

## Migration Guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
