### PR TITLE
Constructor on type entry

### DIFF
--- a/src/reflect/resources/typeregistry.js
+++ b/src/reflect/resources/typeregistry.js
@@ -18,15 +18,16 @@ export class TypeRegistry {
   register(type, info) {
     const typeId = typeid(type)
 
-    this.registerTypeId(typeId, info)
+    this.registerTypeId(typeId, info, type)
   }
 
   /**
    * @param {TypeId} typeId
    * @param {TypeInfo} info
+   * @param {Constructor | undefined} [constructorFn]
    */
-  registerTypeId(typeId, info) {
-    const entry = new TypeEntry(info)
+  registerTypeId(typeId, info, constructorFn) {
+    const entry = new TypeEntry(info, constructorFn)
 
     this.inner.set(typeId, entry)
   }
@@ -74,6 +75,11 @@ export class TypeEntry {
   info
 
   /**
+   * @type {Constructor | undefined}
+   */
+  constructorFn
+
+  /**
    * @private
    * @type {Map<string, MethodEntry>}
    */
@@ -81,9 +87,11 @@ export class TypeEntry {
 
   /**
    * @param {TypeInfo} info
+   * @param {Constructor | undefined} [constructorFn]
    */
-  constructor(info) {
+  constructor(info, constructorFn) {
     this.info = info
+    this.constructorFn = constructorFn
   }
 
   /**

--- a/src/reflect/tests/typeentry.test.js
+++ b/src/reflect/tests/typeentry.test.js
@@ -4,6 +4,20 @@ import { StructInfo } from "../core/index.js";
 import { MethodEntry, TypeEntry } from "../resources/index.js";
 
 describe("Testing `TypeEntry` method registry", () => {
+  test("`TypeEntry` defaults constructorFn to undefined", () => {
+    const entry = new TypeEntry(StructInfo.default());
+
+    strictEqual(entry.constructorFn, undefined);
+  });
+
+  test("`TypeEntry` stores constructorFn when provided", () => {
+    class Test {}
+
+    const entry = new TypeEntry(StructInfo.default(), Test);
+
+    strictEqual(entry.constructorFn, Test);
+  });
+
   test("`TypeEntry` can set and get methods", () => {
     /**
      * @param {number} a

--- a/src/reflect/tests/typeregistry.test.js
+++ b/src/reflect/tests/typeregistry.test.js
@@ -1,6 +1,6 @@
 import { test, describe } from "node:test";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import { Field, OpaqueInfo, StructInfo, EnumInfo, FunctionInfo } from "../core/index.js";
-import { deepStrictEqual } from "node:assert";
 import { setTypeId, typeid, typeidFunction } from "../../type/index.js";
 import { TypeRegistry } from "../resources/index.js";
 
@@ -36,6 +36,7 @@ describe("Testing `TypeRegistry`", () => {
     deepStrictEqual(registry.get(Test)?.info, new StructInfo({
       age: new Field(typeid(Number))
     }))
+    strictEqual(registry.get(Test)?.constructorFn, Test)
   })
 
   test('`TypeRegistry` registers enum types correctly', () => {
@@ -44,6 +45,7 @@ describe("Testing `TypeRegistry`", () => {
 
     registry.registerTypeId(typeid, new EnumInfo(TestEnum))
     deepStrictEqual(registry.getByTypeId(typeid)?.info, new EnumInfo(TestEnum))
+    strictEqual(registry.getByTypeId(typeid)?.constructorFn, undefined)
   })
 
   test('`TypeRegistry` registers function info by type id', () => {


### PR DESCRIPTION
## Objective

This allows `TypeEntry` records to preserve the original constructor when a type is registered through `TypeRegistry.register()`.

## Solution

### Root Cause

`TypeRegistry` previously stored only `TypeInfo` in each `TypeEntry`. As a result, registry entries could describe a type but could not recover the original constructor used during registration.

### Changes Made

* Updated `TypeRegistry.register()` to pass the registered type constructor into `registerTypeId()`.
* Updated `registerTypeId()` to accept an optional `constructorFn`.
* Added `constructorFn` to `TypeEntry`.
* Updated `TypeEntry` construction to store the constructor when provided.
* Added tests for constructor storage and default `undefined` behavior.

### Why This Approach

The change keeps `registerTypeId()` compatible with existing type-id-only registration while preserving constructor metadata when it is available through `register()`.

## Showcase

### Before

```js
class Test {}

registry.register(Test, StructInfo.default())

registry.get(Test)?.constructorFn // undefined
```

### After

```js
class Test {}

registry.register(Test, StructInfo.default())

registry.get(Test)?.constructorFn === Test // true
```

## Migration Guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
