### PR TITLE
Readd UMD package builds and dist-based exports

### DIFF
--- a/.config/vite.config.js
+++ b/.config/vite.config.js
@@ -1,7 +1,8 @@
-import { readFileSync, readdirSync, rmSync } from 'node:fs'
+import { readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { parse } from 'acorn'
 import { rollup } from 'rollup'
 import dts from 'rollup-plugin-dts'
 import { defineConfig } from 'vite'
@@ -11,7 +12,8 @@ const packageJsonPath = process.env.npm_package_json || resolve(root, 'package.j
 const packageRoot = dirname(packageJsonPath)
 const pkg = JSON.parse(readFileSync(packageJsonPath).toString())
 const isRootPackage = packageRoot === root
-const packageName = pkg.name.split('/').at(-1)
+const libraryName = toLibraryName(pkg.name)
+const packageGlobals = getPackageGlobals()
 const entry = isRootPackage
   ? resolve(root, 'src/index.js')
   : resolve(packageRoot, 'index.js')
@@ -47,17 +49,19 @@ export default defineConfig({
     }
   } : {}),
   plugins: [
+    jsCommentStripPlugin(),
     declarationBundlePlugin()
   ],
   build: {
     outDir: resolve(packageRoot, 'dist'),
     lib: {
       entry,
-      formats: ['es'],
-      fileName: () => 'index.module.js'
+      name: libraryName,
+      formats: ['es', 'umd'],
+      fileName: (format) => `index.${format === 'es' ? 'module' : format}.js`
     },
-    target: 'es2020',
-    minify: 'esbuild',
+    target: 'esnext',
+    minify: false,
     esbuild: {
       keepNames: true
     },
@@ -65,11 +69,28 @@ export default defineConfig({
       external: isPackageExternal,
       output: {
         banner,
-        exports: 'named'
+        exports: 'named',
+        globals: packageGlobals
       }
     }
   }
 })
+
+function jsCommentStripPlugin() {
+  return {
+    name: 'js-comment-strip',
+    apply: 'build',
+    /**
+     * @param {string} code
+     */
+    async renderChunk(code) {
+      const bannerPrefix = code.startsWith(banner) ? banner : ''
+      const body = bannerPrefix ? code.slice(bannerPrefix.length) : code
+
+      return `${bannerPrefix}${stripJsComments(body)}`
+    }
+  }
+}
 
 function declarationBundlePlugin() {
   return {
@@ -104,11 +125,74 @@ function declarationBundlePlugin() {
         file: resolve(packageRoot, 'dist/index.d.ts'),
         format: 'es'
       })
+      stripImportJsdocComments(resolve(packageRoot, 'dist/index.d.ts'))
       await bundle.close()
       if (isRootPackage) {
         rmSync(resolve(packageRoot, 'types'), { recursive: true, force: true })
       }
     }
+  }
+}
+
+/**
+ * Removes line and block comments from generated JavaScript chunks.
+ * The bundle banner is injected after renderChunk, so it stays intact.
+ *
+ * @param {string} code
+ * @returns {string}
+ */
+function stripJsComments(code) {
+  /** @type {{ block: boolean, start: number, end: number }[]} */
+  const comments = []
+
+  parse(code, {
+    ecmaVersion: 'latest',
+    onComment(block, _text, start, end) {
+      comments.push({ block, start, end })
+    },
+    sourceType: 'module'
+  })
+
+  if (!comments.length) {
+    return code
+  }
+
+  let stripped = ''
+  let cursor = 0
+
+  for (const comment of comments) {
+    stripped += code.slice(cursor, comment.start)
+
+    if (comment.block) {
+      const left = code[comment.start - 1]
+      const right = code[comment.end]
+
+      if (left && right && !/\s/.test(left) && !/\s/.test(right)) {
+        stripped += ' '
+      }
+    }
+
+    cursor = comment.end
+  }
+
+  stripped += code.slice(cursor)
+
+  return stripped
+}
+
+/**
+ * Removes JSDoc import-only comment blocks from generated declaration files.
+ *
+ * @param {string} filePath
+ */
+function stripImportJsdocComments(filePath) {
+  const contents = readFileSync(filePath, 'utf8')
+  const stripped = contents.replace(/\/\*\*[\s\S]*?\*\//g, (block) => (
+    block.includes('@import') ? '' : block
+  ))
+
+  if (stripped !== contents) {
+    writeFileSync(filePath, stripped)
   }
 }
 
