### PR TITLE
Implement resources for scenes

### DIFF
--- a/src/scene/assets/scene.js
+++ b/src/scene/assets/scene.js
@@ -42,6 +42,10 @@ export class Scene {
         continue
       }
 
+      if (patchResource(resource, world, entry)) {
+        continue
+      }
+
       const restoredResource = fromSnapshot(resource, world, entry)
 
       if (!restoredResource) {
@@ -220,4 +224,20 @@ function fromSnapshot(component, world, entry) {
   warn(`The component \`${name}\` has not been restored as there is no \`fromSnapshot\` or \`clone\` method registered in the \`TypeRegistry\``)
 
   return undefined
+}
+
+/**
+ * @param {object} resource
+ * @param {World} world
+ * @param {import('../../reflect/resources/typeregistry.js').TypeEntry} entry
+ * @returns {boolean}
+ */
+function patchResource(resource, world, entry) {
+  const method = entry.getMethod('patch')
+
+  if (!method) {
+    return false
+  }
+
+  return entry.call('patch', [resource, world]) === true
 }

--- a/src/scene/assets/scene.js
+++ b/src/scene/assets/scene.js
@@ -3,64 +3,19 @@ import { Entity, Query, World } from '../../ecs/index.js'
 import { Parent } from '../../hierarchy/index.js'
 import { warn } from '../../logger/index.js'
 import { TypeRegistry } from '../../reflect/index.js'
+import { typeid } from '../../type/index.js'
 import { SceneInstance } from '../components/index.js'
-
-/**
- * @param {object} component
- * @param {World} world
- * @param {import('../../reflect/resources/typeregistry.js').TypeEntry} entry
- */
-function toSnapshot(component, world, entry) {
-  const method = entry.getMethod('toSnapshot')
-
-  if (method) {
-    return method.method.call(component, world)
-  }
-
-  const clone = entry?.getMethod('clone')
-
-  if (clone) {
-    return clone.method.call(component)
-  }
-
-  const { constructor } = component
-  const name = constructor.name || 'Unknown'
-
-  warn(`The component \`${name}\` has not been snapshotted as there is no \`toSnapshot\` or \`clone\` method registered in the \`TypeRegistry\``)
-
-  return undefined
-}
-
-/**
- * @param {object} component
- * @param {World} world
- * @param {import('../../reflect/resources/typeregistry.js').TypeEntry} entry
- */
-function fromSnapshot(component, world, entry) {
-  const method = entry.getMethod('fromSnapshot')
-
-  if (method) {
-    return method.method.call(component, world)
-  }
-
-  const clone = entry?.call('clone', [component])
-
-  if (clone) {
-    return clone
-  }
-
-  const { constructor } = component
-  const name = constructor.name || 'Unknown'
-
-  warn(`The component \`${name}\` has not been restored as there is no \`fromSnapshot\` or \`clone\` method registered in the \`TypeRegistry\``)
-
-  return undefined
-}
 
 export class Scene {
 
   /** @type {Map<EntityId, object[]> } */
   entities = new Map()
+
+  /**
+   * Resource snapshots keyed by their snapshot type id.
+   * @type {Map<import('../../type/index.js').TypeId, object>}
+   */
+  resources = new Map()
 
   /**
    * @param {World} world
@@ -79,17 +34,46 @@ export class Scene {
       sceneToWorldMap.set(entity, worldEntity.id())
     }
 
+    for (const [typeId, resource] of this.resources) {
+      const entry = typeRegistry.getByTypeId(typeId)
+
+      if (!entry) {
+        warn(`The type \`${typeId}\` is not registered in the type registry`)
+        continue
+      }
+
+      const restoredResource = fromSnapshot(resource, world, entry)
+
+      if (!restoredResource) {
+        continue
+      }
+
+      entry
+        .getMethod('map')
+        ?.method
+        ?.call(restoredResource, sceneToWorldMap)
+
+      world.setResource(restoredResource)
+    }
+
     for (const [entity, components] of this.entities) {
       const worldEntity = sceneToWorldMap.get(entity)
       const clonedComponents = components.map((component) => {
         const { constructor } = component
-        const type = /** @type {import('../../type/index.js').Constructor} */ (constructor)
-        const entry = typeRegistry.get(type)
 
-        if(!entry){
-          warn(`The type \`${constructor.name}\` is not registered in the type registry`)
+        if (constructor === Entity) {
           return undefined
         }
+
+        const componentType = /** @type {import('../../type/index.js').Constructor} */ (constructor)
+        const entry = typeRegistry.get(componentType)
+
+        if (!entry) {
+          warn(`The type \`${componentType.name}\` is not registered in the type registry`)
+
+          return undefined
+        }
+
         const clonedComponent = fromSnapshot(component, world, entry)
 
         if (!clonedComponent) {
@@ -126,14 +110,17 @@ export class Scene {
       const components = []
 
       for (let i = 0; i < typeIds.length; i++) {
-        const typeId = /**@type {import('../../type/index.js').TypeId}*/(typeIds[i])
-        const component = /**@type {object}*/(cell.getTypeId(typeId))
+        const typeId = /** @type {import('../../type/index.js').TypeId} */(typeIds[i])
+        const component = /** @type {object} */(cell.getTypeId(typeId))
         const entry = typeRegistry.getByTypeId(typeId)
 
-        if(!entry){
-          warn(`The type \`${component.constructor.name}\` is not registered in the type registry`)
+        if (!entry) {
+          const name = component?.constructor?.name || 'Unknown'
+
+          warn(`The type \`${name}\` is not registered in the type registry`)
           continue
         }
+
         const snapshot = toSnapshot(component, world, entry)
 
         if (snapshot) {
@@ -143,6 +130,27 @@ export class Scene {
 
       scene.entities.set(entity.id(), components)
     })
+
+    for (const [typeId, resource] of world.getResources()) {
+      const resourceObject = /** @type {object} */ (resource)
+      const entry = typeRegistry.getByTypeId(typeId)
+
+      if (!entry) {
+        warn(`The type \`${typeId}\` is not registered in the type registry`)
+        continue
+      }
+
+      const snapshot = toSnapshot(resourceObject, world, entry)
+
+      if (!snapshot) {
+        continue
+      }
+
+      scene.resources.set(
+        typeid(/** @type {import('../../type/index.js').Constructor} */ (snapshot.constructor)),
+        /** @type {object} */ (snapshot)
+      )
+    }
 
     return scene
   }
@@ -162,4 +170,54 @@ export class Scene {
   * [Symbol.iterator]() {
     return this.entities
   }
+}
+
+/**
+ * @param {object} component
+ * @param {World} world
+ * @param {import('../../reflect/resources/typeregistry.js').TypeEntry} entry
+ */
+function toSnapshot(component, world, entry) {
+  const method = entry.getMethod('toSnapshot')
+
+  if (method) {
+    return method.method.call(component, world)
+  }
+
+  const clone = entry.call('clone', [component])
+
+  if (clone) {
+    return clone
+  }
+
+  const name = component?.constructor?.name || 'Unknown'
+
+  warn(`The component \`${name}\` has not been snapshotted as there is no \`toSnapshot\` or \`clone\` method registered in the \`TypeRegistry\``)
+
+  return undefined
+}
+
+/**
+ * @param {object} component
+ * @param {World} world
+ * @param {import('../../reflect/resources/typeregistry.js').TypeEntry} entry
+ */
+function fromSnapshot(component, world, entry) {
+  const method = entry.getMethod('fromSnapshot')
+
+  if (method) {
+    return method.method.call(component, world)
+  }
+
+  const clone = entry.call('clone', [component])
+
+  if (clone) {
+    return clone
+  }
+
+  const name = component?.constructor?.name || 'Unknown'
+
+  warn(`The component \`${name}\` has not been restored as there is no \`fromSnapshot\` or \`clone\` method registered in the \`TypeRegistry\``)
+
+  return undefined
 }

--- a/src/scene/assets/scene.js
+++ b/src/scene/assets/scene.js
@@ -6,12 +6,12 @@ import { TypeRegistry } from '../../reflect/index.js'
 import { SceneInstance } from '../components/index.js'
 
 /**
- * @param {unknown} component
+ * @param {object} component
  * @param {World} world
- * @param {import('../../reflect/resources/typeregistry.js').TypeEntry | undefined} entry
+ * @param {import('../../reflect/resources/typeregistry.js').TypeEntry} entry
  */
 function toSnapshot(component, world, entry) {
-  const method = entry?.getMethod('toSnapshot')
+  const method = entry.getMethod('toSnapshot')
 
   if (method) {
     return method.method.call(component, world)
@@ -26,18 +26,18 @@ function toSnapshot(component, world, entry) {
   const { constructor } = component
   const name = constructor.name || 'Unknown'
 
-  warn(`The component \`${name}\` has not been snapshotted as there is no toSnapshot or clone method registered in the \`TypeRegistry\``)
+  warn(`The component \`${name}\` has not been snapshotted as there is no \`toSnapshot\` or \`clone\` method registered in the \`TypeRegistry\``)
 
   return undefined
 }
 
 /**
- * @param {unknown} component
+ * @param {object} component
  * @param {World} world
- * @param {import('../../reflect/resources/typeregistry.js').TypeEntry | undefined} entry
+ * @param {import('../../reflect/resources/typeregistry.js').TypeEntry} entry
  */
 function fromSnapshot(component, world, entry) {
-  const method = entry?.getMethod('fromSnapshot')
+  const method = entry.getMethod('fromSnapshot')
 
   if (method) {
     return method.method.call(component, world)
@@ -52,7 +52,7 @@ function fromSnapshot(component, world, entry) {
   const { constructor } = component
   const name = constructor.name || 'Unknown'
 
-  warn(`The component \`${name}\` has not been restored as there is no fromSnapshot or clone method registered in the \`TypeRegistry\``)
+  warn(`The component \`${name}\` has not been restored as there is no \`fromSnapshot\` or \`clone\` method registered in the \`TypeRegistry\``)
 
   return undefined
 }
@@ -66,7 +66,7 @@ export class Scene {
    * @param {World} world
    * @param {SceneInstance} instance
    * @param {TypeRegistry} typeRegistry
-   * @param {Entity} [instanceEntity]
+   * @param {Entity} instanceEntity
    */
   toWorld(world, instance, typeRegistry, instanceEntity) {
     const { entityMap: worldToSceneMap } = instance
@@ -85,6 +85,11 @@ export class Scene {
         const { constructor } = component
         const type = /** @type {import('../../type/index.js').Constructor} */ (constructor)
         const entry = typeRegistry.get(type)
+
+        if(!entry){
+          warn(`The type \`${constructor.name}\` is not registered in the type registry`)
+          return undefined
+        }
         const clonedComponent = fromSnapshot(component, world, entry)
 
         if (!clonedComponent) {
@@ -121,9 +126,14 @@ export class Scene {
       const components = []
 
       for (let i = 0; i < typeIds.length; i++) {
-        const typeId = typeIds[i]
-        const component = cell.getTypeId(typeId)
+        const typeId = /**@type {import('../../type/index.js').TypeId}*/(typeIds[i])
+        const component = /**@type {object}*/(cell.getTypeId(typeId))
         const entry = typeRegistry.getByTypeId(typeId)
+
+        if(!entry){
+          warn(`The type \`${component.constructor.name}\` is not registered in the type registry`)
+          continue
+        }
         const snapshot = toSnapshot(component, world, entry)
 
         if (snapshot) {

--- a/src/scene/resources/exporters/json.js
+++ b/src/scene/resources/exporters/json.js
@@ -20,7 +20,13 @@ export class JSONSceneExporter extends Exporter {
       entities: Object.fromEntries(
         [...asset.entities].map(([entity, components]) => [
           entity,
-          serializeComponents(components, typeRegistry)
+          serializeSnapshots(components, typeRegistry)
+        ])
+      ),
+      resources: Object.fromEntries(
+        [...asset.resources].map(([typeId, resource]) => [
+          typeId,
+          serializeSnapshot(resource, typeId, typeRegistry)
         ])
       )
     })
@@ -32,24 +38,34 @@ export class JSONSceneExporter extends Exporter {
 }
 
 /**
- * @param {unknown[]} components
+ * @param {unknown[]} snapshots
  * @param {import('../../../reflect/resources/index.js').TypeRegistry} typeRegistry
  * @returns {Record<string, unknown>}
  */
-function serializeComponents(components, typeRegistry) {
+function serializeSnapshots(snapshots, typeRegistry) {
 
   /** @type {Record<import('../../../type/index.js').TypeId, unknown>} */
   const serial = {}
 
-  for (let i = 0; i < components.length; i++) {
-    const component = components[i]
-    const type = /** @type {import('../../../type/index.js').Constructor} */ (component.constructor)
-    const typeId = typeid(type)
-    const entry = typeRegistry.getByTypeId(typeId)
-    const value = entry?.call('serialize', [component]) ?? component
+  for (let i = 0; i < snapshots.length; i++) {
+    const snapshot = /** @type {object}*/(snapshots[i])
+    const typeId = typeid(/** @type {import('../../../type/index.js').Constructor} */ (snapshot.constructor))
 
-    serial[typeId] = value
+    serial[typeId] = serializeSnapshot(snapshot, typeId, typeRegistry)
   }
 
   return serial
+}
+
+/**
+ * @param {unknown} snapshot
+ * @param {import('../../../type/index.js').TypeId} typeId
+ * @param {import('../../../reflect/resources/index.js').TypeRegistry} typeRegistry
+ * @returns {unknown}
+ */
+function serializeSnapshot(snapshot, typeId, typeRegistry) {
+  const entry = typeRegistry.getByTypeId(typeId)
+  const value = entry?.call('serialize', [snapshot]) ?? snapshot
+
+  return value
 }

--- a/src/scene/resources/importers/json.js
+++ b/src/scene/resources/importers/json.js
@@ -34,37 +34,47 @@ export class JSONSceneImporter extends Importer {
 function deserializeScene(serial, typeRegistry) {
   const scene = new Scene()
 
-  if (
-    typeof serial !== 'object' ||
-    serial === null ||
-    !('entities' in serial) ||
-    serial.entities === null ||
-    typeof serial.entities !== 'object'
-  ) {
+  if (typeof serial !== 'object' || serial === null) {
     return scene
   }
 
-  for (const [entityId, componentsSerial] of Object.entries(serial.entities)) {
-    if (!componentsSerial || typeof componentsSerial !== 'object') continue
+  if ('entities' in serial && serial.entities && typeof serial.entities === 'object') {
+    for (const [entityId, componentsSerial] of Object.entries(serial.entities)) {
+      if (!componentsSerial || typeof componentsSerial !== 'object') continue
 
-    const components = Object.entries(componentsSerial).map(([typeId, value]) => {
-      const component = deserializeComponent(/** @type {import('../../../type/index.js').TypeId} */ (typeId), value, typeRegistry)
+      const components = Object.entries(componentsSerial).map(([typeId, value]) => {
+        const component = deserializeComponent(/** @type {import('../../../type/index.js').TypeId} */ (typeId), value, typeRegistry)
 
-      if (typeof component !== 'object' || component === null) {
-        warn(`Failed to deserialize component with type id \`${typeId}\`.`)
+        if (typeof component !== 'object' || component === null) {
+          warn(`Failed to deserialize scene snapshot with type id \`${typeId}\`.`)
 
-        return undefined
+          return undefined
+        }
+
+        return component
+      })
+        .filter((component) => component !== undefined)
+
+      const numericEntityId = Number(entityId)
+
+      if (!Number.isFinite(numericEntityId)) continue
+
+      scene.entities.set(/** @type {import('../../../ecs/index.js').EntityId} */ (numericEntityId), components)
+    }
+  }
+
+  if ('resources' in serial && serial.resources && typeof serial.resources === 'object') {
+    for (const [typeId, value] of Object.entries(serial.resources)) {
+      const resource = deserializeComponent(/** @type {import('../../../type/index.js').TypeId} */ (typeId), value, typeRegistry)
+
+      if (typeof resource !== 'object' || resource === null) {
+        warn(`Failed to deserialize scene snapshot with type id \`${typeId}\`.`)
+
+        continue
       }
 
-      return component
-    })
-      .filter(Boolean)
-
-    const numericEntityId = Number(entityId)
-
-    if (!Number.isFinite(numericEntityId)) continue
-
-    scene.entities.set(/** @type {import('../../../ecs/index.js').EntityId} */ (numericEntityId), components)
+      scene.resources.set(/** @type {import('../../../type/index.js').TypeId} */ (typeId), resource)
+    }
   }
 
   return scene

--- a/src/scene/tests/assets/scene.test.js
+++ b/src/scene/tests/assets/scene.test.js
@@ -1,0 +1,517 @@
+import { deepStrictEqual, strictEqual } from 'assert'
+import test, { describe } from 'node:test'
+import { Entity, Query, World } from '../../../ecs/index.js'
+import { Parent } from '../../../hierarchy/index.js'
+import { Scene } from '../../assets/index.js'
+import { SceneInstance } from '../../components/index.js'
+import { StructInfo } from '../../../reflect/core/index.js'
+import { TypeRegistry } from '../../../reflect/resources/index.js'
+import { typeid } from '../../../type/index.js'
+
+class PureComponent {
+  value = ''
+
+  /**
+   * @param {string} value
+   */
+  constructor(value) {
+    this.value = value
+  }
+
+  /**
+   * @param {PureComponent} target
+   */
+  static clone(target) {
+    return new PureComponent(target.value)
+  }
+
+  /**
+   * @param {World} _world
+   * @returns {ComponentSnapshot}
+   */
+  toSnapshot(_world) {
+    return new ComponentSnapshot(this.value)
+  }
+}
+
+class PureResource {
+  value = ''
+
+  /**
+   * @param {string} value
+   */
+  constructor(value) {
+    this.value = value
+  }
+
+  /**
+   * @param {PureResource} target
+   */
+  static clone(target) {
+    return new PureResource(target.value)
+  }
+
+  /**
+   * @param {World} _world
+   * @returns {ResourceSnapshot}
+   */
+  toSnapshot(_world) {
+    return new ResourceSnapshot(this.value)
+  }
+}
+
+class ComponentSnapshot {
+  value = ''
+
+  /**
+   * @param {string} value
+   */
+  constructor(value) {
+    this.value = value
+  }
+
+  /**
+   * @param {World} _world
+   * @returns {PureComponent}
+   */
+  fromSnapshot(_world) {
+    return new PureComponent(this.value)
+  }
+}
+
+class ResourceSnapshot {
+  value = ''
+
+  /**
+   * @param {string} value
+   */
+  constructor(value) {
+    this.value = value
+  }
+
+  /**
+   * @param {World} _world
+   * @returns {PureResource}
+   */
+  fromSnapshot(_world) {
+    return new PureResource(this.value)
+  }
+}
+
+class PatchableResource {
+  value = ''
+
+  /**
+   * @param {string} value
+   */
+  constructor(value) {
+    this.value = value
+  }
+}
+
+class PatchableResourceSnapshot {
+  value = ''
+
+  /**
+   * @param {string} value
+   */
+  constructor(value) {
+    this.value = value
+  }
+
+  /**
+   * @param {PatchableResourceSnapshot} sceneResource
+   * @param {World} _world
+   */
+  static patch(sceneResource, _world) {
+    if (!_world.hasResource(PatchableResource)) {
+      return false
+    }
+
+    const worldResource = _world.getResource(PatchableResource)
+
+    worldResource.value = `${worldResource.value}:${sceneResource.value}`
+
+    return true
+  }
+
+  /**
+   * @param {World} _world
+   * @returns {PatchableResource}
+   */
+  fromSnapshot(_world) {
+    throw new Error('`fromSnapshot` should not be called when patching is available')
+  }
+}
+
+class DeferredPatchResource {
+  value = ''
+
+  /**
+   * @param {string} value
+   */
+  constructor(value) {
+    this.value = value
+  }
+}
+
+class DeferredPatchResourceSnapshot {
+  value = ''
+
+  /**
+   * @param {string} value
+   */
+  constructor(value) {
+    this.value = value
+  }
+
+  /**
+   * @param {DeferredPatchResourceSnapshot} _sceneResource
+   * @param {World} _world
+   * @returns {boolean}
+   */
+  static patch(_sceneResource, _world) {
+    return false
+  }
+
+  /**
+   * @param {World} _world
+   * @returns {DeferredPatchResource}
+   */
+  fromSnapshot(_world) {
+    return new DeferredPatchResource(this.value)
+  }
+}
+
+/**
+ * @returns {TypeRegistry}
+ */
+function createRegistry() {
+  const registry = new TypeRegistry()
+
+  registry.register(Entity, StructInfo.default())
+  registry.get(Entity)?.setMethod(/** @param {Entity} target */ function clone(target) {
+    return Entity.from(target.id())
+  })
+
+  registry.register(PureComponent, StructInfo.default())
+  registry.get(PureComponent)?.setMethod(PureComponent.clone)
+  registry.get(PureComponent)?.setMethod(PureComponent.prototype.toSnapshot)
+
+  registry.register(ComponentSnapshot, StructInfo.default())
+  registry.get(ComponentSnapshot)?.setMethod(ComponentSnapshot.prototype.fromSnapshot)
+
+  registry.register(PureResource, StructInfo.default())
+  registry.get(PureResource)?.setMethod(PureResource.clone)
+  registry.get(PureResource)?.setMethod(PureResource.prototype.toSnapshot)
+
+  registry.register(ResourceSnapshot, StructInfo.default())
+  registry.get(ResourceSnapshot)?.setMethod(ResourceSnapshot.prototype.fromSnapshot)
+
+  return registry
+}
+
+describe('Testing `Scene`', { concurrency: false }, () => {
+  describe('with pure types', { concurrency: false }, () => {
+    test('`Scene.fromWorld` restores pure entities', () => {
+      const registry = createRegistry()
+      const world = new World()
+      const entity = world.spawn([])
+      const scene = Scene.fromWorld(world, registry)
+
+      strictEqual(scene.entities.size, 1)
+      strictEqual(scene.resources.size, 0)
+      deepStrictEqual(scene.entities.get(entity.id()), [
+        new Entity(entity.index, entity.generation)
+      ])
+    })
+
+    test('`Scene.toWorld` restores pure entities', () => {
+      const registry = createRegistry()
+      const world = new World()
+      const entity = new Entity(42, 1)
+      const scene = new Scene()
+      const instance = new SceneInstance(/** @type {any} */ (null))
+      const instanceEntity = new Entity(99, 1)
+
+      scene.entities.set(entity.id(), [
+        new Entity(entity.index, entity.generation)
+      ])
+
+      scene.toWorld(world, instance, registry, instanceEntity)
+
+      strictEqual(world.getResources().size, 0)
+      strictEqual(instance.entityMap.size, 1)
+
+      const single = new Query(world, [Entity]).single()
+
+      strictEqual(single !== null, true)
+
+      const [restoredEntity] = single
+      const cell = world.getEntity(restoredEntity)
+
+      strictEqual(cell.hasTypeid([typeid(Entity), typeid(Parent)]), true)
+      deepStrictEqual(cell.get(Entity), restoredEntity)
+      deepStrictEqual(cell.get(Parent), new Parent(instanceEntity))
+      strictEqual(instance.entityMap.get(restoredEntity.id()), entity.id())
+    })
+
+    test('`Scene.fromWorld` restores pure resources', () => {
+      const registry = createRegistry()
+      const world = new World()
+
+      world.setResource(new PureResource('resource'))
+
+      const scene = Scene.fromWorld(world, registry)
+
+      strictEqual(scene.entities.size, 0)
+      strictEqual(scene.resources.size, 1)
+      deepStrictEqual(
+        scene.resources.get(typeid(ResourceSnapshot)),
+        new ResourceSnapshot('resource')
+      )
+    })
+
+    test('`Scene.toWorld` restores pure resources', () => {
+      const registry = createRegistry()
+      const scene = new Scene()
+      const world = new World()
+      const instance = new SceneInstance(/** @type {any} */ (null))
+
+      scene.resources.set(
+        typeid(PureResource),
+        new PureResource('resource')
+      )
+
+      scene.toWorld(world, instance, registry, new Entity(99, 1))
+
+      strictEqual(new Query(world, [Entity]).count(), 0)
+      strictEqual(world.getResources().size, 1)
+      strictEqual(instance.entityMap.size, 0)
+      deepStrictEqual(world.getResource(PureResource), new PureResource('resource'))
+    })
+
+    test('`Scene.fromWorld` restores entities and components', () => {
+      const registry = createRegistry()
+      const world = new World()
+      const entity = world.spawn([new PureComponent('component')])
+      const scene = Scene.fromWorld(world, registry)
+
+      strictEqual(scene.entities.size, 1)
+      strictEqual(scene.resources.size, 0)
+      deepStrictEqual(scene.entities.get(entity.id()), [
+        new ComponentSnapshot('component'),
+        new Entity(entity.index, entity.generation)
+      ])
+    })
+
+    test('`Scene.toWorld` restores entities and components', () => {
+      const registry = createRegistry()
+      const world = new World()
+      const entity = world.spawn([new PureComponent('component')])
+      const scene = Scene.fromWorld(world, registry)
+      const targetWorld = new World()
+      const instance = new SceneInstance(/** @type {any} */ (null))
+      const instanceEntity = new Entity(99, 1)
+
+      scene.toWorld(targetWorld, instance, registry, instanceEntity)
+
+      strictEqual(targetWorld.getResources().size, 0)
+      strictEqual(instance.entityMap.size, 1)
+
+      const single = new Query(targetWorld, [Entity]).single()
+
+      strictEqual(single !== null, true)
+
+      const [restoredEntity] = single
+      const cell = targetWorld.getEntity(restoredEntity)
+
+      strictEqual(
+        cell.hasTypeid([typeid(Entity), typeid(PureComponent), typeid(Parent)]),
+        true
+      )
+      deepStrictEqual(cell.get(Entity), restoredEntity)
+      deepStrictEqual(cell.get(PureComponent), new PureComponent('component'))
+      deepStrictEqual(cell.get(Parent), new Parent(instanceEntity))
+      strictEqual(instance.entityMap.get(restoredEntity.id()), entity.id())
+    })
+  })
+
+  describe('with snapshots', { concurrency: false }, () => {
+    test('`Scene.fromWorld` restores pure entities', () => {
+      const registry = createRegistry()
+      const world = new World()
+      const entity = world.spawn([])
+      const scene = Scene.fromWorld(world, registry)
+
+      strictEqual(scene.entities.size, 1)
+      strictEqual(scene.resources.size, 0)
+      deepStrictEqual(scene.entities.get(entity.id()), [
+        new Entity(entity.index, entity.generation)
+      ])
+    })
+
+    test('`Scene.toWorld` restores pure entities', () => {
+      const registry = createRegistry()
+      const world = new World()
+      const entity = new Entity(42, 1)
+      const scene = new Scene()
+      const instance = new SceneInstance(/** @type {any} */ (null))
+      const instanceEntity = new Entity(99, 1)
+
+      scene.entities.set(entity.id(), [
+        new Entity(entity.index, entity.generation)
+      ])
+
+      scene.toWorld(world, instance, registry, instanceEntity)
+
+      strictEqual(world.getResources().size, 0)
+      strictEqual(instance.entityMap.size, 1)
+
+      const single = new Query(world, [Entity]).single()
+
+      strictEqual(single !== null, true)
+
+      const [restoredEntity] = single
+      const cell = world.getEntity(restoredEntity)
+
+      strictEqual(cell.hasTypeid([typeid(Entity), typeid(Parent)]), true)
+      deepStrictEqual(cell.get(Entity), restoredEntity)
+      deepStrictEqual(cell.get(Parent), new Parent(instanceEntity))
+      strictEqual(instance.entityMap.get(restoredEntity.id()), entity.id())
+    })
+
+    test('`Scene.fromWorld` restores pure resources', () => {
+      const registry = createRegistry()
+      const world = new World()
+
+      world.setResource(new PureResource('resource'))
+
+      const scene = Scene.fromWorld(world, registry)
+
+      strictEqual(scene.entities.size, 0)
+      strictEqual(scene.resources.size, 1)
+      deepStrictEqual(
+        scene.resources.get(typeid(ResourceSnapshot)),
+        new ResourceSnapshot('resource')
+      )
+    })
+
+    test('`Scene.toWorld` restores pure resources', () => {
+      const registry = createRegistry()
+      const scene = new Scene()
+      const world = new World()
+      const instance = new SceneInstance(/** @type {any} */ (null))
+
+      scene.resources.set(
+        typeid(ResourceSnapshot),
+        new ResourceSnapshot('resource')
+      )
+
+      scene.toWorld(world, instance, registry, new Entity(99, 1))
+
+      strictEqual(new Query(world, [Entity]).count(), 0)
+      strictEqual(world.getResources().size, 1)
+      strictEqual(instance.entityMap.size, 0)
+      deepStrictEqual(world.getResource(PureResource), new PureResource('resource'))
+    })
+
+    test('`Scene.fromWorld` restores entities and components', () => {
+      const registry = createRegistry()
+      const world = new World()
+      const entity = world.spawn([new PureComponent('component')])
+      const scene = Scene.fromWorld(world, registry)
+
+      strictEqual(scene.entities.size, 1)
+      strictEqual(scene.resources.size, 0)
+      deepStrictEqual(scene.entities.get(entity.id()), [
+        new ComponentSnapshot('component'),
+        new Entity(entity.index, entity.generation)
+      ])
+    })
+
+    test('`Scene.toWorld` restores entities and components', () => {
+      const registry = createRegistry()
+      const world = new World()
+      const entity = world.spawn([new PureComponent('component')])
+      const scene = Scene.fromWorld(world, registry)
+      const targetWorld = new World()
+      const instance = new SceneInstance(/** @type {any} */ (null))
+      const instanceEntity = new Entity(99, 1)
+
+      scene.toWorld(targetWorld, instance, registry, instanceEntity)
+
+      strictEqual(targetWorld.getResources().size, 0)
+      strictEqual(instance.entityMap.size, 1)
+
+      const single = new Query(targetWorld, [Entity]).single()
+
+      strictEqual(single !== null, true)
+
+      const [restoredEntity] = single
+      const cell = targetWorld.getEntity(restoredEntity)
+
+      strictEqual(
+        cell.hasTypeid([typeid(Entity), typeid(PureComponent), typeid(Parent)]),
+        true
+      )
+      deepStrictEqual(cell.get(Entity), restoredEntity)
+      deepStrictEqual(cell.get(PureComponent), new PureComponent('component'))
+      deepStrictEqual(cell.get(Parent), new Parent(instanceEntity))
+      strictEqual(instance.entityMap.get(restoredEntity.id()), entity.id())
+    })
+  })
+
+  describe('with patching', { concurrency: false }, () => {
+    test('`Scene.toWorld` patches existing world resources', () => {
+      const registry = new TypeRegistry()
+      registry.register(PatchableResource, StructInfo.default())
+      registry.register(PatchableResourceSnapshot, StructInfo.default())
+      registry.get(PatchableResourceSnapshot)?.setMethod(PatchableResourceSnapshot.patch)
+      registry.get(PatchableResourceSnapshot)?.setMethod(PatchableResourceSnapshot.prototype.fromSnapshot)
+
+      const world = new World()
+      const worldResource = new PatchableResource('world')
+      world.setResource(worldResource)
+      world.setResourceAlias(typeid(PatchableResource), PatchableResourceSnapshot)
+
+      const scene = new Scene()
+      scene.resources.set(
+        typeid(PatchableResourceSnapshot),
+        new PatchableResourceSnapshot('scene')
+      )
+
+      const instance = new SceneInstance(/** @type {any} */ (null))
+
+      scene.toWorld(world, instance, registry, new Entity(99, 1))
+
+      strictEqual(world.getResource(PatchableResource), worldResource)
+      strictEqual(world.getResources().size, 1)
+      strictEqual(instance.entityMap.size, 0)
+      deepStrictEqual(worldResource, new PatchableResource('world:scene'))
+    })
+
+    test('`Scene.toWorld` restores resources when patching declines', () => {
+      const registry = new TypeRegistry()
+      registry.register(DeferredPatchResource, StructInfo.default())
+      registry.register(DeferredPatchResourceSnapshot, StructInfo.default())
+      registry.get(DeferredPatchResourceSnapshot)?.setMethod(DeferredPatchResourceSnapshot.patch)
+      registry.get(DeferredPatchResourceSnapshot)?.setMethod(DeferredPatchResourceSnapshot.prototype.fromSnapshot)
+
+      const scene = new Scene()
+      scene.resources.set(
+        typeid(DeferredPatchResourceSnapshot),
+        new DeferredPatchResourceSnapshot('resource')
+      )
+
+      const world = new World()
+      const instance = new SceneInstance(/** @type {any} */ (null))
+
+      scene.toWorld(world, instance, registry, new Entity(99, 1))
+
+      strictEqual(world.getResources().size, 1)
+      strictEqual(instance.entityMap.size, 0)
+      deepStrictEqual(world.getResource(DeferredPatchResource), new DeferredPatchResource('resource'))
+    })
+  })
+})

--- a/src/scene/tests/resources/json.test.js
+++ b/src/scene/tests/resources/json.test.js
@@ -18,6 +18,13 @@ class TestSnapshot {
   }
 
   /**
+   * @param {TestSnapshot} target
+   */
+  static clone(target) {
+    return new TestSnapshot(target.value)
+  }
+
+  /**
    * @param {TestSnapshot} value
    */
   static serialize(value) {
@@ -45,6 +52,7 @@ describe('Testing scene JSON importer/exporter', () => {
     const snapshot = new TestSnapshot('hello')
 
     scene.entities.set(42, [snapshot])
+    scene.resources.set(typeid(TestSnapshot), snapshot)
 
     const text = await exporter.serialize(scene, registry)
     const serial = JSON.parse(text)
@@ -57,11 +65,16 @@ describe('Testing scene JSON importer/exporter', () => {
             value: 'hello'
           }
         }
+      },
+      resources: {
+        [typeid(TestSnapshot)]: {
+          value: 'hello'
+        }
       }
     })
   })
 
-  test('`JSONSceneImporter` restores scene entities through the type registry', async () => {
+  test('`JSONSceneImporter` restores scene entities and resources through the type registry', async () => {
     const registry = createRegistry()
     const importer = new JSONSceneImporter()
     const scene = await importer.deserialize(/** @type {Response} */ ({
@@ -73,6 +86,11 @@ describe('Testing scene JSON importer/exporter', () => {
                 value: 'hello'
               }
             }
+          },
+          resources: {
+            [typeid(TestSnapshot)]: {
+              value: 'hello'
+            }
           }
         }
       }
@@ -82,6 +100,9 @@ describe('Testing scene JSON importer/exporter', () => {
     strictEqual(scene.entities.size, 1)
     strictEqual(scene.entities.get(42)?.[0] instanceof TestSnapshot, true)
     deepStrictEqual(scene.entities.get(42)?.[0], new TestSnapshot('hello'))
+    strictEqual(scene.resources.size, 1)
+    strictEqual(scene.resources.get(typeid(TestSnapshot)) instanceof TestSnapshot, true)
+    deepStrictEqual(scene.resources.get(typeid(TestSnapshot)), new TestSnapshot('hello'))
   })
 })
 
@@ -91,6 +112,7 @@ function createRegistry() {
   registry.register(TestSnapshot, new StructInfo({
     value: new Field(typeid(String))
   }))
+  registry.get(TestSnapshot)?.setMethod(TestSnapshot.clone)
   registry.get(TestSnapshot)?.setMethod(TestSnapshot.serialize)
   registry.get(TestSnapshot)?.setMethod(TestSnapshot.deserialize)
 


### PR DESCRIPTION
## Objective

Expands scene serialization to include world resources, introduces resource restoration and patching during scene instantiation, and refactors snapshot handling to unify component and resource serialization workflows.

## Solution

### Root Cause

The scene system previously only serialized entity/component state. World resources were excluded from scene snapshots, making scenes incomplete representations of world state.

Additionally:

* Snapshot restoration logic was duplicated across scene loading paths.
* Resource restoration lacked support for patching existing world resources.
* JSON import/export only supported entity snapshots.

### Changes Made

* Added resource snapshot support directly to `Scene`.
* Unified snapshot conversion logic. Resolution order:

  ```text
  toSnapshot → clone → warning
  fromSnapshot → clone → warning
  ```

* Added patching support when restoring resources. This allows incremental updates instead of full resource replacement.
* Extended scene serialization format to serialize resources.
* Improved reflection handling for snapshot restoration:
  * Added stricter checks for unregistered types
  * Added warnings for missing type registrations
  * Skipped unsupported types safely during serialization/deserialization

## Showcase

N/A

## Migration Guide

No migration required

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
