### PR TITLE
Add embedded asset support for scene serialization

### DIFF
--- a/assets/scene/basic.json
+++ b/assets/scene/basic.json
@@ -1,154 +1,298 @@
 {
   "entities": {
     "1": {
-      "Position2D": { "x": 3, "y": 0 },
-      "Orientation2D": { "cos": 1, "sin": 0 },
-      "Scale2D": { "x": 1, "y": 1 },
-      "GlobalTransform2D": [1, 0, 0, 1, 0, 0],
+      "Position2D": {
+        "x": 3,
+        "y": 0
+      },
+      "Orientation2D": {
+        "cos": 1,
+        "sin": 0
+      },
+      "Scale2D": {
+        "x": 1,
+        "y": 1
+      },
+      "GlobalTransform2D": [
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
       "MeshedSnapshot": {
         "handle": {
           "type": "Mesh",
-          "asset": 4294967296
+          "asset": 0
         }
       },
       "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
-          "asset": 4294967296
+          "asset": 0
         }
       }
     },
     "2": {
-      "Position2D": { "x": 2.121320343559643, "y": 2.1213203435596424 },
-      "Orientation2D": { "cos": 1, "sin": 0 },
-      "Scale2D": { "x": 1, "y": 1 },
-      "GlobalTransform2D": [1, 0, 0, 1, 0, 0],
+      "Position2D": {
+        "x": 2.121320343559643,
+        "y": 2.1213203435596424
+      },
+      "Orientation2D": {
+        "cos": 1,
+        "sin": 0
+      },
+      "Scale2D": {
+        "x": 1,
+        "y": 1
+      },
+      "GlobalTransform2D": [
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
       "MeshedSnapshot": {
         "handle": {
           "type": "Mesh",
-          "asset": 4294967296
+          "asset": 0
         }
       },
       "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
-          "asset": 4294967296
+          "asset": 0
         }
       }
     },
     "3": {
-      "Position2D": { "x": 0, "y": 3 },
-      "Orientation2D": { "cos": 1, "sin": 0 },
-      "Scale2D": { "x": 1, "y": 1 },
-      "GlobalTransform2D": [1, 0, 0, 1, 0, 0],
+      "Position2D": {
+        "x": 0,
+        "y": 3
+      },
+      "Orientation2D": {
+        "cos": 1,
+        "sin": 0
+      },
+      "Scale2D": {
+        "x": 1,
+        "y": 1
+      },
+      "GlobalTransform2D": [
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
       "MeshedSnapshot": {
         "handle": {
           "type": "Mesh",
-          "asset": 4294967296
+          "asset": 0
         }
       },
       "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
-          "asset": 4294967296
+          "asset": 0
         }
       }
     },
     "4": {
-      "Position2D": { "x": -2.1213203435596424, "y": 2.121320343559643 },
-      "Orientation2D": { "cos": 1, "sin": 0 },
-      "Scale2D": { "x": 1, "y": 1 },
-      "GlobalTransform2D": [1, 0, 0, 1, 0, 0],
+      "Position2D": {
+        "x": -2.1213203435596424,
+        "y": 2.121320343559643
+      },
+      "Orientation2D": {
+        "cos": 1,
+        "sin": 0
+      },
+      "Scale2D": {
+        "x": 1,
+        "y": 1
+      },
+      "GlobalTransform2D": [
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
       "MeshedSnapshot": {
         "handle": {
           "type": "Mesh",
-          "asset": 4294967296
+          "asset": 0
         }
       },
       "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
-          "asset": 4294967296
+          "asset": 0
         }
       }
     },
     "5": {
-      "Position2D": { "x": -3, "y": 0 },
-      "Orientation2D": { "cos": 1, "sin": 0 },
-      "Scale2D": { "x": 1, "y": 1 },
-      "GlobalTransform2D": [1, 0, 0, 1, 0, 0],
+      "Position2D": {
+        "x": -3,
+        "y": 0
+      },
+      "Orientation2D": {
+        "cos": 1,
+        "sin": 0
+      },
+      "Scale2D": {
+        "x": 1,
+        "y": 1
+      },
+      "GlobalTransform2D": [
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
       "MeshedSnapshot": {
         "handle": {
           "type": "Mesh",
-          "asset": 4294967296
+          "asset": 0
         }
       },
       "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
-          "asset": 4294967296
+          "asset": 0
         }
       }
     },
     "6": {
-      "Position2D": { "x": -2.121320343559643, "y": -2.1213203435596424 },
-      "Orientation2D": { "cos": 1, "sin": 0 },
-      "Scale2D": { "x": 1, "y": 1 },
-      "GlobalTransform2D": [1, 0, 0, 1, 0, 0],
+      "Position2D": {
+        "x": -2.121320343559643,
+        "y": -2.1213203435596424
+      },
+      "Orientation2D": {
+        "cos": 1,
+        "sin": 0
+      },
+      "Scale2D": {
+        "x": 1,
+        "y": 1
+      },
+      "GlobalTransform2D": [
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
       "MeshedSnapshot": {
         "handle": {
           "type": "Mesh",
-          "asset": 4294967296
+          "asset": 0
         }
       },
       "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
-          "asset": 4294967296
+          "asset": 0
         }
       }
     },
     "7": {
-      "Position2D": { "x": 0, "y": -3 },
-      "Orientation2D": { "cos": 1, "sin": 0 },
-      "Scale2D": { "x": 1, "y": 1 },
-      "GlobalTransform2D": [1, 0, 0, 1, 0, 0],
+      "Position2D": {
+        "x": 0,
+        "y": -3
+      },
+      "Orientation2D": {
+        "cos": 1,
+        "sin": 0
+      },
+      "Scale2D": {
+        "x": 1,
+        "y": 1
+      },
+      "GlobalTransform2D": [
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
       "MeshedSnapshot": {
         "handle": {
           "type": "Mesh",
-          "asset": 4294967296
+          "asset": 0
         }
       },
       "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
-          "asset": 4294967296
+          "asset": 0
         }
       }
     },
     "8": {
-      "Position2D": { "x": 2.1213203435596424, "y": -2.121320343559643 },
-      "Orientation2D": { "cos": 1, "sin": 0 },
-      "Scale2D": { "x": 1, "y": 1 },
-      "GlobalTransform2D": [1, 0, 0, 1, 0, 0],
+      "Position2D": {
+        "x": 2.1213203435596424,
+        "y": -2.121320343559643
+      },
+      "Orientation2D": {
+        "cos": 1,
+        "sin": 0
+      },
+      "Scale2D": {
+        "x": 1,
+        "y": 1
+      },
+      "GlobalTransform2D": [
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
       "MeshedSnapshot": {
         "handle": {
           "type": "Mesh",
-          "asset": 4294967296
+          "asset": 0
         }
       },
       "BasicMaterialInstanceSnapshot": {
         "handle": {
           "type": "BasicMaterial",
-          "asset": 4294967296
+          "asset": 0
         }
       }
     },
     "9": {
-      "Position2D": { "x": 0, "y": 0 },
-      "Orientation2D": { "cos": 1, "sin": 0 },
-      "Scale2D": { "x": 1, "y": 1 },
-      "GlobalTransform2D": [1, 0, 0, 1, 0, 0],
+      "Position2D": {
+        "x": 0,
+        "y": 0
+      },
+      "Orientation2D": {
+        "cos": 1,
+        "sin": 0
+      },
+      "Scale2D": {
+        "x": 1,
+        "y": 1
+      },
+      "GlobalTransform2D": [
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
       "Camera": {
         "projection": {
           "type": "orthographic",
@@ -161,6 +305,69 @@
         "far": 1000
       },
       "RenderLists2D": {}
+    }
+  },
+  "resources": {
+    "AssetsSnapshot<Mesh>": {
+      "type": "Mesh",
+      "assets": [
+        {
+          "attributes": [
+            [
+              "position2d",
+              {
+                "data": [
+                  0,
+                  0,
+                  0.18000000715255737,
+                  0,
+                  0.16217440366744995,
+                  0.0780990719795227,
+                  0.112228162586689,
+                  0.14072966575622559,
+                  0.04005376994609833,
+                  0.17548702657222748,
+                  -0.04005376994609833,
+                  0.17548702657222748,
+                  -0.112228162586689,
+                  0.14072966575622559,
+                  -0.16217440366744995,
+                  0.0780990719795227,
+                  -0.18000000715255737,
+                  2.204364202304404e-17,
+                  -0.16217440366744995,
+                  -0.0780990719795227,
+                  -0.112228162586689,
+                  -0.14072966575622559,
+                  -0.04005376994609833,
+                  -0.17548702657222748,
+                  0.04005376994609833,
+                  -0.17548702657222748,
+                  0.112228162586689,
+                  -0.14072966575622559,
+                  0.16217440366744995,
+                  -0.0780990719795227,
+                  0.18000000715255737,
+                  -4.408728404608808e-17
+                ]
+              }
+            ]
+          ]
+        }
+      ]
+    },
+    "AssetsSnapshot<BasicMaterial>": {
+      "type": "BasicMaterial",
+      "assets": [
+        {
+          "color": {
+            "r": 0.95,
+            "g": 0.8,
+            "b": 0.2,
+            "a": 1
+          }
+        }
+      ]
     }
   }
 }

--- a/examples/samples/scene/2d/load_json.js
+++ b/examples/samples/scene/2d/load_json.js
@@ -2,36 +2,17 @@ import {
   App,
   AppSchedule,
   AssetServer,
-  BasicMaterial,
-  BasicMaterialAssets,
   Canvas2DRendererPlugin,
-  Color,
   createTransform2D,
   DefaultPlugin,
   DOMWindowPlugin,
   EntityCommands,
   FPSDebugger,
-  Mesh,
-  MeshAssets,
   Scene,
   SceneInstance,
   World
 } from 'wima'
 import { HackPlugin, setupViewport } from '../../utils.js'
-
-// NOTE: This is here because scenes dont support resources nor assets.
-// Also asset dependencies need to be supported too in order to load
-// the external dependencies from the server/disk.
-// when that lands, this example should support them natively.
-// TODO: Move this to use internal scene assets when the above land
-class SceneAssetHandles {
-
-  /** @type {import('wima').Handle<Mesh> | undefined} */
-  meshHandle
-
-  /** @type {import('wima').Handle<BasicMaterial> | undefined} */
-  materialHandle
-}
 
 const app = new App()
 
@@ -50,16 +31,7 @@ app
  */
 function init(world) {
   const commands = new EntityCommands(world)
-  const meshes = world.getResource(MeshAssets)
-  const materials = world.getResource(BasicMaterialAssets)
   const server = world.getResource(AssetServer)
-  const handles = new SceneAssetHandles()
-
-  handles.meshHandle = meshes.add(Mesh.circle2D(0.18, 14))
-  handles.materialHandle = materials.add(new BasicMaterial({
-    color: new Color(0.95, 0.8, 0.2)
-  }))
-  world.setResource(handles)
 
   const sceneHandle = server.load(Scene, '/scene/basic.json')
 

--- a/src/asset/core/handle.js
+++ b/src/asset/core/handle.js
@@ -3,9 +3,11 @@
 /** @import {Constructor, TypeId} from '../../type/index.js'*/
 
 import { packInto64Int } from '../../datastructures/index.js'
-import { typeid } from '../../type/index.js'
+import { setTypeId, typeid } from '../../type/index.js'
 import { AssetServer } from '../resources/assetserver.js'
 import { AssetChannel } from './channel.js'
+
+const assetSceneMapId = setTypeId('AssetSceneMap')
 
 /**
  * @template T
@@ -85,7 +87,7 @@ export class Handle {
       return new HandleSnapshot(typeid(this.type), info.path)
     }
 
-    return new HandleSnapshot(typeid(this.type), this.id())
+    return new HandleSnapshot(typeid(this.type), this.index)
   }
 
   drop() {
@@ -99,7 +101,7 @@ export class Handle {
 /**
  * A snapshot of an asset handle.
  *
- * The snapshot preserves the asset type and id, and stores the asset server
+ * The snapshot preserves the asset type and snapshot index, and stores the asset server
  * path when one is registered so the handle can be reloaded by path.
  */
 export class HandleSnapshot {
@@ -110,13 +112,13 @@ export class HandleSnapshot {
   type
 
   /**
-   * @type {AssetId | string}
+   * @type {number | string}
    */
   asset
 
   /**
    * @param {TypeId} typeId
-   * @param {AssetId | string} asset
+   * @param {number | string} asset
    */
   constructor(typeId, asset) {
     this.type = typeId
@@ -127,28 +129,31 @@ export class HandleSnapshot {
    * Restore the live handle from the asset server.
    *
    * If the asset server knows the path, we reload it by path. Otherwise we
-   * upgrade the stored asset id against the asset pool.
+   * upgrade the stored snapshot index against the asset pool.
    *
    * @param {import('../../ecs/index.js').World} world
-   * @returns {UntypedHandle}
+   * @param {AssetId} [sceneAssetId]
+   * @returns {UntypedHandle | undefined}
    */
-  fromSnapshot(world) {
+  fromSnapshot(world, sceneAssetId) {
     const server = world.getResource(AssetServer)
 
     if (typeof this.asset === 'string') {
       return server.loadUntyped(this.type, this.asset)
     }
 
-    const assets = server.getAssets(this.type)
+    if (sceneAssetId !== undefined && world.hasResourceByTypeId(assetSceneMapId)) {
 
-    // TODO: This is inherently incorrect. When scene resources are added,
-    // the assetid will point to the wrong asset in the scene due to desync between
-    // the scene and world when an assets are added/removed from the world or scene.
-    // Add a mapping between scene assets and world assets and use that to create
-    // the asset handle. Also ensure the assets are loaded into world before spawning
-    // the scene into the world.
+      /** @type {{ get: Function }} */
+      const sceneMap = world.getResourceByTypeId(assetSceneMapId)
+      const mapped = sceneMap.get(sceneAssetId, this.type, this.asset)
 
-    return assets.upgrade(this.asset)
+      if (mapped) {
+        return mapped
+      }
+    }
+
+    return undefined
   }
 
   /**
@@ -197,5 +202,5 @@ export class HandleSnapshot {
 /**
  * @typedef HandleSnapshotSerial
  * @property {TypeId} type
- * @property {AssetId | string} asset
+ * @property {number | string} asset
  */

--- a/src/asset/resources/assets.js
+++ b/src/asset/resources/assets.js
@@ -1,10 +1,15 @@
 /** @import {AssetId} from '../types/index.js' */
-/** @import {Constructor} from '../../type/index.js' */
+/** @import {Constructor, TypeId} from '../../type/index.js' */
 
 import { unpackFrom64Int, DenseList, IndexAllocator } from '../../datastructures/index.js'
 import { AssetAdded, AssetDropped, AssetEvent, AssetModified } from '../events/assets.js'
 import { AssetChannel, AssetChannelMessageType } from '../core/channel.js'
 import { Handle } from '../core/handle.js'
+import { setTypeId, typeid, typeidGeneric } from '../../type/index.js'
+import { TypeEntry, TypeRegistry } from '../../reflect/index.js'
+import { warn } from '../../logger/index.js'
+
+const assetSceneMapId = setTypeId('AssetSceneMap')
 
 /**
  * @template T
@@ -275,6 +280,27 @@ export class Assets {
   }
 
   /**
+   * @param {import('../../ecs/index.js').World} world
+   * @returns {AssetsSnapshot<unknown>}
+   */
+  toSnapshot(world) {
+    const typeRegistry = world.getResource(TypeRegistry)
+    const typeEntry = typeRegistry.get(this.type)
+    const assets = this.assets.values().map((entry) => {
+      if (
+        typeEntry &&
+        entry.asset !== undefined
+      ) {
+        return typeEntry.call('serialize', [entry.asset])
+      }
+
+      return entry.asset
+    })
+
+    return new AssetsSnapshot(typeid(this.type), assets)
+  }
+
+  /**
    * Drain and apply queued handle lifecycle messages.
    */
   update() {
@@ -351,3 +377,155 @@ export class AssetEntry {
     this.asset = asset
   }
 }
+
+/**
+ * @template T
+ */
+export class AssetsSnapshot {
+
+  /**
+   * @type {TypeId}
+   */
+  type
+
+  /**
+   * Dense, index-aligned snapshot of the source `Assets<T>` container.
+   * @type {(T | undefined)[]}
+   */
+  assets
+
+  /**
+   * @param {TypeId} type
+   * @param {(T | undefined)[]} assets
+   */
+  constructor(type, assets) {
+    this.type = type
+    this.assets = assets
+  }
+
+  /**
+   * @param {TypeId} assetType
+   * @returns {TypeId}
+   */
+  static typeId(assetType) {
+    return setTypeId(`AssetsSnapshot<${assetType}>`)
+  }
+
+  /**
+   * @param {import('../../ecs/index.js').World} world
+   * @param {AssetId} sceneAssetId
+   * @returns {Assets<unknown> | undefined}
+   */
+  fromSnapshot(world, sceneAssetId) {
+
+    /** @type {{ clear: Function, set: Function }} */
+    const sceneMap = world.getResourceByTypeId(assetSceneMapId)
+    const typeEntry = world.getResource(TypeRegistry).getByTypeId(this.type)
+
+    if (!typeEntry?.constructorFn) {
+      return undefined
+    }
+
+    const assets = new Assets(typeEntry.constructorFn)
+
+    patchInternal(this, sceneMap, assets, sceneAssetId, typeEntry)
+
+    return assets
+  }
+
+  /**
+   * @param {AssetsSnapshot<unknown>} snapshot
+   * @param {import('../../ecs/index.js').World} world
+   * @param {AssetId} sceneAssetId
+   * @returns {boolean}
+   */
+  static patch(snapshot, world, sceneAssetId) {
+    const typeEntry = world.getResource(TypeRegistry).getByTypeId(snapshot.type)
+
+    if (!typeEntry || !typeEntry.constructorFn) {
+      return false
+    }
+
+    const assets = world.getResourceByTypeId(typeidGeneric(Assets, [typeEntry.constructorFn]))
+
+    /** @type {{ clear: Function, set: Function }} */
+    const sceneMap = world.getResourceByTypeId(assetSceneMapId)
+
+    sceneMap.clear(sceneAssetId, snapshot.type)
+    patchInternal(snapshot, sceneMap, assets, sceneAssetId, typeEntry)
+
+    return true
+  }
+
+  /**
+   * @param {AssetsSnapshot<unknown>} value
+   */
+  static serialize(value) {
+    return {
+      type: value.type,
+      assets: value.assets
+    }
+  }
+
+  /**
+   * @param {AssetsSnapshotSerial} value
+   * @param {AssetsSnapshot<unknown>} [out]
+   */
+  static deserialize(value, out = new AssetsSnapshot(typeid(Object), [])) {
+    out.type = value.type
+    out.assets = value.assets
+
+    return out
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {value is AssetsSnapshotSerial}
+   */
+  static validateSerial(value) {
+    if (!value || typeof value !== 'object') {
+      return false
+    }
+
+    if (!('type' in value) || !('assets' in value)) {
+      return false
+    }
+
+    return typeof value.type === 'string' && Array.isArray(value.assets)
+  }
+}
+
+/**
+ * @template T
+ * @param {AssetsSnapshot<T>} snapshot
+ * @param {{ clear: Function, set: Function }} sceneMap
+ * @param {Assets<T>} assetContainer
+ * @param {AssetId} sceneAssetId
+ * @param {TypeEntry} typeEntry
+ */
+function patchInternal(snapshot, sceneMap, assetContainer, sceneAssetId, typeEntry) {
+  sceneMap.clear(sceneAssetId, snapshot.type)
+
+  for (let i = 0; i < snapshot.assets.length; i++) {
+    const asset = snapshot.assets[i]
+
+    if (asset === undefined) {
+      sceneMap.set(sceneAssetId, snapshot.type, i, assetContainer.reserve())
+    } else {
+
+      const actualAsset = /** @type {T | undefined} */(typeEntry.call('deserialize', [asset]))
+
+      if (actualAsset) {
+        sceneMap.set(sceneAssetId, snapshot.type, i, assetContainer.add(actualAsset))
+      } else {
+        warn(`No method to deserialize the asset type \`${snapshot.type}\``)
+      }
+    }
+  }
+}
+
+/**
+ * @typedef AssetsSnapshotSerial
+ * @property {TypeId} type
+ * @property {unknown[]} assets
+ */

--- a/src/asset/systems/types.js
+++ b/src/asset/systems/types.js
@@ -3,7 +3,7 @@
 import { World } from '../../ecs/index.js'
 import { ArrayInfo, Field, StructInfo } from '../../reflect/core/index.js'
 import { TypeRegistry } from '../../reflect/resources/index.js'
-import { AssetServer, Assets } from '../resources/index.js'
+import { AssetServer, Assets, AssetsSnapshot } from '../resources/index.js'
 import { Handle, HandleSnapshot } from '../core/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
 import { AssetLoadFail, AssetSaveSuccess } from '../events/index.js'
@@ -28,13 +28,22 @@ export function registerAssetTypes(asset) {
         type: new Field(typeid(Function))
       })
     )
+    registry.registerTypeId(AssetsSnapshot.typeId(typeid(asset)), new StructInfo({
+      type: new Field(typeid(String)),
+      assets: new Field(typeid(Array))
+    }))
     registry.register(HandleSnapshot, new StructInfo({
       type: new Field(typeid(Function)),
       asset: new Field(typeid(Object))
     }))
+    registry.getByTypeId(AssetsSnapshot.typeId(typeid(asset)))?.setMethod(AssetsSnapshot.serialize)
+    registry.getByTypeId(AssetsSnapshot.typeId(typeid(asset)))?.setMethod(AssetsSnapshot.deserialize)
+    registry.getByTypeId(AssetsSnapshot.typeId(typeid(asset)))?.setMethod(AssetsSnapshot.patch)
+    registry.getByTypeId(AssetsSnapshot.typeId(typeid(asset)))?.setMethod(AssetsSnapshot.prototype.fromSnapshot)
     registry.get(HandleSnapshot)?.setMethod(HandleSnapshot.serialize)
     registry.get(HandleSnapshot)?.setMethod(HandleSnapshot.deserialize)
     registry.get(HandleSnapshot)?.setMethod(HandleSnapshot.prototype.fromSnapshot)
+    registry.getByTypeId(typeidGeneric(Assets, [asset]))?.setMethod(Assets.prototype.toSnapshot)
     registry.get(Handle)?.setMethod(Handle.prototype.toSnapshot)
   }
 }

--- a/src/asset/tests/handle.test.js
+++ b/src/asset/tests/handle.test.js
@@ -3,6 +3,8 @@ import test, { describe } from "node:test";
 import { Assets } from "../resources/index.js";
 import { AssetServer } from "../resources/index.js";
 import { World } from "../../ecs/index.js";
+import { AssetSceneMap } from "../../scene/resources/index.js";
+import { typeid } from "../../type/index.js";
 
 describe('Testing `Handle`',()=>{
     test('`Handle` clone is same as original', () => {
@@ -204,19 +206,25 @@ describe('Testing `Handle`',()=>{
         deepStrictEqual(restored.id(), handle.id())
     })
 
-    test('`Handle` snapshot restores from asset id when no path is registered.', () => {
+    test('`Handle` snapshot restores through the scene asset map when no path is registered.', () => {
         const world = new World()
         const assets = new Assets(String)
         const server = new AssetServer()
-
         world.setResource(server)
+        const sceneMap = new AssetSceneMap()
+        world.setResource(sceneMap)
         server.registerAsset(assets)
 
-        const handle = assets.add('Wima engine')
-        const snapshot = handle.toSnapshot(world)
-        const restored = snapshot.fromSnapshot(world)
+        const sourceHandle = assets.add('Wima engine')
+        const mappedHandle = assets.add('Mapped asset')
+        const sceneAssetId = sourceHandle.id()
+        const snapshot = sourceHandle.toSnapshot(world)
 
-        strictEqual(snapshot.asset, handle.id())
-        deepStrictEqual(restored.id(), handle.id())
+        sceneMap.set(sceneAssetId, typeid(String), sourceHandle.index, mappedHandle)
+
+        const restored = snapshot.fromSnapshot(world, sceneAssetId)
+
+        strictEqual(snapshot.asset, sourceHandle.index)
+        deepStrictEqual(restored.id(), mappedHandle.id())
     })
 })

--- a/src/audio/components/audioplayer.js
+++ b/src/audio/components/audioplayer.js
@@ -94,12 +94,13 @@ export class AudioPlayerSnapshot {
 
   /**
    * @param {import('../../ecs/index.js').World} world
+   * @param {import('../../asset/index.js').AssetId} sceneAssetId
    * @returns {AudioPlayer}
    */
-  fromSnapshot(world) {
+  fromSnapshot(world, sceneAssetId) {
     const player = new AudioPlayer({
       attach: this.attach,
-      audio: /** @type {Handle<Audio>} */(this.audio?.fromSnapshot(world))
+      audio: /** @type {Handle<Audio>} */(this.audio?.fromSnapshot(world, sceneAssetId))
     })
 
     player.sourceNode = this.sourceNode

--- a/src/render-core/components/materials/index.js
+++ b/src/render-core/components/materials/index.js
@@ -53,10 +53,11 @@ export class BasicMaterialInstanceSnapshot {
 
   /**
    * @param {import('../../../ecs/index.js').World} world
+   * @param {import('../../../asset/index.js').AssetId} sceneAssetId
    * @returns {BasicMaterialInstance}
    */
-  fromSnapshot(world) {
-    return new BasicMaterialInstance(/** @type {Handle<BasicMaterial>} */(this.handle.fromSnapshot(world)))
+  fromSnapshot(world, sceneAssetId) {
+    return new BasicMaterialInstance(/** @type {Handle<BasicMaterial>} */(this.handle.fromSnapshot(world, sceneAssetId)))
   }
 
   /**

--- a/src/render-core/components/mesh.js
+++ b/src/render-core/components/mesh.js
@@ -62,10 +62,11 @@ export class MeshedSnapshot {
 
   /**
    * @param {import('../../ecs/index.js').World} world
+   * @param {import('../../asset/index.js').AssetId} sceneAssetId
    * @returns {Meshed}
    */
-  fromSnapshot(world) {
-    return new Meshed(/** @type {Handle<Mesh>} */(this.handle.fromSnapshot(world)))
+  fromSnapshot(world, sceneAssetId) {
+    return new Meshed(/** @type {Handle<Mesh>} */(this.handle.fromSnapshot(world, sceneAssetId)))
   }
 
   /**

--- a/src/scene/assets/scene.js
+++ b/src/scene/assets/scene.js
@@ -4,7 +4,9 @@ import { Parent } from '../../hierarchy/index.js'
 import { warn } from '../../logger/index.js'
 import { TypeRegistry } from '../../reflect/index.js'
 import { typeid } from '../../type/index.js'
+import { AssetsSnapshot } from '../../asset/resources/assets.js'
 import { SceneInstance } from '../components/index.js'
+import { AssetSceneMap } from '../resources/assetmap.js'
 
 export class Scene {
 
@@ -26,6 +28,11 @@ export class Scene {
   toWorld(world, instance, typeRegistry, instanceEntity) {
     const { entityMap: worldToSceneMap } = instance
     const sceneToWorldMap = new Map()
+    const sceneAssetId = instance.handle?.id()
+
+    if (sceneAssetId !== undefined && !world.hasResource(AssetSceneMap)) {
+      world.setResource(new AssetSceneMap())
+    }
 
     for (const entity of this.entities.keys()) {
       const worldEntity = world.spawn([])
@@ -42,11 +49,11 @@ export class Scene {
         continue
       }
 
-      if (patchResource(resource, world, entry)) {
+      if (patchResource(resource, world, entry, sceneAssetId)) {
         continue
       }
 
-      const restoredResource = fromSnapshot(resource, world, entry)
+      const restoredResource = fromSnapshot(resource, world, entry, sceneAssetId)
 
       if (!restoredResource) {
         continue
@@ -78,7 +85,7 @@ export class Scene {
           return undefined
         }
 
-        const clonedComponent = fromSnapshot(component, world, entry)
+        const clonedComponent = fromSnapshot(component, world, entry, sceneAssetId)
 
         if (!clonedComponent) {
           return undefined
@@ -151,7 +158,7 @@ export class Scene {
       }
 
       scene.resources.set(
-        typeid(/** @type {import('../../type/index.js').Constructor} */ (snapshot.constructor)),
+        getSnapshotTypeId(/** @type {object} */ (snapshot)),
         /** @type {object} */ (snapshot)
       )
     }
@@ -174,6 +181,17 @@ export class Scene {
   * [Symbol.iterator]() {
     return this.entities
   }
+}
+
+/**
+ * @param {object} snapshot
+ */
+function getSnapshotTypeId(snapshot) {
+  if (snapshot instanceof AssetsSnapshot) {
+    return AssetsSnapshot.typeId(snapshot.type)
+  }
+
+  return typeid(/** @type {import('../../type/index.js').Constructor} */ (snapshot.constructor))
 }
 
 /**
@@ -205,12 +223,13 @@ function toSnapshot(component, world, entry) {
  * @param {object} component
  * @param {World} world
  * @param {import('../../reflect/resources/typeregistry.js').TypeEntry} entry
+ * @param {import('../../asset/index.js').AssetId} [sceneAssetId]
  */
-function fromSnapshot(component, world, entry) {
+function fromSnapshot(component, world, entry, sceneAssetId) {
   const method = entry.getMethod('fromSnapshot')
 
   if (method) {
-    return method.method.call(component, world)
+    return method.method.call(component, world, sceneAssetId)
   }
 
   const clone = entry.call('clone', [component])
@@ -230,14 +249,15 @@ function fromSnapshot(component, world, entry) {
  * @param {object} resource
  * @param {World} world
  * @param {import('../../reflect/resources/typeregistry.js').TypeEntry} entry
+ * @param {import('../../asset/index.js').AssetId} [sceneAssetId]
  * @returns {boolean}
  */
-function patchResource(resource, world, entry) {
+function patchResource(resource, world, entry, sceneAssetId) {
   const method = entry.getMethod('patch')
 
   if (!method) {
     return false
   }
 
-  return entry.call('patch', [resource, world]) === true
+  return entry.call('patch', [resource, world, sceneAssetId]) === true
 }

--- a/src/scene/components/instance.js
+++ b/src/scene/components/instance.js
@@ -67,10 +67,11 @@ export class SceneInstanceSnapshot {
 
   /**
    * @param {import('../../ecs/index.js').World} world
+   * @param {import('../../asset/index.js').AssetId} sceneAssetId
    * @returns {SceneInstance}
    */
-  fromSnapshot(world) {
-    return new SceneInstance(/** @type {Handle<Scene>} */(this.handle.fromSnapshot(world)))
+  fromSnapshot(world, sceneAssetId) {
+    return new SceneInstance(/** @type {Handle<Scene>} */(this.handle.fromSnapshot(world, sceneAssetId)))
   }
 
   /**

--- a/src/scene/resources/assetmap.js
+++ b/src/scene/resources/assetmap.js
@@ -1,0 +1,114 @@
+/** @import { AssetId } from '../../asset/index.js' */
+/** @import { TypeId } from '../../type/index.js' */
+/** @import { UntypedHandle } from '../../asset/index.js' */
+
+export class AssetSceneMap {
+
+  /**
+   * @private
+   * @type {Map<AssetId, Map<TypeId, Map<number, UntypedHandle>>>}
+   */
+  scenes = new Map()
+
+  /**
+   * @param {AssetId} sceneAssetId
+   * @param {TypeId} assetTypeId
+   * @param {number} snapshotIndex
+   * @param {UntypedHandle} handle
+   */
+  set(sceneAssetId, assetTypeId, snapshotIndex, handle) {
+    const typeMap = this.getOrCreateTypeMap(sceneAssetId)
+    let handles = typeMap.get(assetTypeId)
+
+    if (!handles) {
+      handles = new Map()
+      typeMap.set(assetTypeId, handles)
+    }
+
+    handles.set(snapshotIndex, handle)
+  }
+
+  /**
+   * @param {AssetId} sceneAssetId
+   * @param {TypeId} assetTypeId
+   * @param {number} snapshotIndex
+   * @returns {UntypedHandle | undefined}
+   */
+  get(sceneAssetId, assetTypeId, snapshotIndex) {
+    const handle = this.scenes
+      .get(sceneAssetId)
+      ?.get(assetTypeId)
+      ?.get(snapshotIndex)
+
+    return handle?.clone()
+  }
+
+  /**
+   * @param {AssetId} sceneAssetId
+   * @param {TypeId} [assetTypeId]
+   */
+  clear(sceneAssetId, assetTypeId) {
+    const typeMap = this.scenes.get(sceneAssetId)
+
+    if (!typeMap) {
+      return
+    }
+
+    if (assetTypeId === undefined) {
+      for (const handles of typeMap.values()) {
+        this.dropHandles(handles)
+      }
+
+      this.scenes.delete(sceneAssetId)
+
+      return
+    }
+
+    const handles = typeMap.get(assetTypeId)
+
+    if (!handles) {
+      return
+    }
+
+    this.dropHandles(handles)
+    typeMap.delete(assetTypeId)
+
+    if (typeMap.size === 0) {
+      this.scenes.delete(sceneAssetId)
+    }
+  }
+
+  /**
+   * Runtime-only resource.
+   * @returns {undefined}
+   */
+  toSnapshot() {
+    return undefined
+  }
+
+  /**
+   * @private
+   * @param {AssetId} sceneAssetId
+   * @returns {Map<TypeId, Map<number, UntypedHandle>>}
+   */
+  getOrCreateTypeMap(sceneAssetId) {
+    let typeMap = this.scenes.get(sceneAssetId)
+
+    if (!typeMap) {
+      typeMap = new Map()
+      this.scenes.set(sceneAssetId, typeMap)
+    }
+
+    return typeMap
+  }
+
+  /**
+   * @private
+   * @param {Map<number, UntypedHandle>} handles
+   */
+  dropHandles(handles) {
+    for (const handle of handles.values()) {
+      handle.drop()
+    }
+  }
+}

--- a/src/scene/resources/index.js
+++ b/src/scene/resources/index.js
@@ -1,3 +1,4 @@
+export * from './assetmap.js'
 export * from './aliases.js'
 export * from './exporters/index.js'
 export * from './importers/index.js'

--- a/src/scene/tests/resources/assetmap.test.js
+++ b/src/scene/tests/resources/assetmap.test.js
@@ -1,0 +1,52 @@
+import { deepStrictEqual, strictEqual } from 'assert'
+import test, { describe } from 'node:test'
+import { Assets } from '../../../asset/resources/index.js'
+import { AssetSceneMap } from '../../resources/index.js'
+import { typeid } from '../../../type/index.js'
+
+describe('Testing `AssetSceneMap`', { concurrency: false }, () => {
+  test('`AssetSceneMap.clear` drops handles for an entire scene', () => {
+    const stringAssets = new Assets(String)
+    const numberAssets = new Assets(Number)
+    const sceneMap = new AssetSceneMap()
+    const sceneAssetId = 42
+
+    const stringHandle = stringAssets.add('scene string asset')
+    const numberHandle = numberAssets.add(123)
+
+    sceneMap.set(sceneAssetId, typeid(String), 0, stringHandle)
+    sceneMap.set(sceneAssetId, typeid(Number), 0, numberHandle)
+
+    sceneMap.clear(sceneAssetId)
+    stringAssets.update()
+    numberAssets.update()
+
+    strictEqual(stringAssets.get(stringHandle), undefined)
+    strictEqual(numberAssets.get(numberHandle), undefined)
+    strictEqual(sceneMap.get(sceneAssetId, typeid(String), 0), undefined)
+    strictEqual(sceneMap.get(sceneAssetId, typeid(Number), 0), undefined)
+  })
+
+  test('`AssetSceneMap.clear` only drops handles for the requested asset type', () => {
+    const stringAssets = new Assets(String)
+    const numberAssets = new Assets(Number)
+    const sceneMap = new AssetSceneMap()
+    const sceneAssetId = 42
+
+    const stringHandle = stringAssets.add('scene string asset')
+    const numberHandle = numberAssets.add(123)
+
+    sceneMap.set(sceneAssetId, typeid(String), 0, stringHandle)
+    sceneMap.set(sceneAssetId, typeid(Number), 0, numberHandle)
+
+    sceneMap.clear(sceneAssetId, typeid(String))
+    stringAssets.update()
+    numberAssets.update()
+
+    strictEqual(stringAssets.get(stringHandle), undefined)
+    deepStrictEqual(numberAssets.get(numberHandle), 123)
+    strictEqual(sceneMap.get(sceneAssetId, typeid(String), 0), undefined)
+    strictEqual(sceneMap.get(sceneAssetId, typeid(Number), 0) !== undefined, true)
+    strictEqual(sceneMap.scenes.has(sceneAssetId), true)
+  })
+})

--- a/src/scene/tests/resources/assetmap.test.js
+++ b/src/scene/tests/resources/assetmap.test.js
@@ -9,10 +9,10 @@ describe('Testing `AssetSceneMap`', { concurrency: false }, () => {
     const stringAssets = new Assets(String)
     const numberAssets = new Assets(Number)
     const sceneMap = new AssetSceneMap()
-    const sceneAssetId = 42
 
     const stringHandle = stringAssets.add('scene string asset')
     const numberHandle = numberAssets.add(123)
+    const sceneAssetId = stringHandle.id()
 
     sceneMap.set(sceneAssetId, typeid(String), 0, stringHandle)
     sceneMap.set(sceneAssetId, typeid(Number), 0, numberHandle)
@@ -31,10 +31,10 @@ describe('Testing `AssetSceneMap`', { concurrency: false }, () => {
     const stringAssets = new Assets(String)
     const numberAssets = new Assets(Number)
     const sceneMap = new AssetSceneMap()
-    const sceneAssetId = 42
 
     const stringHandle = stringAssets.add('scene string asset')
     const numberHandle = numberAssets.add(123)
+    const sceneAssetId = stringHandle.id()
 
     sceneMap.set(sceneAssetId, typeid(String), 0, stringHandle)
     sceneMap.set(sceneAssetId, typeid(Number), 0, numberHandle)
@@ -47,6 +47,5 @@ describe('Testing `AssetSceneMap`', { concurrency: false }, () => {
     deepStrictEqual(numberAssets.get(numberHandle), 123)
     strictEqual(sceneMap.get(sceneAssetId, typeid(String), 0), undefined)
     strictEqual(sceneMap.get(sceneAssetId, typeid(Number), 0) !== undefined, true)
-    strictEqual(sceneMap.scenes.has(sceneAssetId), true)
   })
 })


### PR DESCRIPTION
## Objective

Enables scenes to serialize embedded asset collections, restore them into the destination world and correctly remap asset handles so scene instances reference the newly restored assets instead of existing world asset IDs.

## Solution

### Root Cause

Scenes previously serialized component snapshots containing asset handles, but asset collections themselves were not included in scene data. Handle snapshots stored runtime asset IDs, which were only valid within the originating world, making scene-local assets impossible to restore reliably.

### Changes Made

* Introduced `AssetsSnapshot` to serialize entire `Assets<T>` resources.
* Introduced `AssetSceneMap` as a runtime resource mapping scene asset indices to runtime asset handles.
* Updated `HandleSnapshot` to now store a stable scene asset index instead of a runtime asset ID. `fromSnapshot()` now resolves handles through:

  * asset server paths (when available)
  * scene asset mappings for embedded assets. This removes the dependency on runtime asset IDs.
* Extended scene restoration to support scene-local assets.
* Updated snapshot restoration APIs to accept the scene asset ID when needed.
* Scene JSON now embeds serialized asset resources.

The bundled sample scene has been updated to use embedded assets, allowing the loading example to remove its manual asset setup.

## Showcase

### Before

Scene assets had to be created manually before loading.

```js
const meshes = world.getResource(MeshAssets)
const materials = world.getResource(BasicMaterialAssets)

meshHandle = meshes.add(...)
materialHandle = materials.add(...)

// traverse the scene to set them up
```

Asset handles inside the scene depended on runtime asset IDs.

### After

Scenes contain their own asset resources.

```js
const scene = await server.load(Scene, "/scene/basic.json")
commands.spawn([new SceneInstance(scene)])
```

Embedded assets are restored automatically, and all asset handles are remapped to the newly restored runtime handles.

## Migration Guide

No migration required

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