@@ -121,4 +205,34 @@ function getPackageDeclarationPaths() {
         [`packages/${name}/types/index.d.ts`]
       ])
   )
+}
+
+/**
+ * Returns the UMD global names for workspace packages.
+ *
+ * @returns {Record<string, string>}
+ */
+function getPackageGlobals() {
+  return Object.fromEntries(
+    readdirSync(resolve(root, 'packages'), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map(({ name }) => [
+        `@wimaengine/${name}`,
+        toLibraryName(`@wimaengine/${name}`)
+      ])
+  )
+}
+
+/**
+ * Converts a package name to a valid UMD global identifier.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function toLibraryName(name) {
+  return name
+    .replace(/^@/, '')
+    .replace(/\//g, '_')
+    .replace(/-/g, '_')
+    .toUpperCase()
 }

--- a/.github/workflows/pull-lint.yml
+++ b/.github/workflows/pull-lint.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       source: ${{ steps.filter.outputs.source }}
       examples: ${{ steps.filter.outputs.examples }}
+      config: ${{ steps.filter.outputs.config }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -28,9 +29,17 @@ jobs:
               - 'addons/**'
             examples:
               - 'examples/**'
+            config:
+              - '.config/**'
+              - '.github/workflows/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'scripts/**'
+              - 'turbo.json'
+              - 'tsconfig.json'
   lint-source:
     needs: changes
-    if: needs.changes.outputs.source == 'true'
+    if: ${{ needs.changes.outputs.source == 'true' || needs.changes.outputs.config == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -39,18 +48,20 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - run: npm run build
       - run: npm run lint:src-dry -- --max-warnings=0
   lint-examples:
     needs: changes
-    if: needs.changes.outputs.examples == 'true'
+    if: ${{ needs.changes.outputs.examples == 'true' || needs.changes.outputs.config == 'true' }}
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
       - run: npm ci
+      - run: npm run build
       - run: npm run lint:examples-dry -- --max-warnings=0
   tests:
     needs: compiles
@@ -62,6 +73,7 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - run: npm run build
       - run: npm run test
   builds:
     needs: compiles
@@ -76,9 +88,9 @@ jobs:
       - run: npm run build
   compiles:
     needs: changes
-    if: needs.changes.outputs.source == 'true'
+    if: ${{ needs.changes.outputs.source == 'true' || needs.changes.outputs.config == 'true' }}
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
   },
   "type": "module",
   "license": "SEE LICENSE in LICENSE.txt",
-  "main": "./dist/index.module.js",
+  "main": "./dist/index.umd.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.module.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "author": "Wima engine contributors",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wima",
   "version": "0.3.0",
   "description": "An ECS driven modular game engine.",
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build:docs": "npm run typedoc",
     "types": "turbo run types //#types:root",
     "test": "turbo run test",
-    "build": "npm run clean:build && turbo run build && turbo run //#build:root //#build:docs",
+    "build": "turbo run build && turbo run //#build:root //#build:docs",
     "lint": "npm run lint:src && npm run lint:examples",
     "version": "changeset version",
     "check:release-version": "node scripts/check-release-version.js",
@@ -50,7 +50,7 @@
     "tsc:lint": "tsc -p .config/tsc.lint.json",
     "watch:src": "vite build --watch --config .config/vite.config.js",
     "watch:docs": "npm run typedoc -- --watch",
-    "clean:build": "rm -rf dist types packages/*/types"
+    "clean:build": "rm -rf dist types packages/*/types packages/*/dist"
   },
   "keywords": [
     "game",

--- a/packages/animation/package.json
+++ b/packages/animation/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/animation/package.json
+++ b/packages/animation/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/asset/tests/handle.test.js
+++ b/packages/asset/tests/handle.test.js
@@ -1,10 +1,7 @@
 import { deepStrictEqual, strictEqual } from "assert";
 import { test, describe } from "vitest";
-import { Assets } from "../src/resources";
-import { AssetServer } from "../src/resources";
+import { AssetServer, Assets } from "../src/resources";
 import { World } from "@wimaengine/ecs";
-import { AssetSceneMap } from "@wimaengine/scene";
-import { typeid } from "@wimaengine/type";
 
 describe('Testing `Handle`',()=>{
     test('`Handle` clone is same as original', () => {
@@ -204,27 +201,5 @@ describe('Testing `Handle`',()=>{
 
         strictEqual(snapshot.asset, '/assets/text/sample.txt')
         deepStrictEqual(restored.id(), handle.id())
-    })
-
-    test('`Handle` snapshot restores through the scene asset map when no path is registered.', () => {
-        const world = new World()
-        const assets = new Assets(String)
-        const server = new AssetServer()
-        world.setResource(server)
-        const sceneMap = new AssetSceneMap()
-        world.setResource(sceneMap)
-        server.registerAsset(assets)
-
-        const sourceHandle = assets.add('Wima engine')
-        const mappedHandle = assets.add('Mapped asset')
-        const sceneAssetId = sourceHandle.id()
-        const snapshot = sourceHandle.toSnapshot(world)
-
-        sceneMap.set(sceneAssetId, typeid(String), sourceHandle.index, mappedHandle)
-
-        const restored = snapshot.fromSnapshot(world, sceneAssetId)
-
-        strictEqual(snapshot.asset, sourceHandle.index)
-        deepStrictEqual(restored.id(), mappedHandle.id())
     })
 })

--- a/packages/audio/package.json
+++ b/packages/audio/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/audio/package.json
+++ b/packages/audio/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/broadphase/package.json
+++ b/packages/broadphase/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/broadphase/package.json
+++ b/packages/broadphase/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/color/package.json
+++ b/packages/color/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/color/package.json
+++ b/packages/color/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/damping/package.json
+++ b/packages/damping/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/damping/package.json
+++ b/packages/damping/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/datastructures/package.json
+++ b/packages/datastructures/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "vifaa": "^0.4.0"

--- a/packages/datastructures/package.json
+++ b/packages/datastructures/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/device/package.json
+++ b/packages/device/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/device/package.json
+++ b/packages/device/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/diagnostic/package.json
+++ b/packages/diagnostic/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/diagnostic/package.json
+++ b/packages/diagnostic/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/ecs/package.json
+++ b/packages/ecs/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@wimaengine/datastructures": "0.3.0",

--- a/packages/ecs/package.json
+++ b/packages/ecs/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/event/package.json
+++ b/packages/event/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/event/package.json
+++ b/packages/event/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/gizmo/package.json
+++ b/packages/gizmo/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/gizmo/package.json
+++ b/packages/gizmo/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/gravity/package.json
+++ b/packages/gravity/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/gravity/package.json
+++ b/packages/gravity/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/hierarchy/package.json
+++ b/packages/hierarchy/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/hierarchy/package.json
+++ b/packages/hierarchy/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/input-core/package.json
+++ b/packages/input-core/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/input-core/package.json
+++ b/packages/input-core/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/integrator/package.json
+++ b/packages/integrator/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/integrator/package.json
+++ b/packages/integrator/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/misc/package.json
+++ b/packages/misc/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/misc/package.json
+++ b/packages/misc/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/mouse/package.json
+++ b/packages/mouse/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/mouse/package.json
+++ b/packages/mouse/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/movable/package.json
+++ b/packages/movable/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/movable/package.json
+++ b/packages/movable/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/name/package.json
+++ b/packages/name/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/name/package.json
+++ b/packages/name/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/narrowphase/package.json
+++ b/packages/narrowphase/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/narrowphase/package.json
+++ b/packages/narrowphase/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/physics/package.json
+++ b/packages/physics/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/physics/package.json
+++ b/packages/physics/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/profiler/package.json
+++ b/packages/profiler/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/profiler/package.json
+++ b/packages/profiler/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/reflect/package.json
+++ b/packages/reflect/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/reflect/package.json
+++ b/packages/reflect/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/relationship/package.json
+++ b/packages/relationship/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/relationship/package.json
+++ b/packages/relationship/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/render-canvas2d/package.json
+++ b/packages/render-canvas2d/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/render-canvas2d/package.json
+++ b/packages/render-canvas2d/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/render-core/package.json
+++ b/packages/render-core/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/render-core/package.json
+++ b/packages/render-core/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/render-webgl/package.json
+++ b/packages/render-webgl/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/render-webgl/package.json
+++ b/packages/render-webgl/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/scene/package.json
+++ b/packages/scene/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/scene/package.json
+++ b/packages/scene/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/scene/tests/resources/assetmap.test.js
+++ b/packages/scene/tests/resources/assetmap.test.js
@@ -1,6 +1,7 @@
 import { deepStrictEqual, strictEqual } from 'assert'
 import { test, describe } from 'vitest'
-import { Assets } from '@wimaengine/asset'
+import { AssetServer, Assets } from '@wimaengine/asset'
+import { World } from '@wimaengine/ecs'
 import { AssetSceneMap } from '../../src/resources'
 import { typeid } from '@wimaengine/type'
 
@@ -47,5 +48,27 @@ describe.sequential('Testing `AssetSceneMap`', () => {
     deepStrictEqual(numberAssets.get(numberHandle), 123)
     strictEqual(sceneMap.get(sceneAssetId, typeid(String), 0), undefined)
     strictEqual(sceneMap.get(sceneAssetId, typeid(Number), 0) !== undefined, true)
+  })
+
+  test('`Handle` snapshot restores through the scene asset map when no path is registered.', () => {
+    const world = new World()
+    const assets = new Assets(String)
+    const server = new AssetServer()
+    world.setResource(server)
+    const sceneMap = new AssetSceneMap()
+    world.setResource(sceneMap)
+    server.registerAsset(assets)
+
+    const sourceHandle = assets.add('Wima engine')
+    const mappedHandle = assets.add('Mapped asset')
+    const sceneAssetId = sourceHandle.id()
+    const snapshot = sourceHandle.toSnapshot(world)
+
+    sceneMap.set(sceneAssetId, typeid(String), sourceHandle.index, mappedHandle)
+
+    const restored = snapshot.fromSnapshot(world, sceneAssetId)
+
+    strictEqual(snapshot.asset, sourceHandle.index)
+    deepStrictEqual(restored.id(), mappedHandle.id())
   })
 })

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@wimaengine/datastructures": "0.3.0",

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/touch/package.json
+++ b/packages/touch/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/touch/package.json
+++ b/packages/touch/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/tween/package.json
+++ b/packages/tween/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/tween/package.json
+++ b/packages/tween/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/type/package.json
+++ b/packages/type/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/window-dom/package.json
+++ b/packages/window-dom/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/window-dom/package.json
+++ b/packages/window-dom/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/packages/window/package.json
+++ b/packages/window/package.json
@@ -13,20 +13,16 @@
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },
-  "main": "./index.js",
+  "main": "./dist/index.umd.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./index.js"
-    },
-    "./src": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/index.module.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
-    "index.js",
-    "src"
+    "dist"
   ],
   "scripts": {
     "build": "vite build --config ../../.config/vite.config.js",

--- a/packages/window/package.json
+++ b/packages/window/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/wimaengine/wima.git"
   },
