### PR TITLE
Register types automatic in ECS `World`

### DIFF
--- a/packages/animation/src/plugin.js
+++ b/packages/animation/src/plugin.js
@@ -4,7 +4,7 @@ import { AppSchedule } from '@wimaengine/core'
 import { ComponentHooks } from '@wimaengine/ecs'
 import { typeidGeneric } from '@wimaengine/type'
 import { AnimationClip } from './assets'
-import { AnimationPlayer, AnimationTarget, dropAnimationPlayer } from './components'
+import { AnimationPlayer, dropAnimationPlayer } from './components'
 import { AnimationClipAssets } from './resources'
 import { advanceAnimationPlayers, applyAnimations, registerAnimationTypes } from './systems'
 
@@ -17,12 +17,10 @@ export class AnimationPlugin extends Plugin {
     const world = app.getWorld()
 
     app
-      .registerType(AnimationPlayer)
       .setComponentHooks(AnimationPlayer, new ComponentHooks(
         null,
         dropAnimationPlayer
       ))
-      .registerType(AnimationTarget)
       .registerSystem({ schedule: AppSchedule.Startup, system: registerAnimationTypes })
       .registerPlugin(new AssetPlugin({
         asset:AnimationClip

--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -187,6 +187,7 @@ export class App {
    */
   setResource(resource) {
     assert(!this.initialized, registererror)
+
     // SAFETY: An object's constructor is constructible.
     const id = typeid(/** @type {Constructor} */(resource.constructor))
 

--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -171,15 +171,6 @@ export class App {
   }
 
   /**
-   * @param {Constructor} type
-   */
-  registerType(type) {
-    this.world.registerType(type)
-
-    return this
-  }
-
-  /**
    * @template T
    * @param {new (...args:any[])=>T} component
    * @param {ComponentHooks} hooks

--- a/packages/app/src/app.js
+++ b/packages/app/src/app.js
@@ -67,6 +67,12 @@ export class App {
 
   /**
    * @private
+   * @type {Map<TypeId, unknown>}
+   */
+  resources = new Map()
+
+  /**
+   * @private
    * @type {Scheduler}
    */
   scheduler = new Scheduler()
@@ -114,16 +120,18 @@ export class App {
    * Starts up the {@link App}.
    * Prevents calls to {@link App.registerSystem},
    * {@link App.registerPlugin} and {@link App.setResource}.
+   * Flushes any resources staged through {@link App.setResource} into the world before the runner starts.
    *
    * @returns {this}
    */
   run() {
     this.plugins.register(this)
+    this.flushResources()
 
     SchedulerBuilder.Instance.pushToScheduler(this.scheduler)
     assert(this.runner, 'App runner is not set. Call `app.setRunner(...)` before `app.run()`.')
-    this.runner(this.scheduler, this.world)
     this.initialized = true
+    this.runner(this.scheduler, this.world)
 
     return this
   }
@@ -188,10 +196,23 @@ export class App {
    */
   setResource(resource) {
     assert(!this.initialized, registererror)
-    this
-      .world.setResource(resource)
+    // SAFETY: An object's constructor is constructible.
+    const id = typeid(/** @type {Constructor} */(resource.constructor))
+
+    this.resources.set(id, resource)
 
     return this
+  }
+
+  /**
+   * @private
+   */
+  flushResources() {
+    for (const [id, resource] of this.resources) {
+      this.world.setResourceByTypeId(id, resource)
+    }
+
+    this.resources.clear()
   }
 }
 

--- a/packages/audio/src/plugin.js
+++ b/packages/audio/src/plugin.js
@@ -19,12 +19,10 @@ export class AudioPlugin extends Plugin {
     const handler = new AudioCommands()
 
     app
-      .registerType(AudioPlayer)
       .setComponentHooks(AudioPlayer, new ComponentHooks(
         null,
         removeAudioPlayerSink
       ))
-      .registerType(AudioOscillator)
       .setComponentHooks(AudioOscillator, new ComponentHooks(
         null,
         removeOscillatorSink

--- a/packages/broadphase/src/plugin.js
+++ b/packages/broadphase/src/plugin.js
@@ -1,7 +1,6 @@
 /** @import {Broadphasable2D} from './resources'*/
 import { App, Plugin } from '@wimaengine/app'
 import { AppSchedule } from '@wimaengine/core'
-import { PhysicsHitbox } from './components'
 import { CollisionPairs, Broadphase2D } from './resources'
 import { getCollisionPairs, registerBroadphaseTypes2D, updateBroadphase2D } from './systems'
 
@@ -26,7 +25,6 @@ export class Broadphase2DPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(PhysicsHitbox)
       .registerSystem({ schedule: AppSchedule.Startup, system: registerBroadphaseTypes2D })
       .setResource(new Broadphase2D(this.innerBroadphase))
       .setResource(new CollisionPairs())

--- a/packages/ecs/src/component/hooks.js
+++ b/packages/ecs/src/component/hooks.js
@@ -2,9 +2,9 @@
 
 /**
  * Sets the functional hooks for listening on the lifecycle of
- *  a component i.e addition, insertion and removal.
- * The component needs to be {@link World.registerType registered}
- *  on a {@link World world} before its hooks can be set.
+ * a component i.e addition, insertion and removal.
+ * The component is registered automatically when hooks are attached
+ * or when it first appears in a {@link World world}.
  * @example
  * ```ts
  * //a component
@@ -25,9 +25,7 @@
  * const world = new World()
  * const hooks = new ComponentHooks(added,inserted,removed)
  *
- * world
- *   .registerType(A)
- *   .setComponentHooks(A,hooks)
+ * world.setComponentHooks(A, hooks)
  * ```
  *
  */

--- a/packages/ecs/src/query/query.js
+++ b/packages/ecs/src/query/query.js
@@ -9,20 +9,16 @@ import { World } from '../world'
 import { QueryFilter } from './filters'
 
 /**
- * Enables operations to be performed on specified set
- * of components components on a {@link World}.
- * Ensure that the component types matches up with the
- * component names given in the second parameter of
- * the query in lower case.
+ * Enables operations to be performed on entities matching the
+ * given component constructors on a {@link World}.
+ * The world does not need the component types to be pre-registered.
  * @example
  * ```ts
  * class A {}
  * class B {}
  *
  * const world = new World()
- *   .registerType(A)
- *   .registerType(B)
- * const query = new Query<[A, B]>(world, ['a','b'])
+ * const query = new Query(world, [A, B])
  *
  * // you can now use the query to perform operations
  * // on entities with components `A` and `B`

--- a/packages/ecs/src/typestore.js
+++ b/packages/ecs/src/typestore.js
@@ -36,7 +36,7 @@ export class TypeStore {
   setByTypeId(id) {
     const hasid = this.map.get(id)
 
-    if (hasid) return hasid
+    if (hasid !== undefined) return hasid
 
     const compId = this.list.length
 
@@ -119,10 +119,14 @@ export class TypeStore {
   }
 
   /**
-   * @param {TypeId} typeid
+   * @param {TypeId} typeId
    */
-  getOrSetByTypeId(typeid) {
-    return this.getIdByTypeId(typeid) || this.setByTypeId(typeid)
+  getOrSetByTypeId(typeId) {
+    const id = this.getIdByTypeId(typeId)
+
+    if (id !== undefined) return id
+
+    return this.setByTypeId(typeId)
   }
 
   /**

--- a/packages/ecs/src/world.js
+++ b/packages/ecs/src/world.js
@@ -473,14 +473,6 @@ export class World {
 
   /**
    * @template T
-   * @param {Constructor<T>} type
-   */
-  registerType(type) {
-    this.typestore.set(type)
-  }
-
-  /**
-   * @template T
    * @param {Constructor<T>} component
    * @param {ComponentHooks} hooks
    */

--- a/packages/ecs/tests/typestore.test.js
+++ b/packages/ecs/tests/typestore.test.js
@@ -1,0 +1,36 @@
+import { test, describe } from "vitest";
+import { deepStrictEqual } from "node:assert";
+import { typeid } from "@wimaengine/type";
+import { TypeStore } from "../src";
+import { EntityHandle } from "../src/entities";
+
+describe("Testing `TypeStore`", () => {
+  test('`getOrSet` reuses the first registered id.', () => {
+    const store = new TypeStore()
+
+    const first = store.getOrSet(EntityHandle)
+    const second = store.getOrSet(EntityHandle)
+
+    deepStrictEqual(first, 0)
+    deepStrictEqual(second, 0)
+    deepStrictEqual(
+      [...store.getInfos()].map((info) => info.name),
+      [typeid(EntityHandle)]
+    )
+  })
+
+  test('`getOrSetByTypeId` reuses the first registered id.', () => {
+    const store = new TypeStore()
+    const id = typeid(EntityHandle)
+
+    const first = store.getOrSetByTypeId(id)
+    const second = store.getOrSetByTypeId(id)
+
+    deepStrictEqual(first, 0)
+    deepStrictEqual(second, 0)
+    deepStrictEqual(
+      [...store.getInfos()].map((info) => info.name),
+      [typeid(EntityHandle)]
+    )
+  })
+})

--- a/packages/emitter/src/plugin.js
+++ b/packages/emitter/src/plugin.js
@@ -1,6 +1,5 @@
 import { App, Plugin } from '@wimaengine/app'
 import { AppSchedule } from '@wimaengine/core'
-import { Particle, Emitter } from './components'
 import { despawnParticles, emitParticles2D, emitParticles3D } from './systems'
 
 export class Emitter2DPlugin extends Plugin {
@@ -10,8 +9,6 @@ export class Emitter2DPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(Particle)
-      .registerType(Emitter)
       .registerSystem({ schedule: AppSchedule.Update, system: despawnParticles })
       .registerSystem({ schedule: AppSchedule.Update, system: emitParticles2D })
 
@@ -25,8 +22,6 @@ export class Emitter3DPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(Particle)
-      .registerType(Emitter)
       .registerSystem({ schedule: AppSchedule.Update, system: despawnParticles })
       .registerSystem({ schedule: AppSchedule.Update, system: emitParticles3D })
 

--- a/packages/event/src/plugin.js
+++ b/packages/event/src/plugin.js
@@ -42,7 +42,6 @@ export class EventPlugin extends Plugin {
     const name = typeidGeneric(Events, [event])
 
     app
-      .registerType(event)
       .registerSystem({
         label: `registerEventTypes<${typeid(event)}>`,
         schedule: AppSchedule.Startup,

--- a/packages/hierarchy/src/plugin.js
+++ b/packages/hierarchy/src/plugin.js
@@ -12,13 +12,11 @@ export class HierarchyPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(Children)
       .setComponentHooks(Children, new ComponentHooks(
         addSelfToChildren,
         despawnChildren,
         null
       ))
-      .registerType(Parent)
       .setComponentHooks(Parent, new ComponentHooks(
         addSelfToParent,
         removeSelfFromParent,

--- a/packages/movable/src/plugins/three.js
+++ b/packages/movable/src/plugins/three.js
@@ -1,11 +1,5 @@
 import { App, Plugin } from '@wimaengine/app'
 import { AppSchedule } from '@wimaengine/core'
-import {
-  Velocity3D,
-  Rotation3D,
-  Acceleration3D,
-  Torque3D
-} from '../components'
 import { registerMovable3DTypes } from '../systems'
 
 export class Movable3DPlugin extends Plugin {
@@ -15,10 +9,6 @@ export class Movable3DPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(Velocity3D)
-      .registerType(Rotation3D)
-      .registerType(Acceleration3D)
-      .registerType(Torque3D)
       .registerSystem({ schedule: AppSchedule.Startup, system: registerMovable3DTypes })
   }
 }

--- a/packages/movable/src/plugins/two.js
+++ b/packages/movable/src/plugins/two.js
@@ -1,11 +1,5 @@
 import { App, Plugin } from '@wimaengine/app'
 import { AppSchedule } from '@wimaengine/core'
-import {
-  Velocity2D,
-  Rotation2D,
-  Acceleration2D,
-  Torque2D
-} from '../components'
 import { registerMovable2DTypes } from '../systems'
 
 export class Movable2DPlugin extends Plugin {
@@ -15,10 +9,6 @@ export class Movable2DPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(Velocity2D)
-      .registerType(Rotation2D)
-      .registerType(Acceleration2D)
-      .registerType(Torque2D)
       .registerSystem({ schedule: AppSchedule.Startup, system: registerMovable2DTypes })
   }
 }

--- a/packages/name/src/plugin.js
+++ b/packages/name/src/plugin.js
@@ -1,6 +1,5 @@
 import { App, Plugin } from '@wimaengine/app'
 import { AppSchedule } from '@wimaengine/core'
-import { Name } from './components'
 import { registerNameTypes } from './systems'
 
 export class NamePlugin extends Plugin {
@@ -10,7 +9,6 @@ export class NamePlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(Name)
       .registerSystem({ schedule: AppSchedule.Startup, system: registerNameTypes })
   }
 }

--- a/packages/narrowphase/src/plugin.js
+++ b/packages/narrowphase/src/plugin.js
@@ -1,7 +1,7 @@
 import { App, Plugin } from '@wimaengine/app'
 import { AppSchedule } from '@wimaengine/core'
 import { ComponentHooks } from '@wimaengine/ecs'
-import { Collider2D, PhysicsProperties, SoftBody2D, SoftBody3D } from './components'
+import { PhysicsProperties } from './components'
 import { physicspropertiesAddHook } from './hooks'
 import { Contacts, SATNarrowphase2D } from './resources'
 import { getSATContacts, registerNarrowphase2DTypes } from './systems'
@@ -17,10 +17,6 @@ export class NarrowPhase2DPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(Collider2D)
-      .registerType(PhysicsProperties)
-      .registerType(SoftBody2D)
-      .registerType(SoftBody3D)
       .setComponentHooks(
         PhysicsProperties,
         new ComponentHooks(

--- a/packages/relationship/tests/relationshipquery.test.js
+++ b/packages/relationship/tests/relationshipquery.test.js
@@ -82,7 +82,6 @@ class Neighbour {
 
 function createWorld() {
   const world = new World()
-  world.registerType(Parent)
   world.setComponentHooks(Parent, new ComponentHooks(
     addSelfToParent
   ))

--- a/packages/render-core/src/plugin.js
+++ b/packages/render-core/src/plugin.js
@@ -37,12 +37,10 @@ export class RenderCorePlugin extends Plugin {
     const world = app.getWorld()
 
     app
-      .registerType(Meshed)
       .setComponentHooks(Meshed, new ComponentHooks(
         null,
         removeMeshedHandle
       ))
-      .registerType(Camera)
       .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerRenderCoreTypes })
       .registerPlugin(new AssetPlugin({
         asset: Image,

--- a/packages/render-core/src/plugin.js
+++ b/packages/render-core/src/plugin.js
@@ -6,7 +6,6 @@ import { typeidGeneric } from '@wimaengine/type'
 import { Mesh, Shader, Image, BasicMaterial } from './assets'
 import {
   BasicMaterialInstance,
-  Camera,
   Meshed,
   removeMeshedHandle
 } from './components'

--- a/packages/render-core/src/plugins/material.js
+++ b/packages/render-core/src/plugins/material.js
@@ -40,7 +40,6 @@ export class MaterialInstancePlugin extends Plugin {
     const { asset, component } = this
 
     app
-      .registerType(component)
       .setComponentHooks(component, new ComponentHooks(
         null,
         dropMaterialInstance(component)

--- a/packages/scene/src/plugin.js
+++ b/packages/scene/src/plugin.js
@@ -33,7 +33,6 @@ export class ScenePlugin extends Plugin {
           dropped: SceneDropped
         }
       }))
-      .registerType(SceneInstance)
       .setResource(new SceneSpawner())
       .setComponentHooks(SceneInstance, new ComponentHooks(
         initSceneInstance,

--- a/packages/time/src/plugin.js
+++ b/packages/time/src/plugin.js
@@ -2,7 +2,6 @@ import { App, Plugin } from '@wimaengine/app'
 import { AppSchedule, CoreSystems } from '@wimaengine/core'
 import { World } from '@wimaengine/ecs'
 import { Clock } from './clock'
-import { Timer } from './components'
 import { VirtualClock } from './resource'
 import { registerTimeTypes, updateTimers } from './systems'
 
@@ -13,7 +12,6 @@ export class TimePlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(Timer)
       .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerTimeTypes })
       .setResource(new VirtualClock())
       .registerSystem({ schedule: AppSchedule.Update, systemGroup: CoreSystems.Start, system: updateVirtualClock })

--- a/packages/transform/src/plugins/remote.js
+++ b/packages/transform/src/plugins/remote.js
@@ -1,6 +1,5 @@
 import { Plugin, App } from '@wimaengine/app'
 import { AppSchedule } from '@wimaengine/core'
-import { RemoteTransform3D, RemoteTransform2D } from '../components'
 import { registerRemoteTransform2DTypes, registerRemoteTransform3DTypes, transformRemote2D, transformRemote3D } from '../systems'
 
 export class RemoteTransform2DPlugin extends Plugin {
@@ -10,7 +9,6 @@ export class RemoteTransform2DPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(RemoteTransform2D)
       .registerSystem({ schedule: AppSchedule.Startup, system: registerRemoteTransform2DTypes })
       .registerSystem({ schedule: AppSchedule.Update, system: transformRemote2D })
   }
@@ -23,7 +21,6 @@ export class RemoteTransform3DPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(RemoteTransform3D)
       .registerSystem({ schedule: AppSchedule.Startup, system: registerRemoteTransform3DTypes })
       .registerSystem({ schedule: AppSchedule.Update, system: transformRemote3D })
   }

--- a/packages/transform/src/plugins/transform.js
+++ b/packages/transform/src/plugins/transform.js
@@ -1,15 +1,5 @@
 import { App, Plugin } from '@wimaengine/app'
 import { AppSchedule } from '@wimaengine/core'
-import {
-  Position2D,
-  Orientation2D,
-  Scale2D,
-  GlobalTransform2D,
-  Position3D,
-  Orientation3D,
-  Scale3D,
-  GlobalTransform3D
-} from '../components'
 import { propagateTransform2D, propagateTransform3D, registerTransform2DTypes, registerTransform3DTypes, synctransform2D, synctransform3D } from '../systems'
 
 export class TransformSystems { }
@@ -26,10 +16,6 @@ export class Transform2DPlugin extends Plugin {
         label: TransformSystems,
         schedule: AppSchedule.Update
       })
-      .registerType(Position2D)
-      .registerType(Orientation2D)
-      .registerType(Scale2D)
-      .registerType(GlobalTransform2D)
       .registerSystem({
         schedule: AppSchedule.Startup,
         system: registerTransform2DTypes
@@ -53,10 +39,6 @@ export class Transform3DPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(Position3D)
-      .registerType(Orientation3D)
-      .registerType(Scale3D)
-      .registerType(GlobalTransform3D)
       .registerSystem({
         schedule: AppSchedule.Startup,
         system: registerTransform3DTypes

--- a/packages/tween/src/plugin.js
+++ b/packages/tween/src/plugin.js
@@ -11,8 +11,6 @@ import {
   Position3DTween,
   Orientation3DTween,
   Scale3DTween,
-  TweenFlip,
-  TweenRepeat,
   Tween
 } from './components'
 import { generateTweenFlipSystem, generateTweenRepeatTween, generateTweenTimerSystem, generateTweenUpdateSystem } from './systems'
@@ -64,11 +62,7 @@ export class CoreTweenPlugin extends Plugin {
   /**
    * @param {App} app
    */
-  register(app) {
-    app
-      .registerType(TweenFlip)
-      .registerType(TweenRepeat)
-  }
+  register(app) { }
 
 }
 
@@ -113,7 +107,6 @@ export class TweenPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(this.tween)
       .registerSystem({
         schedule: AppSchedule.Update,
         label: `flipTween<${typeid(this.component)}>`,

--- a/packages/tween/src/plugin.js
+++ b/packages/tween/src/plugin.js
@@ -60,9 +60,9 @@ export class DefaultTweenPlugin extends Plugin {
 export class CoreTweenPlugin extends Plugin {
 
   /**
-   * @param {App} app
+   * @param {App} _app
    */
-  register(app) { }
+  register(_app) { }
 
 }
 

--- a/packages/window/src/plugin.js
+++ b/packages/window/src/plugin.js
@@ -52,8 +52,6 @@ export class WindowPlugin extends Plugin {
    */
   register(app) {
     app
-      .registerType(Window)
-      .registerType(MainWindow)
       .registerSystem({ schedule: AppSchedule.Startup, systemGroup: CoreSystems.Start, system: registerWindowTypes })
       .registerPlugin(new EventPlugin({
         event:WindowMove


### PR DESCRIPTION
## Objective

Removes the need to manually register component types before use, fixes `TypeStore` ID reuse, and cleans up plugins that previously performed redundant registrations.

## Solution

### Changes Made

The following changes were introduced:

* Removed `App.registerType()` and `World.registerType()` from the public API.
* Enabled automatic component registration whenever components are first used or hooks are attached.
* Fixed `TypeStore.getOrSetByTypeId()` and `TypeStore.setByTypeId()` to correctly reuse previously assigned IDs, including ID `0`.

### Why This Approach

* Eliminates unnecessary boilerplate during application and plugin setup.
* Prevents inconsistencies caused by forgetting to register component types.
* Fixes an edge case where falsy IDs could cause duplicate registrations.
* Produces a simpler and more ergonomic API while preserving existing behavior.

## Showcase

### Before

```js
app
  .registerType(Player)
  .setComponentHooks(Player, hooks)
  .setResource(new GameSettings())
```

### After

```js
app
  .setComponentHooks(Player, hooks)
  .setResource(new GameSettings())
```

## Migration Guide

### Removed APIs

* `App.registerType()`
* `World.registerType()`

## Checklist

* [x] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
