### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Deploy static content to Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["dev"]
 
 permissions:
   contents: read
@@ -21,15 +21,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
       - run: npm ci
       - run: "npm run build:docs"
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "./docs"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Node.js Package
 
 permissions:
+  contents: read
   id-token: write
 on:
   release:
@@ -10,20 +11,20 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           cache: npm
       - run: npm ci
       - run: npm run build
       - name: Check version
         run: |
-          VERSION_TAG="${GITHUB_REF#refs/tags/}"
+          VERSION_TAG="${GITHUB_REF_NAME#v}"
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           if [ "$VERSION_TAG" != "$PACKAGE_VERSION" ]; then
-            echo "Error: Git tag ($VERSION_TAG) does not match package.json version ($PACKAGE_VERSION)"
+            echo "Error: Git tag (${GITHUB_REF_NAME}) does not match package.json version (${PACKAGE_VERSION})"
             exit 1
           fi
       - name: Publish check

--- a/.github/workflows/pull-lint.yml
+++ b/.github/workflows/pull-lint.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   pull_request:
-    branches: ["main","dev"]
+    branches: ["dev"]
+
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -10,10 +14,10 @@ jobs:
       source: ${{ steps.filter.outputs.source }}
       examples: ${{ steps.filter.outputs.examples }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           token: ''
@@ -29,8 +33,11 @@ jobs:
     if: needs.changes.outputs.source == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
       - run: npm ci
       - run: npm run lint:src-dry -- --max-warnings=0
   lint-examples:
@@ -38,24 +45,33 @@ jobs:
     if: needs.changes.outputs.examples == 'true'
     runs-on: ubuntu-latest
     steps: 
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
       - run: npm ci
       - run: npm run lint:examples-dry -- --max-warnings=0
   tests:
     needs: compiles
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
       - run: npm ci
       - run: npm run test
   builds:
     needs: compiles
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
       - run: npm ci
       - run: npm run build
   compiles:
@@ -63,7 +79,10 @@ jobs:
     if: needs.changes.outputs.source == 'true'
     runs-on: ubuntu-latest
     steps: 
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
       - run: npm ci
       - run: npm run tsc:lint


### PR DESCRIPTION
## Objective

Upgrades workflow actions, standardizes CI on Node.js 24, adjusts workflow triggers to target `dev`, and tightens publishing/version validation.

## Solution

### Changes Made

* Upgraded GitHub Actions versions:
* Changed Pages deployment trigger from `main` to `dev`.
* Changed PR CI target branches from `main`/`dev` to `dev` only.
* Added explicit `contents: read` permissions where needed.
* Standardized CI, docs, and publish workflows on Node.js `24`.
* Enabled npm dependency caching through `actions/setup-node`.
* Updated npm publish version validation to compare `GITHUB_REF_NAME` without the leading `v`.
* Preserved npm provenance publishing.

### Why This Approach

This keeps the automation stack current, reduces implicit workflow permissions, and aligns CI/deployment behavior with the `dev` branch workflow.

## Showcase

N/A

## Migration Guide

No migration required.

Repository maintainers should note:

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