-  "homepage": "https://wimaengine.github.io/wima/",
+  "homepage": "https://wimaengine.org",
   "bugs": {
     "url": "https://github.com/wimaengine/wima/issues"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -11,9 +11,15 @@
       ]
     },
     "test": {
+      "dependsOn": [
+        "^build"
+      ],
       "outputs": []
     },
     "types": {
+      "dependsOn": [
+        "^build"
+      ],
       "outputs": [
         "types/**"
       ]


### PR DESCRIPTION
## Objective

Introduce UMD build outputs for Wima packages so they can be consumed through both ESM `import` and CommonJS-style `require` entrypoints from generated `dist` files.

## Solution

* Updated the shared Vite config to build both `es` and `umd` formats.
* Added package-level UMD global names generated from package names, such as `@wimaengine/core` to `WIMAENGINE_CORE`.
* Updated root and package `package.json` files to point `main` and `exports.require` to `./dist/index.umd.js`.
* Updated `exports.import` to use `./dist/index.module.js`.
* Changed published package files from source entry files to `dist`.
* Added comment stripping for generated JavaScript chunks and import-only JSDoc comments in declaration bundles.
* Expanded `clean:build` so package `dist` folders are removed during cleanup.

## Showcase

N/A

## Migration guide

No migration required

## Checklist

* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
