### PR TITLE
Rename `Entity` to `EntityHandle`

### DIFF
--- a/examples/samples/ecs/despawn.js
+++ b/examples/samples/ecs/despawn.js
@@ -4,7 +4,7 @@ import {
   World,
   Query,
   EntityCommands,
-  Entity,
+  EntityHandle,
   BasicMaterial,
   BasicMaterialAssets,
   MeshAssets,
@@ -72,7 +72,7 @@ function init(world) {
  */
 function update(world) {
   const commands = new EntityCommands(world)
-  const entities = new Query(world, [Entity, Marker])
+  const entities = new Query(world, [EntityHandle, Marker])
   const entity = entities.single()
 
   if (!entity) return

--- a/examples/samples/ecs/spawn.js
+++ b/examples/samples/ecs/spawn.js
@@ -4,7 +4,7 @@ import {
   World,
   Query,
   EntityCommands,
-  Entity,
+  EntityHandle,
   BasicMaterial,
   BasicMaterialAssets,
   MeshAssets,
@@ -41,7 +41,7 @@ app
  */
 function update(world) {
   const commands = new EntityCommands(world)
-  const entities = new Query(world, [Entity, Marker])
+  const entities = new Query(world, [EntityHandle, Marker])
   const meshes = world.getResource(MeshAssets)
   const materials = world.getResource(BasicMaterialAssets)
 

--- a/examples/samples/emitter/2d/basic.js
+++ b/examples/samples/emitter/2d/basic.js
@@ -25,7 +25,7 @@ import {
   Scale2D,
   Torque2D,
   Velocity2D,
-  Entity,
+  EntityHandle,
   rand,
   HALF_PI,
   Timer,
@@ -77,7 +77,7 @@ function init(world) {
 
   /**
    * @param {EntityCommands} commands
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   function patch(commands, entity) {
     commands

--- a/examples/samples/emitter/2d/duration.js
+++ b/examples/samples/emitter/2d/duration.js
@@ -21,7 +21,7 @@ import {
   Scale2D,
   Torque2D,
   Velocity2D,
-  Entity,
+  EntityHandle,
   rand,
   HALF_PI,
   Timer,
@@ -71,7 +71,7 @@ function init(world) {
 
   /**
    * @param {EntityCommands} commands
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   function patch(commands, entity) {
     commands

--- a/examples/samples/emitter/3d/basic.js
+++ b/examples/samples/emitter/3d/basic.js
@@ -16,7 +16,7 @@ import {
   createBasicMesh3D,
   createRawMovable3D,
   BasicMaterialInstance,
-  Entity,
+  EntityHandle,
   Rotation3D,
   Velocity3D,
   Acceleration3D,
@@ -76,7 +76,7 @@ function init(world) {
 
   /**
    * @param {EntityCommands} commands
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   function patch(commands, entity) {
     commands

--- a/examples/samples/emitter/3d/duration.js
+++ b/examples/samples/emitter/3d/duration.js
@@ -15,7 +15,7 @@ import {
   BasicMaterialInstance,
   createBasicMesh3D,
   createRawMovable3D,
-  Entity,
+  EntityHandle,
   GlobalTransform3D,
   Orientation3D,
   Rotation3D,
@@ -74,7 +74,7 @@ function init(world) {
 
   /**
    * @param {EntityCommands} commands
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   function patch(commands, entity) {
     commands

--- a/examples/samples/input/keyboard.js
+++ b/examples/samples/input/keyboard.js
@@ -7,7 +7,7 @@ import {
   EntityCommands,
   Keyboard,
   KeyCode,
-  Entity,
+  EntityHandle,
   BasicMaterial,
   BasicMaterialInstance,
   BasicMaterialAssets,
@@ -21,7 +21,7 @@ import {
 } from 'wima'
 import { addDefaultCamera2D, HackPlugin, setupViewport } from '../utils.js'
 
-/** @type {Map<KeyCode,Entity>} */
+/** @type {Map<KeyCode,EntityHandle>} */
 class KeytoEntityMap extends Map { }
 
 const offsetX = -0.9
@@ -53,7 +53,7 @@ function update(world) {
   const materials = world.getResource(BasicMaterialAssets)
   const keyboard = world.getResource(Keyboard)
   const map = world.getResource(KeytoEntityMap)
-  const entities = new Query(world, [Entity, BasicMaterialInstance])
+  const entities = new Query(world, [EntityHandle, BasicMaterialInstance])
 
   map.forEach((id, key) => {
     const entity = entities.get(id)

--- a/examples/samples/input/mouse.js
+++ b/examples/samples/input/mouse.js
@@ -8,7 +8,7 @@ import {
   KeyCode,
   MouseButton,
   Position2D,
-  Entity,
+  EntityHandle,
   Mouse,
   MouseButtons,
   BasicMaterial,
@@ -24,7 +24,7 @@ import {
 } from 'wima'
 import { addDefaultCamera2D, HackPlugin, setupViewport, pxToNdc } from '../utils.js'
 
-/** @type {Map<KeyCode,Entity>} */
+/** @type {Map<KeyCode,EntityHandle>} */
 class KeytoEntityMap extends Map { }
 class MouseEntity {}
 
@@ -127,7 +127,7 @@ function updateButtons(world) {
   const materials = world.getResource(BasicMaterialAssets)
   const mousebuttons = world.getResource(MouseButtons)
   const map = world.getResource(KeytoEntityMap)
-  const entities = new Query(world, [Entity, BasicMaterialInstance])
+  const entities = new Query(world, [EntityHandle, BasicMaterialInstance])
 
   map.forEach((id, key) => {
     const entity = entities.get(id)

--- a/examples/samples/input/touch.js
+++ b/examples/samples/input/touch.js
@@ -7,7 +7,7 @@ import {
   EntityCommands,
   warn,
   Touches,
-  Entity,
+  EntityHandle,
   Position2D,
   BasicMaterial,
   BasicMaterialInstance,
@@ -22,7 +22,7 @@ import {
 } from 'wima'
 import { addDefaultCamera2D, HackPlugin, setupViewport, pxToNdc } from '../utils.js'
 
-/** @type {Map<number,Entity>} */
+/** @type {Map<number,EntityHandle>} */
 class TouchtoEntityMap extends Map { }
 
 const app = new App()

--- a/examples/samples/scene/2d/basic.js
+++ b/examples/samples/scene/2d/basic.js
@@ -8,7 +8,7 @@ import {
   SceneInstance,
   SceneAssets,
   Assets,
-  Entity,
+  EntityHandle,
   createCamera2D,
   MeshAssets,
   BasicMaterialAssets,
@@ -81,13 +81,13 @@ function createScene(meshes, materials) {
   // Adds the entities to the scene
   for (let y = -halfHeight; y <= halfHeight; y += itemHeight) {
     for (let x = -halfWidth; x < halfWidth; x += itemWidth) {
-      scene.set(new Entity(index, 1), [
+      scene.set(new EntityHandle(index, 1), [
         ...createBasicMesh2D(mesh.clone(), material.clone(), x, y)])
       index += 1
     }
   }
 
-  scene.set(new Entity(index, 1), [...createCamera2D()])
+  scene.set(new EntityHandle(index, 1), [...createCamera2D()])
 
   // We drop these since they are unused.
   mesh.drop()

--- a/examples/samples/scene/2d/multiple_instances.js
+++ b/examples/samples/scene/2d/multiple_instances.js
@@ -9,7 +9,7 @@ import {
   SceneInstance,
   SceneAssets,
   Assets,
-  Entity,
+  EntityHandle,
   Query,
   MeshAssets,
   BasicMaterialAssets,
@@ -77,7 +77,7 @@ function init(world) {
  * @param {World} world
  */
 function applyRandomDescendantTorque(world) {
-  const roots = new Query(world, [Entity, SceneInstance])
+  const roots = new Query(world, [EntityHandle, SceneInstance])
   const descendants = new RelationshipQuery(world, Children, Parent, [Torque2D])
 
   roots.each(([entity]) => {
@@ -105,7 +105,7 @@ function createScene(meshes, materials) {
   ]
 
   for (let i = 0; i < offsets.length; i++) {
-    scene.set(new Entity(i, 1), [
+    scene.set(new EntityHandle(i, 1), [
       ...createBasicMesh2D(mesh.clone(), material.clone(), offsets[i].x, offsets[i].y),
       new Rotation2D(),
       new Torque2D()

--- a/examples/samples/scene/3d/basic.js
+++ b/examples/samples/scene/3d/basic.js
@@ -8,7 +8,7 @@ import {
   SceneAssets,
   Assets,
   createBasicMesh3D,
-  Entity,
+  EntityHandle,
   createCamera3D,
   MeshAssets,
   BasicMaterialAssets,
@@ -87,14 +87,14 @@ function createScene(meshes, materials) {
   for (let x = -halfWidth; x <= halfWidth; x += itemWidth) {
     for (let y = -halfHeight; y <= halfHeight; y += itemHeight) {
       for (let z = -halfDepth; z <= halfDepth; z += itemDepth) {
-        scene.set(new Entity(index, 1), [
+        scene.set(new EntityHandle(index, 1), [
           ...createBasicMesh3D(mesh.clone(), material.clone(), x, y, z)])
         index += 1
       }
     }
   }
 
-  scene.set(new Entity(index, 1), [...createCamera3D(0, 0, 5)])
+  scene.set(new EntityHandle(index, 1), [...createCamera3D(0, 0, 5)])
 
   // We drop these since they are unused.
   mesh.drop()

--- a/examples/samples/scene/3d/multiple_instances.js
+++ b/examples/samples/scene/3d/multiple_instances.js
@@ -10,7 +10,7 @@ import {
   SceneInstance,
   SceneAssets,
   Assets,
-  Entity,
+  EntityHandle,
   Query,
   MeshAssets,
   BasicMaterialAssets,
@@ -83,7 +83,7 @@ function init(world) {
  * @param {World} world
  */
 function applyRandomDescendantTorque(world) {
-  const roots = new Query(world, [Entity, SceneInstance])
+  const roots = new Query(world, [EntityHandle, SceneInstance])
   const descendants = new RelationshipQuery(world, Children, Parent, [Torque3D])
 
   roots.each(([entity]) => {
@@ -113,7 +113,7 @@ function createScene(meshes, materials) {
   ]
 
   for (let i = 0; i < offsets.length; i++) {
-    scene.set(new Entity(i, 1), [
+    scene.set(new EntityHandle(i, 1), [
       ...createBasicMesh3D(mesh.clone(), material.clone(), offsets[i].x, offsets[i].y, offsets[i].z),
       new Rotation3D(),
       new Torque3D()

--- a/examples/samples/utils.js
+++ b/examples/samples/utils.js
@@ -9,7 +9,7 @@ import {
   typeidGeneric,
   Query,
   WindowCommands,
-  Entity,
+  EntityHandle,
   MainWindow,
   Vector2,
   warn,
@@ -45,7 +45,7 @@ export function addDefaultCamera2D(world) {
  */
 export function setupViewport(world) {
   const windowcommands = new WindowCommands(world)
-  const window = new Query(world, [Entity, MainWindow]).single()
+  const window = new Query(world, [EntityHandle, MainWindow]).single()
 
   if (!window) return warn('No main window defined.')
 
@@ -59,7 +59,7 @@ export function setupViewport(world) {
  */
 export function setupViewportWebgl(world) {
   const windowcommands = new WindowCommands(world)
-  const window = new Query(world, [Entity, MainWindow]).single()
+  const window = new Query(world, [EntityHandle, MainWindow]).single()
   const canvases = world.getResource(Windows)
   const width = innerWidth
   const height = innerHeight

--- a/src/animation/components/target.js
+++ b/src/animation/components/target.js
@@ -1,9 +1,9 @@
-import { Entity } from '../../ecs/index.js'
+import { EntityHandle } from '../../ecs/index.js'
 
 export class AnimationTarget {
 
   /**
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   player
 
@@ -13,7 +13,7 @@ export class AnimationTarget {
   id
 
   /**
-   * @param {Entity} player
+   * @param {EntityHandle} player
    * @param {string} id
    */
   constructor(player, id) {
@@ -44,7 +44,7 @@ export class AnimationTarget {
    */
   static serialize(value) {
     return {
-      player: Entity.serialize(value.player),
+      player: EntityHandle.serialize(value.player),
       id: value.id
     }
   }
@@ -53,8 +53,8 @@ export class AnimationTarget {
    * @param {AnimationTargetSerial} value
    * @param {AnimationTarget} [out]
    */
-  static deserialize(value, out = new AnimationTarget(new Entity(0, 0), '')) {
-    out.player = Entity.deserialize(value.player, out.player)
+  static deserialize(value, out = new AnimationTarget(new EntityHandle(0, 0), '')) {
+    out.player = EntityHandle.deserialize(value.player, out.player)
     out.id = value.id
 
     return out

--- a/src/animation/core/animationeffector.js
+++ b/src/animation/core/animationeffector.js
@@ -1,4 +1,4 @@
-/** @import { Entity } from '../../ecs/index.js' */
+/** @import { EntityHandle } from '../../ecs/index.js' */
 import { World } from '../../ecs/registry.js'
 import { Rotary } from '../../math/index.js'
 import { Position2D, Orientation2D, Scale2D, Position3D, Orientation3D, Scale3D } from '../../transform/index.js'
@@ -10,7 +10,7 @@ export class AnimationEffector {
 
   /**
    * @param {World} _world
-   * @param {Entity} _entity
+   * @param {EntityHandle} _entity
    * @param {number[]} _results
    */
   static apply(_world, _entity, _results) {}
@@ -24,7 +24,7 @@ export class Position2DAnimationEffector extends AnimationEffector {
 
   /**
    * @param {World} world
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {number[]} results
    */
   static apply(world, entity, results) {
@@ -42,7 +42,7 @@ export class Position3DAnimationEffector extends AnimationEffector {
 
   /**
    * @param {World} world
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {number[]} results
    */
   static apply(world, entity, results) {
@@ -60,7 +60,7 @@ export class Orientation2DAnimationEffector extends AnimationEffector {
 
   /**
    * @param {World} world
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {number[]} results
    */
   static apply(world, entity, results) {
@@ -78,7 +78,7 @@ export class Orientation3DAnimationEffector extends AnimationEffector {
 
   /**
    * @param {World} world
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {number[]} results
    */
   static apply(world, entity, results) {
@@ -96,7 +96,7 @@ export class Scale2DAnimationEffector extends AnimationEffector {
 
   /**
    * @param {World} world
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {number[]} results
    */
   static apply(world, entity, results) {
@@ -114,7 +114,7 @@ export class Scale3DAnimationEffector extends AnimationEffector {
 
   /**
    * @param {World} world
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {number[]} results
    */
   static apply(world, entity, results) {
@@ -129,6 +129,6 @@ export class Scale3DAnimationEffector extends AnimationEffector {
 
 /**
  * @typedef AnimationEffectorEnforcer
- * @property {(world:World,entity:Entity,results:number[])=>void} apply
+ * @property {(world:World,entity:EntityHandle,results:number[])=>void} apply
  * @property {()=>number} elementSize
  */

--- a/src/animation/systems/animation.js
+++ b/src/animation/systems/animation.js
@@ -1,4 +1,4 @@
-import { Entity, Query, World } from '../../ecs/index.js'
+import { EntityHandle, Query, World } from '../../ecs/index.js'
 import { VirtualClock } from '../../time/index.js'
 import { AnimationPlayer, AnimationTarget } from '../components/index.js'
 import { AnimationClipAssets } from '../resources/index.js'
@@ -23,7 +23,7 @@ export function advanceAnimationPlayers(world) {
 export function applyAnimations(world) {
   const clips = world.getResource(AnimationClipAssets)
   const players = new Query(world, [AnimationPlayer])
-  const targets = new Query(world, [Entity, AnimationTarget])
+  const targets = new Query(world, [EntityHandle, AnimationTarget])
 
   targets.each(([entity, target]) => {
     const play = players.get(target.player)

--- a/src/animation/systems/types.js
+++ b/src/animation/systems/types.js
@@ -1,4 +1,4 @@
-import { Entity, World } from '../../ecs/index.js'
+import { EntityHandle, World } from '../../ecs/index.js'
 import { ArrayInfo, EnumInfo, Field, MapInfo, StructInfo } from '../../reflect/core/index.js'
 import { TypeRegistry } from '../../reflect/resources/index.js'
 import { setTypeId, typeid, typeidGeneric } from '../../type/index.js'
@@ -53,7 +53,7 @@ export function registerAnimationTypes(world) {
   registry.get(AnimationPlayer)?.setMethod(AnimationPlayer.serialize)
   registry.get(AnimationPlayer)?.setMethod(AnimationPlayer.deserialize)
   registry.register(AnimationTarget, new StructInfo({
-    player: new Field(typeid(Entity)),
+    player: new Field(typeid(EntityHandle)),
     id: new Field(typeid(String))
   }))
   registry.get(AnimationTarget)?.setMethod(AnimationTarget.copy)

--- a/src/broadphase/core/broadphases/naive.js
+++ b/src/broadphase/core/broadphases/naive.js
@@ -1,4 +1,4 @@
-/** @import {Entity} from '../../../ecs/index.js' */
+/** @import {EntityHandle} from '../../../ecs/index.js' */
 import { BoundingBox2D, BoundingCircle, intersectAABB2D, intersectAABB2DvsCircle } from '../../../geometry/index.js'
 import { Vector2 } from '../../../math/index.js'
 import { PhysicsHitbox } from '../../components/index.js'
@@ -11,7 +11,7 @@ export class NaiveBroadphase2D {
 
   /**
    * @private
-   * @type {Entity[]}
+   * @type {EntityHandle[]}
    */
   entities = []
 
@@ -23,8 +23,8 @@ export class NaiveBroadphase2D {
 
   /**
    * @param {BoundingBox2D} bound - Region to check in.
-   * @param {Entity[]} target - Empty array to store results.
-   * @returns {Entity[]}
+   * @param {EntityHandle[]} target - Empty array to store results.
+   * @returns {EntityHandle[]}
    */
   queryBox(bound, target = []) {
     for (let i = 0; i < this.entities.length; i++) if (intersectAABB2D(bound, this.bounds[i])) target.push(this.entities[i])
@@ -34,8 +34,8 @@ export class NaiveBroadphase2D {
 
   /**
    * @param {BoundingCircle} bound - Region to check in.
-   * @param {Entity[]} target - Empty array to store results.
-   * @returns {Entity[]}
+   * @param {EntityHandle[]} target - Empty array to store results.
+   * @returns {EntityHandle[]}
    */
   queryCircle(bound, target = []) {
     for (let i = 0; i < this.entities.length; i++) if (intersectAABB2DvsCircle(this.bounds[i], bound)) target.push(this.entities[i])
@@ -45,8 +45,8 @@ export class NaiveBroadphase2D {
 
   /**
    * @param {Vector2} _point - Region to check in.
-   * @param {Entity[]} target - Empty array to store results.
-   * @returns {Entity[]}
+   * @param {EntityHandle[]} target - Empty array to store results.
+   * @returns {EntityHandle[]}
    */
   queryPoint(_point, target = []) {
     for (let i = 0; i < this.entities.length; i++) {
@@ -66,7 +66,7 @@ export class NaiveBroadphase2D {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {PhysicsHitbox} bound
    */
   push(entity, bound) {

--- a/src/broadphase/core/collisionpair.js
+++ b/src/broadphase/core/collisionpair.js
@@ -1,20 +1,20 @@
-/** @import { Entity } from '../../ecs/index.js'*/
+/** @import { EntityHandle } from '../../ecs/index.js'*/
 
 export class CollisionPair {
 
   /**
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   a
 
   /**
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   b
 
   /**
-   * @param {Entity} a
-   * @param {Entity} b
+   * @param {EntityHandle} a
+   * @param {EntityHandle} b
    */
   constructor(a, b) {
     this.a = a

--- a/src/broadphase/resources/broadphase.js
+++ b/src/broadphase/resources/broadphase.js
@@ -1,4 +1,4 @@
-/** @import { Entity } from "../../ecs/index.js"*/
+/** @import { EntityHandle } from "../../ecs/index.js"*/
 import { BoundingBox2D, BoundingCircle } from '../../geometry/index.js'
 import { Vector2 } from '../../math/index.js'
 
@@ -19,7 +19,7 @@ export class Broadphase2D {
 
   /**
    * @param {BoundingBox2D} bound
-   * @param {Entity[]} [target=[]]
+   * @param {EntityHandle[]} [target=[]]
    */
   queryBox(bound, target = []) {
     return this.inner.queryBox(bound, target)
@@ -27,7 +27,7 @@ export class Broadphase2D {
 
   /**
    * @param {BoundingCircle} bound
-   * @param {Entity[]} target
+   * @param {EntityHandle[]} target
    */
   queryCircle(bound, target = []) {
     return this.inner.queryCircle(bound, target)
@@ -35,7 +35,7 @@ export class Broadphase2D {
 
   /**
    * @param {Vector2} point
-   * @param {Entity[]} [target=[]]
+   * @param {EntityHandle[]} [target=[]]
    */
   queryPoint(point, target = []) {
     return this.inner.queryPoint(point, target)
@@ -45,7 +45,7 @@ export class Broadphase2D {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {BoundingBox2D} broadphase
    */
   push(entity, broadphase) {
@@ -55,9 +55,9 @@ export class Broadphase2D {
 
 /**
  * @typedef Broadphasable2D
- * @property {(bound:BoundingBox2D,target?:Entity[])=>Entity[]} queryBox
- * @property {(bound:BoundingCircle,target?:Entity[])=>Entity[]} queryCircle
- * @property {(bound:Vector2,target?:Entity[])=>Entity[]} queryPoint
- * @property {(entity:Entity,bound:BoundingBox2D)=>void} push
+ * @property {(bound:BoundingBox2D,target?:EntityHandle[])=>EntityHandle[]} queryBox
+ * @property {(bound:BoundingCircle,target?:EntityHandle[])=>EntityHandle[]} queryCircle
+ * @property {(bound:Vector2,target?:EntityHandle[])=>EntityHandle[]} queryPoint
+ * @property {(entity:EntityHandle,bound:BoundingBox2D)=>void} push
  * @property {()=>void} clear
  */

--- a/src/broadphase/systems/broadphase.js
+++ b/src/broadphase/systems/broadphase.js
@@ -1,7 +1,7 @@
 import { Broadphase2D, CollisionPairs } from '../resources/index.js'
 import { PhysicsHitbox } from '../components/index.js'
 import { CollisionPair } from '../core/index.js'
-import { Entity, Query, World } from '../../ecs/index.js'
+import { EntityHandle, Query, World } from '../../ecs/index.js'
 import { intersectAABB2D } from '../../geometry/index.js'
 
 /**
@@ -9,7 +9,7 @@ import { intersectAABB2D } from '../../geometry/index.js'
  */
 export function getCollisionPairs(world) {
   const pairs = world.getResource(CollisionPairs)
-  const query = new Query(world, [Entity, PhysicsHitbox])
+  const query = new Query(world, [EntityHandle, PhysicsHitbox])
 
   pairs.clear()
 
@@ -23,7 +23,7 @@ export function getCollisionPairs(world) {
  */
 export function updateBroadphase2D(world) {
   const broadphase = world.getResource(Broadphase2D)
-  const query = new Query(world, [Entity, PhysicsHitbox])
+  const query = new Query(world, [EntityHandle, PhysicsHitbox])
 
   broadphase.clear()
 

--- a/src/broadphase/systems/types.js
+++ b/src/broadphase/systems/types.js
@@ -1,4 +1,4 @@
-import { Entity, World } from '../../ecs/index.js'
+import { EntityHandle, World } from '../../ecs/index.js'
 import { ArrayInfo, Field, StructInfo } from '../../reflect/core/index.js'
 import { TypeRegistry } from '../../reflect/resources/index.js'
 import { typeid } from '../../type/index.js'
@@ -14,8 +14,8 @@ export function registerBroadphaseTypes2D(world) {
   const registry = world.getResource(TypeRegistry)
 
   registry.register(CollisionPair, new StructInfo({
-    a: new Field(typeid(Entity)),
-    b: new Field(typeid(Entity))
+    a: new Field(typeid(EntityHandle)),
+    b: new Field(typeid(EntityHandle))
   }))
   registry.register(PhysicsHitbox, new StructInfo({
     type: new Field(typeid(Number)),

--- a/src/core/commands/despawn.js
+++ b/src/core/commands/despawn.js
@@ -1,16 +1,16 @@
-/** @import { Entity } from '../../ecs/index.js' */
+/** @import { EntityHandle } from '../../ecs/index.js' */
 import { Command } from '../../command/index.js'
 import { World } from '../../ecs/registry.js'
 
 export class DespawnCommand extends Command {
 
   /**
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   entity
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   constructor(entity) {
     super()

--- a/src/core/commands/spawn.js
+++ b/src/core/commands/spawn.js
@@ -1,11 +1,11 @@
-import { World, Entity } from '../../ecs/index.js'
+import { World, EntityHandle } from '../../ecs/index.js'
 import { Command } from '../../command/index.js'
 
 export class SpawnCommand extends Command {
 
   /**
    * @readonly
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   entity
 
@@ -15,7 +15,7 @@ export class SpawnCommand extends Command {
   components = []
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   constructor(entity) {
     super()

--- a/src/core/core/entity.js
+++ b/src/core/core/entity.js
@@ -1,4 +1,4 @@
-/** @import { Entity } from '../../ecs/index.js' */
+/** @import { EntityHandle } from '../../ecs/index.js' */
 import { CommandQueue } from '../../command/resources/queue.js'
 import { SpawnCommand, DespawnCommand } from '../commands/index.js'
 import { assert } from '../../logger/index.js'
@@ -29,7 +29,7 @@ export class EntityCommands {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   entity(entity) {
     this.buffered = new SpawnCommand(entity)
@@ -51,7 +51,7 @@ export class EntityCommands {
   /**
    * @template {unknown[]} T
    * @param {[...T][]} batch
-   * @returns {Entity[]}
+   * @returns {EntityHandle[]}
    */
   spawnBatch(batch) {
     const entities = []
@@ -71,7 +71,7 @@ export class EntityCommands {
   /**
    * Builds an entity with the components previously passed to
    * {@link EntityCommands.insert} and {@link EntityCommands.insertPrefab}.
-   * @returns {Entity}
+   * @returns {EntityHandle}
    */
   build() {
     assert(this.buffered, `${entityerror}\`EntityCommands.build()\`.`)
@@ -111,7 +111,7 @@ export class EntityCommands {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   despawn(entity) {
     this.queue.add(new DespawnCommand(entity))

--- a/src/core/systems/types.js
+++ b/src/core/systems/types.js
@@ -1,4 +1,4 @@
-import { Entity, World } from '../../ecs/index.js'
+import { EntityHandle, World } from '../../ecs/index.js'
 import { Field, StructInfo, TypeRegistry } from '../../reflect/index.js'
 import { typeid } from '../../type/index.js'
 
@@ -8,10 +8,10 @@ import { typeid } from '../../type/index.js'
 export function registerCoreTypes(world) {
   const registry = world.getResource(TypeRegistry)
 
-  registry.register(Entity, new StructInfo({
+  registry.register(EntityHandle, new StructInfo({
     index: new Field(typeid(Number)),
     generation: new Field(typeid(Number))
   }))
-  registry.get(Entity)?.setMethod(Entity.serialize)
-  registry.get(Entity)?.setMethod(Entity.deserialize)
+  registry.get(EntityHandle)?.setMethod(EntityHandle.serialize)
+  registry.get(EntityHandle)?.setMethod(EntityHandle.deserialize)
 }

--- a/src/diagnostic/entitycount.js
+++ b/src/diagnostic/entitycount.js
@@ -1,6 +1,6 @@
 import { App } from '../app/index.js'
 import { AppSchedule, CoreSystems } from '../core/index.js'
-import { World, Entity, Query } from '../ecs/index.js'
+import { World, EntityHandle, Query } from '../ecs/index.js'
 
 export class EntityCountDiagnosticPlugin {
 
@@ -35,7 +35,7 @@ function setUpUI() {
  * @param {World} world
  */
 function updateEntityCount(world) {
-  const entities = new Query(world, [Entity])
+  const entities = new Query(world, [EntityHandle])
   const num = entities.count()
   const container = document.querySelector('#entity-count-container')
 

--- a/src/ecs/entities/entity.js
+++ b/src/ecs/entities/entity.js
@@ -1,6 +1,6 @@
 import { packInto64Int, unpackFrom64Int } from 'vifaa'
 
-export class Entity {
+export class EntityHandle {
 
   /**
    * @readonly
@@ -24,7 +24,7 @@ export class Entity {
   }
 
   /**
-   * @param {Entity} other
+   * @param {EntityHandle} other
    */
   equals(other) {
     return (
@@ -48,11 +48,11 @@ export class Entity {
   static from(id) {
     const [index, generation] = unpackFrom64Int(id)
 
-    return new Entity(index, generation)
+    return new EntityHandle(index, generation)
   }
 
   /**
-   * @param {Entity} value
+   * @param {EntityHandle} value
    */
   static serialize(value) {
     return {
@@ -63,9 +63,9 @@ export class Entity {
 
   /**
    * @param {EntityId} value
-   * @param {Entity} [out]
+   * @param {EntityHandle} [out]
    */
-  static deserialize(value, out = new Entity(0, 0)) {
+  static deserialize(value, out = new EntityHandle(0, 0)) {
     const [index, generation] = unpackFrom64Int(value)
     const target = /** @type {any} */ (out)
 

--- a/src/ecs/entities/entitycell.js
+++ b/src/ecs/entities/entitycell.js
@@ -3,7 +3,7 @@
 import { typeid } from '../../type/index.js'
 import { Archetypes } from '../archetype/index.js'
 import { Tables } from '../tables/index.js'
-import { Entity } from './entity.js'
+import { EntityHandle } from './entity.js'
 import { EntityLocation } from './location.js'
 
 // TODO: This currently does not work with adding or removing components,
@@ -13,7 +13,7 @@ export class EntityCell {
 
   /**
    * @private
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   entity
 
@@ -34,7 +34,7 @@ export class EntityCell {
 
   /**
    * @param {World} world
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   constructor(world, entity) {
     const entities = world.getEntities()
@@ -120,7 +120,7 @@ export class EntityCell {
   }
 
   /**
-   * @returns {Entity}
+   * @returns {EntityHandle}
    */
   id() {
     return this.entity

--- a/src/ecs/query/query.js
+++ b/src/ecs/query/query.js
@@ -1,7 +1,7 @@
 /** @import { TableId, TableRow } from '../typedef/index.js'*/
 /** @import { TypeId, TupleConstructor  } from '../../type/index.js'*/
 
-import { Entity } from '../entities/index.js'
+import { EntityHandle } from '../entities/index.js'
 import { World } from '../registry.js'
 import { typeid } from '../../type/index.js'
 import { Table } from '../tables/index.js'
@@ -101,7 +101,7 @@ export class Query {
   /**
    * Gets the components of a given entity.
    *
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @returns {T | null}
    */
   get(entity) {

--- a/src/ecs/registry.js
+++ b/src/ecs/registry.js
@@ -5,7 +5,7 @@ import { Table, Tables } from './tables/index.js'
 import { TypeStore } from './typestore.js'
 import { assert } from '../logger/index.js'
 import { ComponentHooks } from './component/index.js'
-import { Entities, Entity } from './entities/index.js'
+import { Entities, EntityHandle } from './entities/index.js'
 import { Archetypes, Archetype } from './archetype/index.js'
 import { EntityLocation } from './entities/location.js'
 import { typeid } from '../type/index.js'
@@ -48,7 +48,7 @@ export class World {
    */
   entities = new Entities()
   constructor() {
-    this.typestore.set(Entity)
+    this.typestore.set(EntityHandle)
   }
 
   /**
@@ -60,7 +60,7 @@ export class World {
 
   /**
    * @private
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {readonly TypeId[]} newIds
    */
   callAddComponentHook(entity, newIds) {
@@ -73,7 +73,7 @@ export class World {
 
   /**
    * @private
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {readonly TypeId[]} newIds
    */
   callRemoveComponentHook(entity, newIds) {
@@ -86,7 +86,7 @@ export class World {
 
   /**
    * @private
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {readonly TypeId[]} newIds
    *
    */
@@ -129,7 +129,7 @@ export class World {
    *
    * @template {{}[]} T
    * @param {[...T]} components - The entity to add.
-   * @returns {Entity}
+   * @returns {EntityHandle}
    */
   spawn(components) {
     const entityIndex = this.entities.reserve()
@@ -146,9 +146,9 @@ export class World {
 
     // SAFETY:Object constructors can be casted from `Function` to `Constructor`
     const newIds = (components.map((c) => typeid(/** @type {Constructor} */(c.constructor))))
-    const entity = new Entity(entityIndex, location.generation)
+    const entity = new EntityHandle(entityIndex, location.generation)
 
-    newIds.push(typeid(Entity))
+    newIds.push(typeid(EntityHandle))
     components.push(entity)
 
     const [tableId, table, archetypeId] = this.resolve(newIds)
@@ -166,7 +166,7 @@ export class World {
    * Inserts components into an entity.
    *
    * @template {object[]} T
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {[...T]} components - The entity to add.
    */
   insert(entity, components) {
@@ -192,7 +192,7 @@ export class World {
       oldTable.insertUnchecked(index, newIds, components)
     } else {
       const newIndex = oldTable.moveTo(newTable, index)
-      const swapped = /** @type {Entity | null}*/ (oldTable.get(typeid(Entity), index))
+      const swapped = /** @type {EntityHandle | null}*/ (oldTable.get(typeid(EntityHandle), index))
 
       newTable.insertUnchecked(newIndex, newIds, components)
       location.tableId = newTableId
@@ -212,7 +212,7 @@ export class World {
 
   /**
    * @template {unknown[]} T
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {TupleConstructor<T>} components
    */
   remove(entity, components) {
@@ -236,7 +236,7 @@ export class World {
     this.callRemoveComponentHook(entity, removedIds)
 
     const newIndex = oldTable.moveTo(newTable, index)
-    const swapped = /** @type {Entity | null}*/ (oldTable.get(typeid(Entity), index))
+    const swapped = /** @type {EntityHandle | null}*/ (oldTable.get(typeid(EntityHandle), index))
 
     location.tableId = newTableId
     location.archetypeId = newArchetypeId
@@ -266,7 +266,7 @@ export class World {
    * Note that this doesn't destroy the entity, only removes it and its components from the manager.
    * To destroy the entity,use `Entity.destroy()` method.
    *
-   * @param {Entity} entity - The entity to remove.
+   * @param {EntityHandle} entity - The entity to remove.
    */
   despawn(entity) {
     const location = this.entities.get(entity.index)
@@ -285,7 +285,7 @@ export class World {
     table.remove(index)
 
     // SAFETY: The fetched component is an `Entity`.
-    const swapped = /** @type {Entity | null}*/ (table.get(typeid(Entity), index))
+    const swapped = /** @type {EntityHandle | null}*/ (table.get(typeid(EntityHandle), index))
 
     // SAFETY: -1 is the invalid identifier
     location.tableId = /** @type {TableId}*/ (-1)
@@ -304,7 +304,7 @@ export class World {
 
   /**
    * @template T
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param { Constructor<T>} type
    * @returns {T | null}
    */
@@ -324,7 +324,7 @@ export class World {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @returns {EntityCell}
    */
   getEntity(entity) {

--- a/src/ecs/tests/entities/entitycell.test.js
+++ b/src/ecs/tests/entities/entitycell.test.js
@@ -1,5 +1,5 @@
 import { test, describe } from "node:test";
-import { Entity, World } from "../../index.js";
+import { EntityHandle, World } from "../../index.js";
 import { deepStrictEqual } from "assert";
 import { typeid } from "../../../type/index.js";
 
@@ -8,7 +8,7 @@ describe("Testing `EntityCell`", () => {
     const world = new World()
     const entity = world.spawn([new A(), new B(), new C()])
     const cell = world.getEntity(entity)
-    deepStrictEqual(cell.components(), [typeid(A), typeid(B), typeid(C), typeid(Entity)])
+    deepStrictEqual(cell.components(), [typeid(A), typeid(B), typeid(C), typeid(EntityHandle)])
   })
 
   test('`EntityCell` gets correct component', () => {
@@ -28,8 +28,8 @@ describe("Testing `EntityCell`", () => {
     const cell1 = world.getEntity(entity1)
     const cell2 = world.getEntity(entity2)
 
-    deepStrictEqual(cell1.id(), new Entity(0, 1))
-    deepStrictEqual(cell2.id(), new Entity(1, 1))
+    deepStrictEqual(cell1.id(), new EntityHandle(0, 1))
+    deepStrictEqual(cell2.id(), new EntityHandle(1, 1))
   })
 
   test('`EntityCell` tests entity existence correctly.', () => {

--- a/src/ecs/tests/query.test.js
+++ b/src/ecs/tests/query.test.js
@@ -1,5 +1,5 @@
 import { test, describe } from "node:test";
-import { Entity, Query, has, without, World } from "../index.js";
+import { EntityHandle, Query, has, without, World } from "../index.js";
 import assert, { strictEqual } from "node:assert";
 import { typeid } from "../../type/index.js";
 
@@ -75,7 +75,7 @@ describe("Testing `Query`", () => {
   test('query for single component, specific entity', () => {
     const world = createWorld()
     const query = new Query(world, [A])
-    const entity = new Entity(0, 1)
+    const entity = new EntityHandle(0, 1)
     const components = query.get(entity)
     assert(components)
 
@@ -89,7 +89,7 @@ describe("Testing `Query`", () => {
   test('query for multiple components, specific entity', () => {
     const world = createWorld()
     const query = new Query(world, [A, B, C])
-    const entity = new Entity(0, 1)
+    const entity = new EntityHandle(0, 1)
     const components = query.get(entity)
 
     assert(components)

--- a/src/ecs/tests/world.test.js
+++ b/src/ecs/tests/world.test.js
@@ -2,7 +2,7 @@ import { test, describe } from "node:test";
 import { deepStrictEqual, throws } from "node:assert";
 import { World } from "../registry.js";
 import { typeid } from "../../type/index.js";
-import { Entity } from "../entities/entity.js";
+import { EntityHandle } from "../entities/entity.js";
 class A {
   number = 0
 }
@@ -25,14 +25,14 @@ describe("Testing `World`", () => {
     const entityCell = world.getEntity(entity)
     const components = [...entityCell.components()]
 
-    deepStrictEqual(components, [typeid(A), typeid(B), typeid(C), typeid(Entity)])
+    deepStrictEqual(components, [typeid(A), typeid(B), typeid(C), typeid(EntityHandle)])
   })
 
   test('Entity generation starts at one.', () => {
     const world = new World()
     const entity = world.spawn([new A(), new B(), new C()])
 
-    deepStrictEqual(entity,new Entity(0,1))
+    deepStrictEqual(entity,new EntityHandle(0,1))
   })
 
   test('Entity generation is incremented.', () => {
@@ -43,9 +43,9 @@ describe("Testing `World`", () => {
     world.despawn(entity2)
     const entity3 = world.spawn([new A(), new B(), new C()])
 
-    deepStrictEqual(entity1,new Entity(0,1))
-    deepStrictEqual(entity2,new Entity(0,2))
-    deepStrictEqual(entity3,new Entity(0,3))
+    deepStrictEqual(entity1,new EntityHandle(0,1))
+    deepStrictEqual(entity2,new EntityHandle(0,2))
+    deepStrictEqual(entity3,new EntityHandle(0,3))
   })
 
   test('Entity is despawned correctly from a world.', () => {
@@ -67,8 +67,8 @@ describe("Testing `World`", () => {
     const cell1 = world.getEntity(entity1)
     const cell2 = world.getEntity(entity2)
   
-    deepStrictEqual(entity1,new Entity(0,1))
-    deepStrictEqual(entity2,new Entity(0,2))
+    deepStrictEqual(entity1,new EntityHandle(0,1))
+    deepStrictEqual(entity2,new EntityHandle(0,2))
     deepStrictEqual(cell1.exists(), false)
     deepStrictEqual(cell2.exists(), true)
   })
@@ -80,7 +80,7 @@ describe("Testing `World`", () => {
     const entityCell = world.getEntity(entity)
     const components = [...entityCell.components()]
 
-    deepStrictEqual(components, [typeid(Entity), typeid(A), typeid(B), typeid(C)])
+    deepStrictEqual(components, [typeid(EntityHandle), typeid(A), typeid(B), typeid(C)])
   })
 
   test('Components are removed from an entity.', () => {
@@ -90,7 +90,7 @@ describe("Testing `World`", () => {
     const entityCell = world.getEntity(entity)
     const components = [...entityCell.components()]
 
-    deepStrictEqual(components, [typeid(C), typeid(Entity)])
+    deepStrictEqual(components, [typeid(C), typeid(EntityHandle)])
   })
 
   test('Set and get correct resource on world.', () => {

--- a/src/ecs/typedef/componenthook.js
+++ b/src/ecs/typedef/componenthook.js
@@ -1,8 +1,8 @@
 /** @import { World } from "../registry.js" */
-/** @import { Entity } from "../entities/index.js" */
+/** @import { EntityHandle } from "../entities/index.js" */
 /**
  * @callback ComponentHook
- * @param {Entity} entity
+ * @param {EntityHandle} entity
  * @param {World} registry
  * @returns {void}
  */

--- a/src/emitter/components/emitter.js
+++ b/src/emitter/components/emitter.js
@@ -1,6 +1,6 @@
 import { EntityCommands } from '../../core/index.js'
 import { Range } from '../../datastructures/index.js'
-import { Entity } from '../../ecs/index.js'
+import { EntityHandle } from '../../ecs/index.js'
 
 export class Emitter {
 
@@ -11,7 +11,7 @@ export class Emitter {
   prefab
 
   /**
-   * @type {((commands:EntityCommands,entity:Entity)=>void) | undefined}
+   * @type {((commands:EntityCommands,entity:EntityHandle)=>void) | undefined}
    */
   patch
 
@@ -121,7 +121,7 @@ export class Emitter {
 /**
  * @typedef EmitterSerial
  * @property {(() => unknown[]) | undefined} [prefab]
- * @property {((commands:EntityCommands,entity:Entity)=>void) | undefined} [patch]
+ * @property {((commands:EntityCommands,entity:EntityHandle)=>void) | undefined} [patch]
  * @property {{ start: number, end: number }} burstCount
  * @property {boolean} enabled
  * @property {{ start: number, end: number }} lifetime
@@ -130,7 +130,7 @@ export class Emitter {
 /**
  * @typedef EmitterOptions
  * @property {()=>unknown[]} [prefab]
- * @property {(commands:EntityCommands,entity:Entity)=>void} [patch]
+ * @property {(commands:EntityCommands,entity:EntityHandle)=>void} [patch]
  * @property {Range} [burstCount]
  * @property {Range} [lifetime]
  * @property {boolean} [enabled]

--- a/src/emitter/systems/index.js
+++ b/src/emitter/systems/index.js
@@ -1,4 +1,4 @@
-import { Entity, has, Query, World } from '../../ecs/index.js'
+import { EntityHandle, has, Query, World } from '../../ecs/index.js'
 import { Timer } from '../../time/index.js'
 import { EntityCommands } from '../../core/index.js'
 import { Position2D, Orientation2D, GlobalTransform2D, GlobalTransform3D, Orientation3D, Position3D, Scale3D } from '../../transform/index.js'
@@ -95,7 +95,7 @@ export function emitParticles3D(world) {
  * @param {World} world
  */
 export function despawnParticles(world) {
-  const particles = new Query(world, [Entity, Timer], [has(Particle)])
+  const particles = new Query(world, [EntityHandle, Timer], [has(Particle)])
   const commands = new EntityCommands(world)
 
   particles.each(([entity, timer]) => {

--- a/src/gizmo/systems/canvas2d.js
+++ b/src/gizmo/systems/canvas2d.js
@@ -1,6 +1,6 @@
 /** @import { Constructor } from '../../type/index.js' */
 /** @import { SystemFunc } from '../../ecs/index.js' */
-import { Entity, Query } from '../../ecs/index.js'
+import { EntityHandle, Query } from '../../ecs/index.js'
 import {
   Gizmo2D,
   Gizmo3D,
@@ -25,7 +25,7 @@ export function genenerateDrawGizmo2Dsystem(label) {
     /** @type {Gizmo2D<T>} */
     const gizmo = world.getResourceByTypeId(gizmotypeid)
     const canvases = world.getResource(Windows)
-    const window = new Query(world, [Entity, Window]).single()
+    const window = new Query(world, [EntityHandle, Window]).single()
 
     if (!window) return
 

--- a/src/hierarchy/components/children.js
+++ b/src/hierarchy/components/children.js
@@ -1,4 +1,4 @@
-import { Entity } from '../../ecs/index.js'
+import { EntityHandle } from '../../ecs/index.js'
 import { TraverseEntities } from '../../relationship/index.js'
 
 /**
@@ -8,12 +8,12 @@ export class Children {
 
   /**
    * @public
-   * @type {Entity[]}
+   * @type {EntityHandle[]}
    */
   list = []
 
   /**
-   * @param {Entity[]} children
+   * @param {EntityHandle[]} children
    */
   constructor(children = []) {
     this.list = children
@@ -48,7 +48,7 @@ export class Children {
    * @param {Children} [out]
    */
   static deserialize(value, out = new Children([])) {
-    out.list = value.map((entity) => Entity.deserialize(entity))
+    out.list = value.map((entity) => EntityHandle.deserialize(entity))
 
     return out
   }
@@ -63,7 +63,7 @@ export class Children {
     }
 
     for (let i = 0; i < value.length; i++) {
-      if (!Entity.validateSerial(value[i])) {
+      if (!EntityHandle.validateSerial(value[i])) {
         return false
       }
     }
@@ -72,14 +72,14 @@ export class Children {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   add(entity) {
     this.list.push(entity)
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   remove(entity) {
     this.list.splice(this.list.indexOf(entity), 1)
@@ -92,7 +92,7 @@ export class Children {
    * @param {Map<import('../../ecs/index.js').EntityId,import('../../ecs/index.js').EntityId>} entityMap
    */
   map(entityMap) {
-    this.list = this.list.map((e) => Entity.from(entityMap.get(e.id())))
+    this.list = this.list.map((e) => EntityHandle.from(entityMap.get(e.id())))
   }
 
   /**

--- a/src/hierarchy/components/parent.js
+++ b/src/hierarchy/components/parent.js
@@ -1,4 +1,4 @@
-import { Entity } from '../../ecs/index.js'
+import { EntityHandle } from '../../ecs/index.js'
 import { TraverseEntities } from '../../relationship/index.js'
 
 /**
@@ -8,12 +8,12 @@ export class Parent {
 
   /**
    * @public
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   entity
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   constructor(entity) {
     this.entity = entity
@@ -27,7 +27,7 @@ export class Parent {
    * @param {Map<import('../../ecs/index.js').EntityId,import('../../ecs/index.js').EntityId>} entityMap
    */
   map(entityMap) {
-    this.entity = Entity.from(entityMap.get(this.entity.id()))
+    this.entity = EntityHandle.from(entityMap.get(this.entity.id()))
   }
 
   /**
@@ -58,8 +58,8 @@ export class Parent {
    * @param {ParentSerial} value
    * @param {Parent} [out]
    */
-  static deserialize(value, out = new Parent(new Entity(0, 0))) {
-    out.entity = Entity.deserialize(value, out.entity)
+  static deserialize(value, out = new Parent(new EntityHandle(0, 0))) {
+    out.entity = EntityHandle.deserialize(value, out.entity)
 
     return out
   }
@@ -69,7 +69,7 @@ export class Parent {
    * @returns {value is ParentSerial}
    */
   static validateSerial(value) {
-    return Entity.validateSerial(value)
+    return EntityHandle.validateSerial(value)
   }
 }
 

--- a/src/hierarchy/systems/types.js
+++ b/src/hierarchy/systems/types.js
@@ -1,4 +1,4 @@
-import { Entity, World } from '../../ecs/index.js'
+import { EntityHandle, World } from '../../ecs/index.js'
 import { ArrayInfo, Field, StructInfo } from '../../reflect/core/index.js'
 import { TypeRegistry } from '../../reflect/resources/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
@@ -10,9 +10,9 @@ import { Children, Parent } from '../components/index.js'
 export function registerHierarchyTypes(world) {
   const registry = world.getResource(TypeRegistry)
 
-  const entityArrayId = typeidGeneric(Array, [Entity])
+  const entityArrayId = typeidGeneric(Array, [EntityHandle])
 
-  registry.registerTypeId(entityArrayId, new ArrayInfo(typeid(Entity)))
+  registry.registerTypeId(entityArrayId, new ArrayInfo(typeid(EntityHandle)))
 
   registry.register(Children, new StructInfo({
     list: new Field(entityArrayId)
@@ -24,7 +24,7 @@ export function registerHierarchyTypes(world) {
   registry.get(Children)?.setMethod(Children.prototype.visit)
   registry.get(Children)?.setMethod(Children.prototype.map)
   registry.register(Parent, new StructInfo({
-    entity: new Field(typeid(Entity))
+    entity: new Field(typeid(EntityHandle))
   }))
   registry.get(Parent)?.setMethod(Parent.copy)
   registry.get(Parent)?.setMethod(Parent.clone)

--- a/src/narrowphase/core/mainfold.js
+++ b/src/narrowphase/core/mainfold.js
@@ -1,16 +1,16 @@
-/** @import { Entity } from '../../ecs/index.js'*/
+/** @import { EntityHandle } from '../../ecs/index.js'*/
 import { Vector2, Angle, clamp } from '../../math/index.js'
 import { PhysicsSettings } from '../../physics/settings.js'
 
 export class CollisionManifold {
 
   /**
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   entityA
 
   /**
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   entityB
 
@@ -125,8 +125,8 @@ export class CollisionManifold {
   invinertiaB = 0
 
   /**
-   * @param {Entity} a
-   * @param {Entity} b
+   * @param {EntityHandle} a
+   * @param {EntityHandle} b
    * @param {Vector2} pA
    * @param {Vector2} pB
    * @param {Vector2} vA

--- a/src/narrowphase/systems/types.js
+++ b/src/narrowphase/systems/types.js
@@ -1,4 +1,4 @@
-import { World, Entity } from '../../ecs/index.js'
+import { World, EntityHandle } from '../../ecs/index.js'
 import { ArrayInfo, Field, MapInfo, StructInfo } from '../../reflect/core/index.js'
 import { TypeRegistry } from '../../reflect/resources/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
@@ -37,8 +37,8 @@ export function registerNarrowphase2DTypes(world) {
     contactNo: new Field(typeid(Number))
   }))
   registry.register(CollisionManifold, new StructInfo({
-    entityA: new Field(typeid(Entity)),
-    entityB: new Field(typeid(Entity)),
+    entityA: new Field(typeid(EntityHandle)),
+    entityB: new Field(typeid(EntityHandle)),
     velocityA: new Field(typeid(Vector2)),
     velocityB: new Field(typeid(Vector2)),
     rotationA: new Field(typeid(Angle)),

--- a/src/physics/plugins/debugger.js
+++ b/src/physics/plugins/debugger.js
@@ -1,4 +1,4 @@
-/** @import {Entity} from '../../ecs/index.js' */
+/** @import {EntityHandle} from '../../ecs/index.js' */
 import { App, Plugin } from '../../app/index.js'
 import { AppSchedule } from '../../core/index.js'
 import {

--- a/src/physics/systems/debugger.js
+++ b/src/physics/systems/debugger.js
@@ -1,7 +1,7 @@
 import { Collider2D } from '../components/index.js'
 import { Vector2 } from '../../math/index.js'
 import { vertices } from '../../render-canvas2d/index.js'
-import { Query, World, Entity } from '../../ecs/index.js'
+import { Query, World, EntityHandle } from '../../ecs/index.js'
 import { Position2D } from '../../transform/index.js'
 import { PhysicsHitbox } from '../../broadphase/index.js'
 import { MainWindow, Windows } from '../../window/index.js'
@@ -13,9 +13,9 @@ import { Contacts } from '../../narrowphase/index.js'
  */
 export function drawBounds(world) {
   const query = new Query(world, [PhysicsHitbox])
-  const windows = new Query(world, [Entity, MainWindow])
+  const windows = new Query(world, [EntityHandle, MainWindow])
   const canvases = world.getResource(Windows)
-  const window = /** @type {[Entity,MainWindow]}*/(windows.single())
+  const window = /** @type {[EntityHandle,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
 
@@ -49,9 +49,9 @@ export function drawBounds(world) {
  */
 export function drawPosition(world) {
   const query = new Query(world, [Position2D])
-  const windows = new Query(world, [Entity, MainWindow])
+  const windows = new Query(world, [EntityHandle, MainWindow])
   const canvases = world.getResource(Windows)
-  const window = /** @type {[Entity,MainWindow]}*/(windows.single())
+  const window = /** @type {[EntityHandle,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
 
@@ -75,10 +75,10 @@ export function drawPosition(world) {
  */
 export function drawVelocity(world) {
   const query = new Query(world, [Position2D, Velocity2D])
-  const windows = new Query(world, [Entity, MainWindow])
+  const windows = new Query(world, [EntityHandle, MainWindow])
   const canvases = world.getResource(Windows)
 
-  const window = /** @type {[Entity,MainWindow]}*/(windows.single())
+  const window = /** @type {[EntityHandle,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
 
@@ -101,9 +101,9 @@ export function drawVelocity(world) {
  * @param {World} world
  */
 export function drawShapes(world) {
-  const windows = new Query(world, [Entity, MainWindow])
+  const windows = new Query(world, [EntityHandle, MainWindow])
   const canvases = world.getResource(Windows)
-  const window = /** @type {[Entity,MainWindow]}*/(windows.single())
+  const window = /** @type {[EntityHandle,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
 
@@ -144,10 +144,10 @@ export function drawShapes(world) {
  * @param {World} world
  */
 export function drawArms(world) {
-  const windows = new Query(world, [Entity, MainWindow])
+  const windows = new Query(world, [EntityHandle, MainWindow])
   const contacts = world.getResource(Contacts)
   const canvases = world.getResource(Windows)
-  const window = /** @type {[Entity,MainWindow]}*/(windows.single())
+  const window = /** @type {[EntityHandle,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
 
@@ -180,11 +180,11 @@ export function drawArms(world) {
  * @param {World} world
  */
 export function drawContacts(world) {
-  const windows = new Query(world, [Entity, MainWindow])
+  const windows = new Query(world, [EntityHandle, MainWindow])
   const canvases = world.getResource(Windows)
   const clmd = world.getResource(Contacts)
 
-  const window = /** @type {[Entity,MainWindow]}*/(windows.single())
+  const window = /** @type {[EntityHandle,MainWindow]}*/(windows.single())
 
   const canvas = canvases.getWindow(window[0])
 

--- a/src/relationship/core/query.js
+++ b/src/relationship/core/query.js
@@ -1,12 +1,12 @@
 /** @import { QueryFilter,EntityId } from '../../ecs/index.js' */
 /** @import { Constructor, TupleConstructor } from '../../type/index.js' */
-import { Query, World, Entity } from '../../ecs/index.js'
+import { Query, World, EntityHandle } from '../../ecs/index.js'
 import { TraverseEntities } from './traverseentities.js'
 
 /**
  * @template {TraverseEntities} Relationship
  * @template {TraverseEntities} [Target = Relationship]
- * @template {unknown[]} [Data = [Entity]]
+ * @template {unknown[]} [Data = [EntityHandle]]
  * @template {QueryFilter[]} [Filter = []]
  */
 export class RelationshipQuery {
@@ -50,7 +50,7 @@ export class RelationshipQuery {
     target = /** @type {Constructor<Target>}*/ (/** @type {unknown} */ (relationship)),
 
     // SAFETY: matches the default `Data`.
-    data = /** @type {[...TupleConstructor<Data>]} */([Entity]),
+    data = /** @type {[...TupleConstructor<Data>]} */([EntityHandle]),
 
     // SAFETY: matches the default `Filter`.
     filter = /** @type {Filter}*/([])
@@ -65,7 +65,7 @@ export class RelationshipQuery {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param { (descendant: Data, ancestor: Data) => void } visit
    */
   treebfs(entity, visit) {
@@ -75,7 +75,7 @@ export class RelationshipQuery {
 
       // SAFETY: `stack` is dense and an element is guaranteed to exist
       // as we check the length above.
-      const ancestorEntity = /** @type {Entity}*/(queue.shift())
+      const ancestorEntity = /** @type {EntityHandle}*/(queue.shift())
       const ancestor = this.ancestors.get(ancestorEntity)
 
       if (!ancestor) continue
@@ -99,12 +99,12 @@ export class RelationshipQuery {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param { (descendant: Data, ancestor: Data) => void } visit
    */
   treedfs(entity, visit) {
 
-    /** @type {[Entity,Entity][]} */
+    /** @type {[EntityHandle,EntityHandle][]} */
     const stack = []
     const root = this.ancestors.get(entity)
 
@@ -114,7 +114,7 @@ export class RelationshipQuery {
 
     stack.push(
       ...relationship.visit()
-        .map((c) => /** @type {[Entity,Entity]} */([entity, c]))
+        .map((c) => /** @type {[EntityHandle,EntityHandle]} */([entity, c]))
         .reverse()
     )
 
@@ -134,14 +134,14 @@ export class RelationshipQuery {
 
       if (grand) stack.push(
         ...grand[0].visit()
-          .map((c) => /** @type {[Entity,Entity]} */([descendantEntity, c]))
+          .map((c) => /** @type {[EntityHandle,EntityHandle]} */([descendantEntity, c]))
           .reverse()
       )
     }
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param { (descendant: Data, ancestor: Data) => void } visit
    */
   graphbfs(entity, visit) {
@@ -154,7 +154,7 @@ export class RelationshipQuery {
 
       // SAFETY: `stack` is dense and an element is guaranteed to exist
       // as we check the length above.
-      const ancestorEntity = /** @type {Entity}*/(queue.shift())
+      const ancestorEntity = /** @type {EntityHandle}*/(queue.shift())
       const ancestorEntityId = ancestorEntity.id()
       const ancestor = this.ancestors.get(ancestorEntity)
 
@@ -181,12 +181,12 @@ export class RelationshipQuery {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param { (descendant: Data, ancestor: Data) => void } visit
    */
   graphdfs(entity, visit) {
 
-    /** @type {[Entity,Entity][]} */
+    /** @type {[EntityHandle,EntityHandle][]} */
     const stack = []
 
     /** @type {Set<EntityId>} */
@@ -199,7 +199,7 @@ export class RelationshipQuery {
 
     stack.push(
       ...rootRelationship.visit()
-        .map((c) => /** @type {[Entity,Entity]} */([entity, c]))
+        .map((c) => /** @type {[EntityHandle,EntityHandle]} */([entity, c]))
         .reverse()
     )
     while (stack.length) {
@@ -221,7 +221,7 @@ export class RelationshipQuery {
 
       if (grand) stack.push(
         ...grand[0].visit()
-          .map((c) => /** @type {[Entity,Entity]} */([descendantEntity, c]))
+          .map((c) => /** @type {[EntityHandle,EntityHandle]} */([descendantEntity, c]))
           .filter(([e]) => !visited.has(e.id()))
           .reverse()
       )

--- a/src/relationship/core/traverseentities.js
+++ b/src/relationship/core/traverseentities.js
@@ -1,4 +1,4 @@
-import { Entity } from '../../ecs/index.js'
+import { EntityHandle } from '../../ecs/index.js'
 import { abstractMethod } from '../../utils/index.js'
 
 /**
@@ -7,7 +7,7 @@ import { abstractMethod } from '../../utils/index.js'
 export class TraverseEntities {
 
   /**
-   * @returns {Entity[]}
+   * @returns {EntityHandle[]}
    * @throws {string} Throws when the method is not implemented on implementing class.
    */
   visit() {

--- a/src/relationship/tests/relationshipquery.test.js
+++ b/src/relationship/tests/relationshipquery.test.js
@@ -4,18 +4,18 @@ import { test, describe } from "node:test";
 import { RelationshipQuery, TraverseEntities } from "../core/index.js";
 import { deepStrictEqual } from "node:assert";
 import { World } from "../../ecs/registry.js";
-import { ComponentHooks, Entity } from "../../ecs/index.js";
+import { ComponentHooks, EntityHandle } from "../../ecs/index.js";
 
 /**
  * @implements {TraverseEntities}
  */
 class Children {
   /**
-   * @type {Entity[]}
+   * @type {EntityHandle[]}
    */
   list
   /**
-   * @param {Entity[]} list 
+   * @param {EntityHandle[]} list 
    */
   constructor(list = []) {
     this.list = list
@@ -28,7 +28,7 @@ class Children {
    * @param {Map<import('../../ecs/index.js').EntityId,import('../../ecs/index.js').EntityId>} entityMap
    */
   map(entityMap){
-    this.list = this.list.map(e=>Entity.from(entityMap.get(e.id())))
+    this.list = this.list.map(e=>EntityHandle.from(entityMap.get(e.id())))
   }
 }
 
@@ -37,7 +37,7 @@ class Children {
  */
 class Parent {
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   constructor(entity) {
     this.entity = entity
@@ -51,7 +51,7 @@ class Parent {
    * @param {Map<import('../../ecs/index.js').EntityId,import('../../ecs/index.js').EntityId>} entityMap
    */
   map(entityMap){
-    this.entity = Entity.from(entityMap.get(this.entity.id()))
+    this.entity = EntityHandle.from(entityMap.get(this.entity.id()))
   }
 }
 
@@ -60,11 +60,11 @@ class Parent {
  */
 class Neighbour {
   /**
-   * @type {Entity[]}
+   * @type {EntityHandle[]}
    */
   list
   /**
-   * @param {Entity[]} list 
+   * @param {EntityHandle[]} list 
    */
   constructor(list = []) {
     this.list = list
@@ -76,7 +76,7 @@ class Neighbour {
    * @param {Map<import('../../ecs/index.js').EntityId,import('../../ecs/index.js').EntityId>} entityMap
    */
   map(entityMap){
-    this.list = this.list.map(e=>Entity.from(entityMap.get(e.id())))
+    this.list = this.list.map(e=>EntityHandle.from(entityMap.get(e.id())))
   }
 }
 
@@ -167,8 +167,8 @@ describe("Testing `RelationshipQuery`", () => {
   const neighbour6 = world.spawn([new Neighbour([neighbour5,neighbour3])])
 
   test("`RelationshipQuery` correctly does tree bfs iteration.", () => {
-    const query = new RelationshipQuery(world, Children, Parent, [Entity])
-    /**@type {[Entity,Entity][]} */
+    const query = new RelationshipQuery(world, Children, Parent, [EntityHandle])
+    /**@type {[EntityHandle,EntityHandle][]} */
     const entities = []
 
     query.treebfs(parent1, ([child], [parent]) => {
@@ -189,7 +189,7 @@ describe("Testing `RelationshipQuery`", () => {
 
   test("`RelationshipQuery` correctly does tree dfs iteration.", () => {
     const query = new RelationshipQuery(world, Children, Parent)
-    /**@type {[Entity,Entity][]} */
+    /**@type {[EntityHandle,EntityHandle][]} */
     const entities = []
 
     query.treedfs(parent1, ([child], [parent]) => {
@@ -210,7 +210,7 @@ describe("Testing `RelationshipQuery`", () => {
 
   test("`RelationshipQuery` correctly does graph bfs iteration.", () => {
     const query = new RelationshipQuery(world, Neighbour)
-    /**@type {[Entity,Entity][]} */
+    /**@type {[EntityHandle,EntityHandle][]} */
     const entities = []
 
     query.graphbfs(neighbour1, ([child], [parent]) => {
@@ -231,7 +231,7 @@ describe("Testing `RelationshipQuery`", () => {
 
   test("`RelationshipQuery` correctly does graph dfs iteration.", () => {
     const query = new RelationshipQuery(world, Neighbour)
-    /**@type {[Entity,Entity][]} */
+    /**@type {[EntityHandle,EntityHandle][]} */
     const entities = []
 
     query.graphdfs(neighbour1, ([child], [parent]) => {

--- a/src/render-canvas2d/systems/clear.js
+++ b/src/render-canvas2d/systems/clear.js
@@ -1,5 +1,5 @@
 /** @import {SystemFunc} from '../../ecs/index.js' */
-import { Entity, Query } from '../../ecs/index.js'
+import { EntityHandle, Query } from '../../ecs/index.js'
 import { warn } from '../../logger/index.js'
 import { MainWindow, Windows, Window } from '../../window/index.js'
 
@@ -9,7 +9,7 @@ import { MainWindow, Windows, Window } from '../../window/index.js'
  * @type {SystemFunc}
  */
 export function clearCanvas2d(world) {
-  const windows = new Query(world, [Entity, Window, MainWindow])
+  const windows = new Query(world, [EntityHandle, Window, MainWindow])
   const canvases = world.getResource(Windows)
   const window = windows.single()
 

--- a/src/render-canvas2d/systems/index.js
+++ b/src/render-canvas2d/systems/index.js
@@ -2,7 +2,7 @@
 /** @import {Canvas2DFunction} from '../types/index.js' */
 /** @import {SystemFunc} from '../../ecs/index.js' */
 import { Assets } from '../../asset/index.js'
-import { Entity, Query } from '../../ecs/index.js'
+import { EntityHandle, Query } from '../../ecs/index.js'
 import { warn } from '../../logger/index.js'
 import { typeidGeneric, typeid } from '../../type/index.js'
 import { Material, Mesh, TextureCache, RenderLists2D, Camera, OrthographicProjection } from '../../render-core/index.js'
@@ -30,7 +30,7 @@ export function genrender(type, renderMaterial) {
     /** @type {TextureCache<HTMLImageElement>} */
     const textures = world.getResourceByTypeId(typeid(TextureCache))
     const cameras = new Query(world, [GlobalTransform2D, RenderLists2D, Camera])
-    const windows = new Query(world, [Entity, Window, MainWindow])
+    const windows = new Query(world, [EntityHandle, Window, MainWindow])
     const canvases = world.getResource(Windows)
     const window = windows.single()
 

--- a/src/render-webgl/plugin.js
+++ b/src/render-webgl/plugin.js
@@ -1,6 +1,6 @@
 import { App, Plugin } from '../app/index.js'
 import { AppSchedule, CoreSystems } from '../core/index.js'
-import { Entity, Query, World } from '../ecs/index.js'
+import { EntityHandle, Query, World } from '../ecs/index.js'
 import { warn } from '../logger/index.js'
 import { MeshAttribute, ProgramCache, BasicMaterial } from '../render-core/index.js'
 import { MainWindow, Window, Windows } from '../window/index.js'
@@ -59,7 +59,7 @@ function registerDefaultAttributeLocs(attributeMap) {
 function registerBuffers(world) {
   const ubos = world.getResource(UBOCache)
   const canvases = world.getResource(Windows)
-  const windows = new Query(world, [Entity, Window, MainWindow])
+  const windows = new Query(world, [EntityHandle, Window, MainWindow])
 
   const window = windows.single()
 

--- a/src/render-webgl/systems/index.js
+++ b/src/render-webgl/systems/index.js
@@ -3,7 +3,7 @@
 /** @import {UniformBind } from '../../render-core/index.js' */
 /** @import { AssetId } from '../../asset/index.js' */
 
-import { Entity, Query } from '../../ecs/index.js'
+import { EntityHandle, Query } from '../../ecs/index.js'
 import { assert, warn } from '../../logger/index.js'
 import { Windows, MainWindow, Window } from '../../window/index.js'
 import { typeid, typeidGeneric } from '../../type/index.js'
@@ -24,7 +24,7 @@ export function genRegisterBuffer(type) {
   return function registerBuffers(world) {
     const ubos = world.getResource(UBOCache)
     const canvases = world.getResource(Windows)
-    const windows = new Query(world, [Entity, Window, MainWindow])
+    const windows = new Query(world, [EntityHandle, Window, MainWindow])
 
     const window = windows.single()
 
@@ -56,7 +56,7 @@ export function genRenderPipeline(type, vertexSource, fragmentSource) {
     const attributeMap = world.getResource(AttributeMap)
     const ubos = world.getResource(UBOCache)
     const renderpipelines = world.getResource(WebglProgramCache)
-    const windows = new Query(world, [Entity, Window, MainWindow])
+    const windows = new Query(world, [EntityHandle, Window, MainWindow])
     const canvases = world.getResource(Windows)
 
     if (renderpipelines.has(materialid)) return
@@ -112,7 +112,7 @@ export function genRender(type) {
     const programs = world.getResource(WebglProgramCache)
     const ubos = world.getResource(UBOCache)
     const canvases = world.getResource(Windows)
-    const windows = new Query(world, [Entity, Window, MainWindow])
+    const windows = new Query(world, [EntityHandle, Window, MainWindow])
     const cameras = new Query(world, [GlobalTransform3D, RenderLists3D, Camera])
     const clearColor = world.getResource(ClearColor)
 
@@ -206,7 +206,7 @@ export function queueMeshes(world) {
   /** @type {MeshCache<WebGLVertexArrayObject>} */
   const cache = world.getResource(MeshCache)
   const attributes = world.getResource(AttributeMap)
-  const windows = new Query(world, [Entity, Window, MainWindow])
+  const windows = new Query(world, [EntityHandle, Window, MainWindow])
   const canvases = world.getResource(Windows)
 
   // TODO: Find a way to decouple to allow multi-window support.
@@ -249,7 +249,7 @@ export function disposeDroppedMeshes(world) {
 
   /** @type {MeshCache<WebGLVertexArrayObject>} */
   const cache = world.getResource(MeshCache)
-  const windows = new Query(world, [Entity, Window, MainWindow])
+  const windows = new Query(world, [EntityHandle, Window, MainWindow])
   const canvases = world.getResource(Windows)
 
   // TODO: Find a way to decouple to allow multi-window support.

--- a/src/scene/assets/scene.js
+++ b/src/scene/assets/scene.js
@@ -1,5 +1,5 @@
 /** @import {EntityId} from '../../ecs/index.js' */
-import { Entity, Query, World } from '../../ecs/index.js'
+import { EntityHandle, Query, World } from '../../ecs/index.js'
 import { Parent } from '../../hierarchy/index.js'
 import { warn } from '../../logger/index.js'
 import { TypeRegistry } from '../../reflect/index.js'
@@ -23,7 +23,7 @@ export class Scene {
    * @param {World} world
    * @param {SceneInstance} instance
    * @param {TypeRegistry} typeRegistry
-   * @param {Entity} instanceEntity
+   * @param {EntityHandle} instanceEntity
    */
   toWorld(world, instance, typeRegistry, instanceEntity) {
     const { entityMap: worldToSceneMap } = instance
@@ -72,7 +72,7 @@ export class Scene {
       const clonedComponents = components.map((component) => {
         const { constructor } = component
 
-        if (constructor === Entity) {
+        if (constructor === EntityHandle) {
           return undefined
         }
 
@@ -103,7 +103,7 @@ export class Scene {
         clonedComponents.push(new Parent(instanceEntity))
       }
 
-      world.insert(Entity.from(worldEntity), clonedComponents)
+      world.insert(EntityHandle.from(worldEntity), clonedComponents)
     }
   }
 
@@ -113,7 +113,7 @@ export class Scene {
    */
   static fromWorld(world, typeRegistry) {
     const scene = new Scene()
-    const entities = new Query(world, [Entity])
+    const entities = new Query(world, [EntityHandle])
 
     entities.each(([entity]) => {
       const cell = world.getEntity(entity)
@@ -171,7 +171,7 @@ export class Scene {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {{}[]} components
    */
   set(entity, components) {

--- a/src/scene/resources/scenespawner.js
+++ b/src/scene/resources/scenespawner.js
@@ -1,4 +1,4 @@
-/** @import {Entity, EntityId} from '../../ecs/index.js' */
+/** @import {EntityHandle, EntityId} from '../../ecs/index.js' */
 /** @import {AssetId} from '../../asset/index.js' */
 
 /**
@@ -14,7 +14,7 @@ export class SceneSpawner {
 
   /**
    * @param {AssetId} id
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   add(id, entity) {
     const list = this.map.get(id)
@@ -28,7 +28,7 @@ export class SceneSpawner {
 
   /**
    * @param {AssetId} id
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   remove(id, entity) {
     const list = this.map.get(id)

--- a/src/scene/systems/index.js
+++ b/src/scene/systems/index.js
@@ -1,4 +1,4 @@
-import { Entity, Query, World } from '../../ecs/index.js'
+import { EntityHandle, Query, World } from '../../ecs/index.js'
 import { TypeRegistry } from '../../reflect/resources/index.js'
 import { SceneInstance } from '../components/index.js'
 import { SceneAssets, SceneSpawner } from '../resources/index.js'
@@ -22,7 +22,7 @@ export function spawnScenes(world) {
     const list = spawner.get(assetId)
 
     for (let i = 0; i < list.length; i++) {
-      const entity = Entity.from(list[i])
+      const entity = EntityHandle.from(list[i])
       const instance = instances.get(entity)
 
       if (!instance) continue

--- a/src/scene/tests/assets/scene.test.js
+++ b/src/scene/tests/assets/scene.test.js
@@ -1,6 +1,6 @@
 import { deepStrictEqual, strictEqual } from 'assert'
 import test, { describe } from 'node:test'
-import { Entity, Query, World } from '../../../ecs/index.js'
+import { EntityHandle, Query, World } from '../../../ecs/index.js'
 import { Parent } from '../../../hierarchy/index.js'
 import { Scene } from '../../assets/index.js'
 import { SceneInstance } from '../../components/index.js'
@@ -189,9 +189,9 @@ class DeferredPatchResourceSnapshot {
 function createRegistry() {
   const registry = new TypeRegistry()
 
-  registry.register(Entity, StructInfo.default())
-  registry.get(Entity)?.setMethod(/** @param {Entity} target */ function clone(target) {
-    return Entity.from(target.id())
+  registry.register(EntityHandle, StructInfo.default())
+  registry.get(EntityHandle)?.setMethod(/** @param {EntityHandle} target */ function clone(target) {
+    return EntityHandle.from(target.id())
   })
 
   registry.register(PureComponent, StructInfo.default())
@@ -222,20 +222,20 @@ describe('Testing `Scene`', { concurrency: false }, () => {
       strictEqual(scene.entities.size, 1)
       strictEqual(scene.resources.size, 0)
       deepStrictEqual(scene.entities.get(entity.id()), [
-        new Entity(entity.index, entity.generation)
+        new EntityHandle(entity.index, entity.generation)
       ])
     })
 
     test('`Scene.toWorld` restores pure entities', () => {
       const registry = createRegistry()
       const world = new World()
-      const entity = new Entity(42, 1)
+      const entity = new EntityHandle(42, 1)
       const scene = new Scene()
       const instance = new SceneInstance(/** @type {any} */ (null))
-      const instanceEntity = new Entity(99, 1)
+      const instanceEntity = new EntityHandle(99, 1)
 
       scene.entities.set(entity.id(), [
-        new Entity(entity.index, entity.generation)
+        new EntityHandle(entity.index, entity.generation)
       ])
 
       scene.toWorld(world, instance, registry, instanceEntity)
@@ -243,15 +243,15 @@ describe('Testing `Scene`', { concurrency: false }, () => {
       strictEqual(world.getResources().size, 0)
       strictEqual(instance.entityMap.size, 1)
 
-      const single = new Query(world, [Entity]).single()
+      const single = new Query(world, [EntityHandle]).single()
 
       strictEqual(single !== null, true)
 
       const [restoredEntity] = single
       const cell = world.getEntity(restoredEntity)
 
-      strictEqual(cell.hasTypeid([typeid(Entity), typeid(Parent)]), true)
-      deepStrictEqual(cell.get(Entity), restoredEntity)
+      strictEqual(cell.hasTypeid([typeid(EntityHandle), typeid(Parent)]), true)
+      deepStrictEqual(cell.get(EntityHandle), restoredEntity)
       deepStrictEqual(cell.get(Parent), new Parent(instanceEntity))
       strictEqual(instance.entityMap.get(restoredEntity.id()), entity.id())
     })
@@ -283,9 +283,9 @@ describe('Testing `Scene`', { concurrency: false }, () => {
         new PureResource('resource')
       )
 
-      scene.toWorld(world, instance, registry, new Entity(99, 1))
+      scene.toWorld(world, instance, registry, new EntityHandle(99, 1))
 
-      strictEqual(new Query(world, [Entity]).count(), 0)
+      strictEqual(new Query(world, [EntityHandle]).count(), 0)
       strictEqual(world.getResources().size, 1)
       strictEqual(instance.entityMap.size, 0)
       deepStrictEqual(world.getResource(PureResource), new PureResource('resource'))
@@ -301,7 +301,7 @@ describe('Testing `Scene`', { concurrency: false }, () => {
       strictEqual(scene.resources.size, 0)
       deepStrictEqual(scene.entities.get(entity.id()), [
         new ComponentSnapshot('component'),
-        new Entity(entity.index, entity.generation)
+        new EntityHandle(entity.index, entity.generation)
       ])
     })
 
@@ -312,14 +312,14 @@ describe('Testing `Scene`', { concurrency: false }, () => {
       const scene = Scene.fromWorld(world, registry)
       const targetWorld = new World()
       const instance = new SceneInstance(/** @type {any} */ (null))
-      const instanceEntity = new Entity(99, 1)
+      const instanceEntity = new EntityHandle(99, 1)
 
       scene.toWorld(targetWorld, instance, registry, instanceEntity)
 
       strictEqual(targetWorld.getResources().size, 0)
       strictEqual(instance.entityMap.size, 1)
 
-      const single = new Query(targetWorld, [Entity]).single()
+      const single = new Query(targetWorld, [EntityHandle]).single()
 
       strictEqual(single !== null, true)
 
@@ -327,10 +327,10 @@ describe('Testing `Scene`', { concurrency: false }, () => {
       const cell = targetWorld.getEntity(restoredEntity)
 
       strictEqual(
-        cell.hasTypeid([typeid(Entity), typeid(PureComponent), typeid(Parent)]),
+        cell.hasTypeid([typeid(EntityHandle), typeid(PureComponent), typeid(Parent)]),
         true
       )
-      deepStrictEqual(cell.get(Entity), restoredEntity)
+      deepStrictEqual(cell.get(EntityHandle), restoredEntity)
       deepStrictEqual(cell.get(PureComponent), new PureComponent('component'))
       deepStrictEqual(cell.get(Parent), new Parent(instanceEntity))
       strictEqual(instance.entityMap.get(restoredEntity.id()), entity.id())
@@ -347,20 +347,20 @@ describe('Testing `Scene`', { concurrency: false }, () => {
       strictEqual(scene.entities.size, 1)
       strictEqual(scene.resources.size, 0)
       deepStrictEqual(scene.entities.get(entity.id()), [
-        new Entity(entity.index, entity.generation)
+        new EntityHandle(entity.index, entity.generation)
       ])
     })
 
     test('`Scene.toWorld` restores pure entities', () => {
       const registry = createRegistry()
       const world = new World()
-      const entity = new Entity(42, 1)
+      const entity = new EntityHandle(42, 1)
       const scene = new Scene()
       const instance = new SceneInstance(/** @type {any} */ (null))
-      const instanceEntity = new Entity(99, 1)
+      const instanceEntity = new EntityHandle(99, 1)
 
       scene.entities.set(entity.id(), [
-        new Entity(entity.index, entity.generation)
+        new EntityHandle(entity.index, entity.generation)
       ])
 
       scene.toWorld(world, instance, registry, instanceEntity)
@@ -368,15 +368,15 @@ describe('Testing `Scene`', { concurrency: false }, () => {
       strictEqual(world.getResources().size, 0)
       strictEqual(instance.entityMap.size, 1)
 
-      const single = new Query(world, [Entity]).single()
+      const single = new Query(world, [EntityHandle]).single()
 
       strictEqual(single !== null, true)
 
       const [restoredEntity] = single
       const cell = world.getEntity(restoredEntity)
 
-      strictEqual(cell.hasTypeid([typeid(Entity), typeid(Parent)]), true)
-      deepStrictEqual(cell.get(Entity), restoredEntity)
+      strictEqual(cell.hasTypeid([typeid(EntityHandle), typeid(Parent)]), true)
+      deepStrictEqual(cell.get(EntityHandle), restoredEntity)
       deepStrictEqual(cell.get(Parent), new Parent(instanceEntity))
       strictEqual(instance.entityMap.get(restoredEntity.id()), entity.id())
     })
@@ -408,9 +408,9 @@ describe('Testing `Scene`', { concurrency: false }, () => {
         new ResourceSnapshot('resource')
       )
 
-      scene.toWorld(world, instance, registry, new Entity(99, 1))
+      scene.toWorld(world, instance, registry, new EntityHandle(99, 1))
 
-      strictEqual(new Query(world, [Entity]).count(), 0)
+      strictEqual(new Query(world, [EntityHandle]).count(), 0)
       strictEqual(world.getResources().size, 1)
       strictEqual(instance.entityMap.size, 0)
       deepStrictEqual(world.getResource(PureResource), new PureResource('resource'))
@@ -426,7 +426,7 @@ describe('Testing `Scene`', { concurrency: false }, () => {
       strictEqual(scene.resources.size, 0)
       deepStrictEqual(scene.entities.get(entity.id()), [
         new ComponentSnapshot('component'),
-        new Entity(entity.index, entity.generation)
+        new EntityHandle(entity.index, entity.generation)
       ])
     })
 
@@ -437,14 +437,14 @@ describe('Testing `Scene`', { concurrency: false }, () => {
       const scene = Scene.fromWorld(world, registry)
       const targetWorld = new World()
       const instance = new SceneInstance(/** @type {any} */ (null))
-      const instanceEntity = new Entity(99, 1)
+      const instanceEntity = new EntityHandle(99, 1)
 
       scene.toWorld(targetWorld, instance, registry, instanceEntity)
 
       strictEqual(targetWorld.getResources().size, 0)
       strictEqual(instance.entityMap.size, 1)
 
-      const single = new Query(targetWorld, [Entity]).single()
+      const single = new Query(targetWorld, [EntityHandle]).single()
 
       strictEqual(single !== null, true)
 
@@ -452,10 +452,10 @@ describe('Testing `Scene`', { concurrency: false }, () => {
       const cell = targetWorld.getEntity(restoredEntity)
 
       strictEqual(
-        cell.hasTypeid([typeid(Entity), typeid(PureComponent), typeid(Parent)]),
+        cell.hasTypeid([typeid(EntityHandle), typeid(PureComponent), typeid(Parent)]),
         true
       )
-      deepStrictEqual(cell.get(Entity), restoredEntity)
+      deepStrictEqual(cell.get(EntityHandle), restoredEntity)
       deepStrictEqual(cell.get(PureComponent), new PureComponent('component'))
       deepStrictEqual(cell.get(Parent), new Parent(instanceEntity))
       strictEqual(instance.entityMap.get(restoredEntity.id()), entity.id())
@@ -483,7 +483,7 @@ describe('Testing `Scene`', { concurrency: false }, () => {
 
       const instance = new SceneInstance(/** @type {any} */ (null))
 
-      scene.toWorld(world, instance, registry, new Entity(99, 1))
+      scene.toWorld(world, instance, registry, new EntityHandle(99, 1))
 
       strictEqual(world.getResource(PatchableResource), worldResource)
       strictEqual(world.getResources().size, 1)
@@ -507,7 +507,7 @@ describe('Testing `Scene`', { concurrency: false }, () => {
       const world = new World()
       const instance = new SceneInstance(/** @type {any} */ (null))
 
-      scene.toWorld(world, instance, registry, new Entity(99, 1))
+      scene.toWorld(world, instance, registry, new EntityHandle(99, 1))
 
       strictEqual(world.getResources().size, 1)
       strictEqual(instance.entityMap.size, 0)

--- a/src/transform/components/2d/remote.js
+++ b/src/transform/components/2d/remote.js
@@ -1,4 +1,4 @@
-import { Entity } from '../../../ecs/index.js'
+import { EntityHandle } from '../../../ecs/index.js'
 import { Affine2 } from '../../../math/index.js'
 
 export class RemoteTransform2D {
@@ -19,7 +19,7 @@ export class RemoteTransform2D {
   copyScale = true
 
   /**
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   entity
 
@@ -29,7 +29,7 @@ export class RemoteTransform2D {
   offsetTransform = new Affine2()
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   constructor(entity) {
     this.entity = entity
@@ -64,7 +64,7 @@ export class RemoteTransform2D {
       copyTranslation: value.copyTranslation,
       copyOrientation: value.copyOrientation,
       copyScale: value.copyScale,
-      entity: Entity.serialize(value.entity),
+      entity: EntityHandle.serialize(value.entity),
       offsetTransform: Affine2.serialize(value.offsetTransform)
     }
   }
@@ -90,7 +90,7 @@ export class RemoteTransform2D {
     return typeof value.copyTranslation === 'boolean' &&
       typeof value.copyOrientation === 'boolean' &&
       typeof value.copyScale === 'boolean' &&
-      Entity.validateSerial(value.entity) &&
+      EntityHandle.validateSerial(value.entity) &&
       Affine2.validateSerial(value.offsetTransform)
   }
 
@@ -98,11 +98,11 @@ export class RemoteTransform2D {
    * @param {RemoteTransform2DSerial} value
    * @param {RemoteTransform2D} [out]
    */
-  static deserialize(value, out = new RemoteTransform2D(new Entity(0, 0))) {
+  static deserialize(value, out = new RemoteTransform2D(new EntityHandle(0, 0))) {
     out.copyTranslation = value.copyTranslation
     out.copyOrientation = value.copyOrientation
     out.copyScale = value.copyScale
-    out.entity = Entity.deserialize(value.entity, out.entity)
+    out.entity = EntityHandle.deserialize(value.entity, out.entity)
     out.offsetTransform = Affine2.deserialize(value.offsetTransform, out.offsetTransform)
 
     return out

--- a/src/transform/components/3d/remote.js
+++ b/src/transform/components/3d/remote.js
@@ -1,5 +1,5 @@
 import { Affine3 } from '../../../math/index.js'
-import { Entity } from '../../../ecs/index.js'
+import { EntityHandle } from '../../../ecs/index.js'
 
 export class RemoteTransform3D {
 
@@ -19,7 +19,7 @@ export class RemoteTransform3D {
   copyScale = true
 
   /**
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   entity
 
@@ -29,7 +29,7 @@ export class RemoteTransform3D {
   offsetTransform = new Affine3()
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   constructor(entity) {
     this.entity = entity
@@ -64,7 +64,7 @@ export class RemoteTransform3D {
       copyTranslation: value.copyTranslation,
       copyOrientation: value.copyOrientation,
       copyScale: value.copyScale,
-      entity: Entity.serialize(value.entity),
+      entity: EntityHandle.serialize(value.entity),
       offsetTransform: Affine3.serialize(value.offsetTransform)
     }
   }
@@ -90,7 +90,7 @@ export class RemoteTransform3D {
     return typeof value.copyTranslation === 'boolean' &&
       typeof value.copyOrientation === 'boolean' &&
       typeof value.copyScale === 'boolean' &&
-      Entity.validateSerial(value.entity) &&
+      EntityHandle.validateSerial(value.entity) &&
       Affine3.validateSerial(value.offsetTransform)
   }
 
@@ -98,11 +98,11 @@ export class RemoteTransform3D {
    * @param {RemoteTransform3DSerial} value
    * @param {RemoteTransform3D} [out]
    */
-  static deserialize(value, out = new RemoteTransform3D(new Entity(0, 0))) {
+  static deserialize(value, out = new RemoteTransform3D(new EntityHandle(0, 0))) {
     out.copyTranslation = value.copyTranslation
     out.copyOrientation = value.copyOrientation
     out.copyScale = value.copyScale
-    out.entity = Entity.deserialize(value.entity, out.entity)
+    out.entity = EntityHandle.deserialize(value.entity, out.entity)
     out.offsetTransform = Affine3.deserialize(value.offsetTransform, out.offsetTransform)
 
     return out

--- a/src/transform/systems/transform.js
+++ b/src/transform/systems/transform.js
@@ -1,4 +1,4 @@
-import { Entity, has, Query, without, World } from '../../ecs/index.js'
+import { EntityHandle, has, Query, without, World } from '../../ecs/index.js'
 import { Children, Parent } from '../../hierarchy/index.js'
 import { Affine2, Affine3 } from '../../math/index.js'
 import { RelationshipQuery } from '../../relationship/index.js'
@@ -31,7 +31,7 @@ export function synctransform3D(world) {
  */
 export function propagateTransform2D(world) {
   const hierachyTransforms = new RelationshipQuery(world, Children, Parent, [GlobalTransform2D])
-  const roots = new Query(world, [Entity], [has(Children), without(Parent)])
+  const roots = new Query(world, [EntityHandle], [has(Children), without(Parent)])
 
   roots.each(([entity]) => {
     hierachyTransforms.treebfs(entity, ([childTransform], [parentTransform]) => {
@@ -47,7 +47,7 @@ export function propagateTransform2D(world) {
  */
 export function propagateTransform3D(world) {
   const hierachyTransforms = new RelationshipQuery(world, Children, Parent, [GlobalTransform3D])
-  const roots = new Query(world, [Entity], [has(Children), without(Parent)])
+  const roots = new Query(world, [EntityHandle], [has(Children), without(Parent)])
 
   roots.each(([entity]) => {
     hierachyTransforms.treebfs(entity, ([childTransform], [parentTransform]) => {

--- a/src/transform/systems/types.js
+++ b/src/transform/systems/types.js
@@ -1,4 +1,4 @@
-import { World, Entity } from '../../ecs/index.js'
+import { World, EntityHandle } from '../../ecs/index.js'
 import { Field, StructInfo } from '../../reflect/core/index.js'
 import { TypeRegistry } from '../../reflect/resources/index.js'
 import { typeid } from '../../type/index.js'
@@ -124,7 +124,7 @@ export function registerRemoteTransform2DTypes(world) {
     copyTranslation: new Field(typeid(Boolean)),
     copyOrientation: new Field(typeid(Boolean)),
     copyScale: new Field(typeid(Boolean)),
-    entity: new Field(typeid(Entity)),
+    entity: new Field(typeid(EntityHandle)),
     offsetTransform: new Field(typeid(Affine2))
   }))
   registry.get(RemoteTransform2D)?.setMethod(RemoteTransform2D.copy)
@@ -143,7 +143,7 @@ export function registerRemoteTransform3DTypes(world) {
     copyTranslation: new Field(typeid(Boolean)),
     copyOrientation: new Field(typeid(Boolean)),
     copyScale: new Field(typeid(Boolean)),
-    entity: new Field(typeid(Entity)),
+    entity: new Field(typeid(EntityHandle)),
     offsetTransform: new Field(typeid(Affine3))
   }))
   registry.get(RemoteTransform3D)?.setMethod(RemoteTransform3D.copy)

--- a/src/window-dom/hooks/window.js
+++ b/src/window-dom/hooks/window.js
@@ -33,7 +33,7 @@ export function openWindow(entity, world) {
 
 /**
  * @param {import("../../ecs/registry.js").World} world
- * @param {import("../../ecs/index.js").Entity} entity
+ * @param {import("../../ecs/index.js").EntityHandle} entity
  * @param {HTMLCanvasElement} canvas
  * @param {Window} window
  */

--- a/src/window/commands/window.js
+++ b/src/window/commands/window.js
@@ -1,4 +1,4 @@
-import { Query, Entity, World } from '../../ecs/index.js'
+import { Query, EntityHandle, World } from '../../ecs/index.js'
 import { Command } from '../../command/index.js'
 import { error } from '../../logger/index.js'
 import { WindowRequest } from '../core/index.js'
@@ -9,7 +9,7 @@ export class WindowCommand extends Command {
 
   /**
    * @readonly
-   * @type {Entity}
+   * @type {EntityHandle}
    */
   entity
 
@@ -26,7 +26,7 @@ export class WindowCommand extends Command {
   data
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {WindowRequest} type
    * @param {any} data
    */

--- a/src/window/core/commands.js
+++ b/src/window/core/commands.js
@@ -1,4 +1,4 @@
-/** @import {Entity, World} from '../../ecs/index.js' */
+/** @import {EntityHandle, World} from '../../ecs/index.js' */
 import { CommandQueue } from '../../command/index.js'
 import { assert } from '../../logger/index.js'
 import { Vector2 } from '../../math/index.js'
@@ -9,7 +9,7 @@ export class WindowCommands {
 
   /**
    * @private
-   * @type {Entity | undefined}
+   * @type {EntityHandle | undefined}
    */
   entity
 
@@ -27,7 +27,7 @@ export class WindowCommands {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   window(entity) {
     this.entity = entity

--- a/src/window/resources/windows.js
+++ b/src/window/resources/windows.js
@@ -1,4 +1,4 @@
-/** @import {Entity,EntityId} from '../../ecs/index.js'*/
+/** @import {EntityHandle,EntityId} from '../../ecs/index.js'*/
 
 export class Windows {
 
@@ -9,7 +9,7 @@ export class Windows {
   entities = new Map()
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @returns {HTMLCanvasElement | undefined}
    */
   getWindow(entity) {
@@ -19,7 +19,7 @@ export class Windows {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    * @param {HTMLCanvasElement} window
    */
   setWindow(entity, window) {
@@ -27,7 +27,7 @@ export class Windows {
   }
 
   /**
-   * @param {Entity} entity
+   * @param {EntityHandle} entity
    */
   delete(entity) {
     this.entities.delete(entity.id())


### PR DESCRIPTION
## Objective

Rename the ECS `Entity` type to `EntityHandle` to better communicate its purpose and distinguish it from the entity itself.

## Solution

### Root Cause

The `Entity` type represents a lightweight identifier (index + generation) used to reference entities within the ECS, rather than the entity or its data. The previous name could imply ownership of the entity or its components, making APIs confusing.

### Changes Made

* Renamed `Entity` to `EntityHandle` throughout the codebase.
* Updated ECS internals, systems, resources, commands, relationship traversal, scene serialization, reflection registrations, animation, physics, rendering, transforms and examples to use the new type.

This is a naming-only refactor. Runtime behavior remains unchanged.

## Showcase

### Before

```js
const query = new Query(world, [Entity, Transform])

const entity = world.spawn([
  new Transform()
])
```

### After

```js
const query = new Query(world, [EntityHandle, Transform])

const entity = world.spawn([
  new Transform()
])
```

## Migration Guide

Replace imports of `Entity` with `EntityHandle`:

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
