### PR TITLE
Add deferred resource commands

### DIFF
--- a/packages/core/src/commands/addresource.js
+++ b/packages/core/src/commands/addresource.js
@@ -1,0 +1,26 @@
+import { Command } from '@wimaengine/command'
+import { World } from '@wimaengine/ecs'
+
+export class AddResourceCommand extends Command {
+
+  /**
+   * @readonly
+   * @type {object}
+   */
+  resource
+
+  /**
+   * @param {object} resource
+   */
+  constructor(resource) {
+    super()
+    this.resource = resource
+  }
+
+  /**
+   * @param {World} world
+   */
+  execute(world) {
+    world.setResource(this.resource)
+  }
+}

--- a/packages/core/src/commands/index.js
+++ b/packages/core/src/commands/index.js
@@ -1,2 +1,5 @@
-export * from './spawn'
+export * from './addresource'
 export * from './despawn'
+export * from './removeresource'
+export * from './setresourcealias'
+export * from './spawn'

--- a/packages/core/src/commands/removeresource.js
+++ b/packages/core/src/commands/removeresource.js
@@ -1,0 +1,27 @@
+/** @import {Constructor} from '@wimaengine/type' */
+import { Command } from '@wimaengine/command'
+import { World } from '@wimaengine/ecs'
+
+export class RemoveResourceCommand extends Command {
+
+  /**
+   * @readonly
+   * @type {Constructor}
+   */
+  resourceType
+
+  /**
+   * @param {Constructor} resourceType
+   */
+  constructor(resourceType) {
+    super()
+    this.resourceType = resourceType
+  }
+
+  /**
+   * @param {World} world
+   */
+  execute(world) {
+    world.removeResource(this.resourceType)
+  }
+}

--- a/packages/core/src/commands/setresourcealias.js
+++ b/packages/core/src/commands/setresourcealias.js
@@ -1,0 +1,35 @@
+/** @import {Constructor, TypeId} from '@wimaengine/type' */
+import { Command } from '@wimaengine/command'
+import { World } from '@wimaengine/ecs'
+
+export class SetResourceAliasCommand extends Command {
+
+  /**
+   * @readonly
+   * @type {TypeId}
+   */
+  id
+
+  /**
+   * @readonly
+   * @type {Constructor}
+   */
+  alias
+
+  /**
+   * @param {TypeId} id
+   * @param {Constructor} alias
+   */
+  constructor(id, alias) {
+    super()
+    this.id = id
+    this.alias = alias
+  }
+
+  /**
+   * @param {World} world
+   */
+  execute(world) {
+    world.setResourceAlias(this.id, this.alias)
+  }
+}

--- a/packages/core/src/core/index.js
+++ b/packages/core/src/core/index.js
@@ -1,6 +1,7 @@
 export * from './schedules'
 export * from './runner'
 export * from './entity'
+export * from './resourcecommands'
 export * from './systemgroups'
 export * from './snapshot'
 export * from './worlds'

--- a/packages/core/src/core/resourcecommands.js
+++ b/packages/core/src/core/resourcecommands.js
@@ -1,0 +1,51 @@
+/** @import {Constructor, TypeId} from '@wimaengine/type' */
+import { CommandQueue } from '@wimaengine/command'
+import { World } from '@wimaengine/ecs'
+import { AddResourceCommand, RemoveResourceCommand, SetResourceAliasCommand } from '../commands'
+
+export class ResourceCommands {
+
+  /**
+   * @private
+   * @type {CommandQueue}
+   */
+  buffer
+
+  /**
+   * @param {World} world
+   */
+  constructor(world) {
+    this.buffer = world.getResource(CommandQueue)
+  }
+
+  /**
+   * @param {object} resource
+   * @returns {this}
+   */
+  add(resource) {
+    this.buffer.add(new AddResourceCommand(resource))
+
+    return this
+  }
+
+  /**
+   * @param {Constructor} resourceType
+   * @returns {this}
+   */
+  remove(resourceType) {
+    this.buffer.add(new RemoveResourceCommand(resourceType))
+
+    return this
+  }
+
+  /**
+   * @param {TypeId} id
+   * @param {Constructor} alias
+   * @returns {this}
+   */
+  setAlias(id, alias) {
+    this.buffer.add(new SetResourceAliasCommand(id, alias))
+
+    return this
+  }
+}

--- a/packages/core/tests/resourcecommands.test.js
+++ b/packages/core/tests/resourcecommands.test.js
@@ -1,0 +1,53 @@
+import { strictEqual } from 'node:assert'
+import { describe, test } from 'vitest'
+import { CommandQueue } from '@wimaengine/command'
+import { World } from '@wimaengine/ecs'
+import { typeid } from '@wimaengine/type'
+import { ResourceCommands } from '../src/index.js'
+import { executeCommands } from '../src/systems/index.js'
+
+class TestResource { }
+class TestAlias extends TestResource { }
+
+describe('Testing `ResourceCommands`', () => {
+  test('`add()` adds a resource when commands execute', () => {
+    const world = new World()
+    const resource = new TestResource()
+
+    world.setResource(new CommandQueue())
+    const commands = new ResourceCommands(world)
+
+    commands.add(resource)
+    executeCommands(world)
+
+    strictEqual(world.getResource(TestResource), resource)
+  })
+
+  test('`remove()` removes a resource when commands execute', () => {
+    const world = new World()
+
+    world.setResource(new CommandQueue())
+    world.setResource(new TestResource())
+    const commands = new ResourceCommands(world)
+
+    commands.remove(TestResource)
+    executeCommands(world)
+
+    strictEqual(world.hasResource(TestResource), false)
+  })
+
+  test('`setAlias()` resolves a resource through an alias when commands execute', () => {
+    const world = new World()
+    const resource = new TestResource()
+    const id = typeid(TestResource)
+
+    world.setResource(resource)
+    world.setResource(new CommandQueue())
+    const commands = new ResourceCommands(world)
+
+    commands.setAlias(id, TestAlias)
+    executeCommands(world)
+
+    strictEqual(world.getResource(TestAlias), resource)
+  })
+})


### PR DESCRIPTION
## Objective

Introduces a command-based API for deferred resource operations for adding, removing, and aliasing resources.

## Solution

Resource changes are now represented as commands and queued through the world's existing `CommandQueue`. The operations are applied when the command execution system processes the queue.

### Changes Made

The following changes were introduced:

* Added `AddResourceCommand` to add a resource.
* Added `RemoveResourceCommand` to remove a resource.
* Added `SetResourceAliasCommand` to assign a resource alias.
* Added `ResourceCommands` as a higher-level API for queuing the three operations.

### Why This Approach

This solution was chosen because:

* Resource mutations can be deferred and executed through the existing command queue.
* Resource operations follow the same command-based workflow used elsewhere in the core.
* The implementation avoids directly mutating the world when the resource operation is requested.

## Showcase

### Before

Resource mutations had no dedicated command API for queuing resource additions, removals, or aliases.

### After

Resource operations can be queued through `ResourceCommands`:

```js
const commands = new ResourceCommands(world)

commands
  .add(resource)
  .remove(ResourceType)
  .setAlias(typeid(ResourceType), ResourceAlias)
```

The corresponding operations are then applied when the command queue is executed.

## Migration Guide

No migration required.

## Checklist

* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
